### PR TITLE
ping/liveness endpoint

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -21,6 +21,7 @@ Unreleased
 - Stub `ProjectsModule`.
 - Stub roles.
 - PoC JSON:API serialization.
+- Ping/liveness endpoint.
 
 ### Changed
 

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PingController } from './modules/ping/ping.controller';
 import { ProjectsModule } from './modules/projects/projects.module';
 import { UsersModule } from './modules/users/users.module';
 
 @Module({
   imports: [TypeOrmModule.forRoot(), ProjectsModule, UsersModule],
-  controllers: [AppController],
+  controllers: [AppController, PingController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/api/src/modules/ping/ping.controller.spec.ts
+++ b/api/src/modules/ping/ping.controller.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PingController } from './ping.controller';
+
+describe('Ping Controller', () => {
+  let controller: PingController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PingController],
+    }).compile();
+
+    controller = module.get<PingController>(PingController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/api/src/modules/ping/ping.controller.ts
+++ b/api/src/modules/ping/ping.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('ping')
+export class PingController {
+  @Get()
+  ping(): { ping: string } {
+    return { ping: 'pong' };
+  }
+}


### PR DESCRIPTION
### Overview

Ping/liveness endpoint. Needed for k8s liveness/readiness probes.

### Designs

N/A

### Testing instructions

`GET /api/v1/ping`

Once #23 is merged, this will respond to `GET /ping`, which is where I want this endpoint to eventually be (we should not really need versioning for a ping endpoint).

### Feature relevant tickets

https://www.pivotaltracker.com/story/show/176485047

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [x] Update CHANGELOG file