### PR TITLE
Add a modal component

### DIFF
--- a/app/components/modal/component.stories.tsx
+++ b/app/components/modal/component.stories.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { Story } from '@storybook/react/types-6-0';
+
+import Button from 'components/button';
+import Modal, { ModalProps } from './component';
+
+export default {
+  title: 'Components/Modal',
+  component: Modal,
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+  argTypes: {
+    open: {
+      control: {
+        disable: true,
+      },
+    },
+  },
+};
+
+const Template: Story<ModalProps> = ({ ...args }: ModalProps) => {
+  const [open, setOpen] = useState(false);
+
+  const onOpen = () => setOpen(true);
+  const onClose = (e) => {
+    setOpen(false);
+    args.onClose(e);
+  };
+
+  return (
+    <>
+      <Button theme="primary" size="base" onClick={onOpen}>
+        Open modal
+      </Button>
+      <Modal {...args} open={open} onClose={onClose}>
+        <h1 className="mb-5 text-xl font-medium">Modal content</h1>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean at
+        sodales est, eu imperdiet elit. Suspendisse eget diam accumsan, lacinia
+        odio nec, fringilla ex. Quisque consectetur diam in massa egestas, vitae
+        posuere magna semper. Sed ac iaculis purus, at pretium tellus. Duis non
+        commodo lorem, non tincidunt ex.
+      </Modal>
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'Modal component',
+  open: false,
+};

--- a/app/components/modal/component.tsx
+++ b/app/components/modal/component.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import cx from 'classnames';
+import ReactModal from 'react-modal';
+
+import Icon from 'components/icon';
+import CLOSE_SVG from 'svgs/ui/close.svg';
+
+const COMMON_CONTENT_CLASSES = 'absolute top-1/2 inset-x-4 sm:left-1/2 max-h-full transform -translate-y-1/2 sm:-translate-x-1/2 outline-none bg-white overflow-auto rounded-3xl py-7 px-8';
+const CONTENT_CLASSES = {
+  narrow: `sm:w-4/6 md:w-1/2 lg:w-5/12 xl:w-1/3 ${COMMON_CONTENT_CLASSES}`,
+  default: `sm:w-4/5 md:w-2/3 lg:1/2 xl:w-2/5 ${COMMON_CONTENT_CLASSES}`,
+  wide: `sm:w-11/12 md:w-10/12 lg:w-9/12 xl:w-3/5 ${COMMON_CONTENT_CLASSES}`,
+};
+
+const OVERLAY_CLASSES = 'z-10 fixed inset-0 bg-black bg-blur';
+
+export interface ModalProps {
+  /**
+   * Title used by screen readers
+   */
+  title: string;
+  /**
+   * Whether the modal is opened or closed
+   */
+  open: boolean;
+  /**
+   * Callback executed when the component requests its closure
+   */
+  onClose: (event: React.MouseEvent) => void;
+  /**
+   * Size (width) of the modal
+   */
+  size?: 'narrow' | 'default' | 'wide';
+  /**
+   * Callback executed after the modal has opened
+   */
+  onAfterOpen?: () => void;
+  /**
+   * Callback executed after the modal has closed
+   */
+  onAfterClose?: () => void;
+  children?: React.ReactNode;
+  /**
+   * Class name to assign to the modal
+   */
+  className?: string;
+}
+
+// appElement is the root of the Next application
+// In Storybook, this element doesn't exist hence the condition
+const appElement = document.querySelector('#__next');
+if (appElement) {
+  ReactModal.setAppElement(appElement);
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  title,
+  open,
+  onClose,
+  size = 'default',
+  onAfterOpen,
+  onAfterClose,
+  children,
+  className,
+}: ModalProps) => (
+  <ReactModal
+    isOpen={open}
+    onRequestClose={onClose}
+    onAfterOpen={onAfterOpen}
+    onAfterClose={onAfterClose}
+    contentLabel={title}
+    className={cx({ [CONTENT_CLASSES[size]]: true, [className]: !!className })}
+    overlayClassName={cx({ [OVERLAY_CLASSES]: true })}
+  >
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-0 right-0 text-sm text-gray-300 focus:text-black hover:text-black"
+      >
+        Close
+        <Icon
+          icon={CLOSE_SVG}
+          className="inline-block ml-2 w-4 h-4 text-black"
+        />
+      </button>
+    </div>
+    {children}
+  </ReactModal>
+);
+
+export default Modal;

--- a/app/components/modal/index.ts
+++ b/app/components/modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/app/package.json
+++ b/app/package.json
@@ -21,8 +21,8 @@
     "axios": "^0.21.0",
     "classnames": "^2.2.6",
     "d3-ease": "^2.0.0",
-    "deck.gl": "7.3.6",
     "date-fns": "^2.16.1",
+    "deck.gl": "7.3.6",
     "final-form": "^4.20.1",
     "layer-manager": "3.0.9",
     "lodash": "^4.17.20",
@@ -34,6 +34,7 @@
     "react-dom": "17.0.1",
     "react-final-form": "^6.5.2",
     "react-map-gl": "^6.0.1",
+    "react-modal": "^3.12.1",
     "tailwindcss": "^2.0.2",
     "use-debounce": "^5.2.0",
     "validate.js": "^0.13.1"

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -7,7 +7,7 @@
   @font-face {
     font-family: 'Poppins';
     src: url('/fonts/Poppins-Bold.woff2') format('woff2'),
-        url('/fonts/Poppins-Bold.woff') format('woff');
+      url('/fonts/Poppins-Bold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
     font-display: swap;
@@ -16,7 +16,7 @@
   @font-face {
     font-family: 'Poppins';
     src: url('/fonts/Poppins-Medium.woff2') format('woff2'),
-        url('/fonts/Poppins-Medium.woff') format('woff');
+      url('/fonts/Poppins-Medium.woff') format('woff');
     font-weight: 500;
     font-style: normal;
     font-display: swap;
@@ -26,7 +26,7 @@
   @font-face {
     font-family: 'Basier Circle';
     src: url('/fonts/basiercircle-regular-webfont.woff2') format('woff2'),
-        url('/fonts/basiercircle-regular-webfont.woff') format('woff');
+      url('/fonts/basiercircle-regular-webfont.woff') format('woff');
     font-weight: 400;
     font-style: normal;
   }
@@ -34,7 +34,7 @@
   @font-face {
     font-family: 'Basier Circle';
     src: url('/fonts/basiercircle-medium-webfont.woff2') format('woff2'),
-        url('/fonts/basiercircle-medium-webfont.woff') format('woff');
+      url('/fonts/basiercircle-medium-webfont.woff') format('woff');
     font-weight: 500;
     font-style: normal;
   }
@@ -42,8 +42,24 @@
   @font-face {
     font-family: 'Basier Circle';
     src: url('/fonts/basiercircle-semibold-webfont.woff2') format('woff2'),
-        url('/fonts/basiercircle-semibold-webfont.woff') format('woff');
+      url('/fonts/basiercircle-semibold-webfont.woff') format('woff');
     font-weight: 600;
     font-style: normal;
+  }
+}
+
+@layer utilities {
+  /* We want a blur effect without having a high opacity background, but we still want the
+  background to be visible for the browsers that don't support backdrop-filter, so we double the
+  background opacity. This can be tested on Firefox. */
+  .bg-blur {
+    @apply bg-opacity-40;
+  }
+
+  @supports (backdrop-filter: blur(4px)) {
+    .bg-blur {
+      @apply bg-opacity-20;
+      backdrop-filter: blur(4px);
+    }
   }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6204,6 +6204,11 @@ executable@^4.1.1:
   dependencies:
     pify "^2.2.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -10873,7 +10878,7 @@ react-is@16.13.1, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -10889,6 +10894,16 @@ react-map-gl@^6.0.1:
     prop-types "^15.7.2"
     react-virtualized-auto-sizer "^1.0.2"
     viewport-mercator-project "^6.2.3 || ^7.0.1"
+
+react-modal@^3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.12.1.tgz#38c33f70d81c33d02ff1ed115530443a3dc2afd3"
+  integrity sha512-WGuXn7Fq31PbFJwtWmOk+jFtGC7E9tJVbFX0lts8ZoS5EPi9+WWylUJWLKKVm3H4GlQ7ZxY7R6tLlbSIBQ5oZA==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^4.0.3"
 
 react-popper-tooltip@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Modal component

### Overview

This PR adds a modal component to the project and Storybook.

<p align="center">
<img width="593" alt="Modal with a “Lorem Ipsum” content and a blurred overlay" src="https://user-images.githubusercontent.com/6073968/104611594-97a8e700-5685-11eb-988e-b07bf5df7c51.png">
</p>

### Designs

Multiple example of modals can be found in [Figma](https://www.figma.com/file/hq0BZNB9fzyFSbEUgQIHdK/Marxan-Visual_V02?node-id=1523%3A8942).

Each of the modals of the visuals has a different size so I categorised them into 3 categories: narrow (e.g. prompts), default and wide (e.g. modals with a table inside).

Due to the limits of Tailwind, I've tried my best to keep the design's average sizes (~400px, ~520px and ~800px) as stable as possible for all screen sizes. Though, because the modal's size is a percentage of the viewport, the modal's size around the breakpoints differs vastly. If your screen is 1280px wide, that's when you'll see the modal closer to it's target size.

In Figma, the overlay is also blurry. This feature is not supported by all the browsers (e.g. Firefox), so when it's not possible to blur the background, a darker overlay is displayed instead.

### Testing instructions

Open Storybook, test different argument configurations and resize the browser to make sure the modal looks good on all screen sizes. You can also check the actions of the callbacks.

### Feature relevant tickets

None.