### PR TITLE
Slider component

### DIFF
--- a/app/components/forms/component.stories.tsx
+++ b/app/components/forms/component.stories.tsx
@@ -7,6 +7,7 @@ import Textarea from 'components/forms/textarea';
 import Select from 'components/forms/select';
 import Checkbox from 'components/forms/checkbox';
 import Radio from 'components/forms/radio';
+import Slider from 'components/forms/slider';
 import Button from 'components/button';
 import {
   composeValidators,
@@ -20,6 +21,8 @@ export default {
 };
 
 export const Form = (): React.ReactNode => {
+  const sliderLabelRef = React.useRef(null);
+
   return (
     <FormRFF
       debug={() => {
@@ -200,6 +203,27 @@ export const Form = (): React.ReactNode => {
                 >
                   <Radio />
                   <Label className="ml-2">Option 2</Label>
+                </Field>
+              )}
+            </FieldRFF>
+          </div>
+
+          <div className="mt-5">
+            <FieldRFF
+              name="slider"
+              validate={composeValidators([{ presence: true }])}
+            >
+              {(fprops) => (
+                <Field id="form-slider" {...fprops}>
+                  <Label ref={sliderLabelRef} className="mb-1 uppercase">
+                    Slider
+                  </Label>
+                  <Slider
+                    labelRef={sliderLabelRef}
+                    minValue={0}
+                    maxValue={1}
+                    step={0.01}
+                  />
                 </Field>
               )}
             </FieldRFF>

--- a/app/components/forms/label/component.tsx
+++ b/app/components/forms/label/component.tsx
@@ -12,12 +12,12 @@ export interface LabelProps {
   className?: string;
 }
 
-export const Label: React.FC<LabelProps> = ({
-  id,
-  theme = 'primary',
-  children,
-  className,
-}: LabelProps) => {
+const LabelComponent = (
+  {
+    id, theme = 'primary', children, className,
+  }: LabelProps,
+  ref,
+) => {
   return (
     <label
       className={cx({
@@ -25,10 +25,15 @@ export const Label: React.FC<LabelProps> = ({
         [className]: !!className,
       })}
       htmlFor={id}
+      ref={ref}
     >
       {children}
     </label>
   );
 };
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  LabelComponent,
+);
 
 export default Label;

--- a/app/components/forms/slider/component.stories.tsx
+++ b/app/components/forms/slider/component.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Story } from '@storybook/react/types-6-0';
+
+import Slider, { SliderProps } from './component';
+import Label from '../label';
+
+export default {
+  title: 'Components/Forms/Slider',
+  component: Slider,
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+  argTypes: {
+    theme: {
+      control: {
+        type: 'select',
+        options: ['primary'],
+      },
+    },
+    state: {
+      control: {
+        type: 'select',
+        options: ['none', 'valid', 'error'],
+      },
+    },
+    id: {
+      control: {
+        disable: true,
+      },
+    },
+    labelRef: {
+      control: {
+        disable: true,
+      },
+    },
+  },
+};
+
+const Template: Story<SliderProps> = (args: SliderProps) => {
+  const labelRef = React.useRef(null);
+  return (
+    <>
+      <Label ref={labelRef} id="slider-component" className="uppercase">
+        Label
+      </Label>
+      <Slider id="slider-component" labelRef={labelRef} {...args} />
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  theme: 'primary',
+  state: 'none',
+  disabled: false,
+  formatOptions: { style: 'percent' },
+  minValue: 0,
+  maxValue: 1,
+  step: 0.01,
+  defaultValue: 0.42,
+};

--- a/app/components/forms/slider/component.tsx
+++ b/app/components/forms/slider/component.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import cx from 'classnames';
+import { useSliderState } from '@react-stately/slider';
+import { useSlider } from '@react-aria/slider';
+import { useNumberFormatter } from '@react-aria/i18n';
+import { setInteractionModality } from '@react-aria/interactions';
+
+import Thumb from './thumb';
+
+const THEME = {
+  primary: {
+    base: 'w-full h-12 pt-8 touch-action-none',
+    output:
+      'absolute bottom-1 transform -translate-y-full -translate-x-1/2 text-sm text-white border border-t-0 border-l-0 border-r-0 border-dashed border-white',
+    filledTrack: 'absolute left-0 h-1.5 bg-white rounded',
+    track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
+  },
+};
+
+export interface SliderProps {
+  /**
+   * ID of the input (required)
+   */
+  id?: string;
+  /**
+   * Theme of the component
+   */
+  theme?: 'primary';
+  /**
+   * Validation state of the input. If the `disabled` prop is set to `true`, it is overwritten to
+   * `'disabled'`.
+   */
+  state?: 'none' | 'valid' | 'error' | 'disabled';
+  /**
+   * Whether the input is disabled
+   */
+  disabled?: boolean;
+  /**
+   * Format of the value
+   */
+  formatOptions?: Intl.NumberFormatOptions;
+  /**
+   * Reference to the input's label
+   */
+  labelRef: React.MutableRefObject<HTMLLabelElement | null>;
+  /**
+   * Minimum allowed value
+   */
+  minValue?: number;
+  /**
+   * Maximum allowed value
+   */
+  maxValue?: number;
+  /**
+   * Minimum increment value
+   */
+  step?: number;
+  /**
+   * Value of the input (controlled mode)
+   */
+  value?: number;
+  /**
+   * Default value of the input (uncontrolled mode)
+   */
+  defaultValue?: number;
+  /**
+   * Callback executed when the input's value changes
+   */
+  onChange?: (value: number) => void;
+  /**
+   * Callback executed when the input receives focus
+   */
+  onFocus?: React.FocusEventHandler;
+  /**
+   * Callback executed when the input loses focus
+   */
+  onBlur?: React.FocusEventHandler;
+}
+
+export const Slider: React.FC<SliderProps> = ({
+  theme = 'primary',
+  state: rawState = 'none',
+  disabled = false,
+  formatOptions = { style: 'percent' },
+  labelRef,
+  ...rest
+}: SliderProps) => {
+  const state = disabled ? 'disabled' : rawState;
+  const onChangeOverride = rest.onChange
+    ? (values: number[]) => rest.onChange(values[0])
+    : undefined;
+  const propsOverride = {
+    // `useSliderState` is expecting `value` and `defaultValue` to be arrays
+    value: rest.value !== undefined ? [rest.value] : undefined,
+    defaultValue:
+      rest.defaultValue !== undefined ? [rest.defaultValue] : undefined,
+    onChange: onChangeOverride,
+    isDisabled: disabled,
+    // `useSliderState` expects a `label` attribute for accessibility, but this is worked around in
+    // this component so that the `<label />` can be rendered outside of it
+    label: 'workaround-label',
+  };
+
+  const trackRef = React.useRef(null);
+  const sliderState = useSliderState({
+    ...rest,
+    ...propsOverride,
+    numberFormatter: useNumberFormatter(formatOptions),
+  });
+  const { groupProps, trackProps, outputProps } = useSlider(
+    {
+      ...rest,
+      ...propsOverride,
+      // `rest` contains the attribute `id` and we don't want `useSlider` to receive it because it
+      // assumes the label has this id so it can connect the hidden range input to it via a
+      // `aria-labelledby` attribute
+      // The way our forms work is that the labels are the ones connected to the input i.e. the
+      // input has the `id` attribute and the label has a `for` attribute
+      // For this reason, we remove the `id` attribute from the object
+      id: undefined,
+    },
+    sliderState,
+    trackRef,
+  );
+
+  // When the user clicks the external `<label />`, the hidden range input is focused but the
+  // component's state isn't updated
+  // Calling `setInteractionModality` make sure the component is in the focus state
+  React.useEffect(() => {
+    const label = labelRef.current;
+    // Why `'keyboard'`? This is based on React Aria's on code:
+    // https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/slider/src/useSlider.ts#L178-L181
+    const handler = () => setInteractionModality('keyboard');
+
+    if (label) {
+      label.addEventListener('click', handler);
+    }
+
+    return () => {
+      if (label) {
+        label.removeEventListener('click', handler);
+      }
+    };
+  }, [labelRef]);
+
+  return (
+    <div
+      {...groupProps}
+      className={cx({
+        [THEME[theme].base]: true,
+        'opacity-30': state === 'disabled',
+      })}
+    >
+      <div
+        {...trackProps}
+        ref={trackRef}
+        className="relative w-full h-full flex items-center"
+      >
+        <output
+          {...outputProps}
+          className={THEME[theme].output}
+          style={{
+            left: `${sliderState.getThumbPercent(0) * 100}%`,
+          }}
+        >
+          {sliderState.getThumbValueLabel(0)}
+        </output>
+        <div
+          className={THEME[theme].filledTrack}
+          style={{
+            width: `${sliderState.getThumbPercent(0) * 100}%`,
+          }}
+        />
+        <div className={THEME[theme].track} />
+        <Thumb
+          {...rest}
+          theme={theme}
+          state={state}
+          sliderState={sliderState}
+          trackRef={trackRef}
+          isDisabled={disabled}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Slider;

--- a/app/components/forms/slider/index.ts
+++ b/app/components/forms/slider/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/app/components/forms/slider/thumb/index.ts
+++ b/app/components/forms/slider/thumb/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,13 @@
   },
   "dependencies": {
     "@math.gl/web-mercator": "^3.3.2",
+    "@react-aria/focus": "^3.2.3",
+    "@react-aria/i18n": "^3.2.0",
+    "@react-aria/interactions": "^3.3.2",
+    "@react-aria/slider": "^3.0.0",
+    "@react-aria/utils": "^3.5.0",
+    "@react-aria/visually-hidden": "^3.2.1",
+    "@react-stately/slider": "^3.0.0",
     "@storybook/react": "^6.1.11",
     "@tailwindcss/custom-forms": "^0.2.1",
     "axios": "^0.21.0",

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -62,4 +62,8 @@
       backdrop-filter: blur(4px);
     }
   }
+
+  .touch-action-none {
+    touch-action: none;
+  }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1054,7 +1054,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.12.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@7.12.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1789,6 +1789,142 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
+
+"@react-aria/focus@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.2.3.tgz#3e4137498a7fb5235d056c30fd94ab4a82e73aea"
+  integrity sha512-+OWmJMivrq3f8ApWihH1KJYqYj3rZV34YJORacBohcAsF1Qd1V1/P+w3dMkf24kV0wqAiWePCF1FwgnrL/rYzQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/interactions" "^3.3.0"
+    "@react-aria/utils" "^3.4.0"
+    "@react-types/shared" "^3.3.0"
+    clsx "^1.1.1"
+
+"@react-aria/i18n@^3.1.3", "@react-aria/i18n@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.2.0.tgz#d49f4990fe3f125545686121edc129007bcd9233"
+  integrity sha512-D6Ent8R6iFMz04kQAuJ6uAV/3Q9YCvPB06/jJfXvDbtvtsRkxvVi2MEDbNXeCacbsRFaoStH9XOmOYD5mZWyzQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.0.1"
+    "@react-types/shared" "^3.3.0"
+    intl-messageformat "^2.2.0"
+
+"@react-aria/interactions@^3.2.1", "@react-aria/interactions@^3.3.0", "@react-aria/interactions@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.3.2.tgz#2ac1950a73152563b298f1b88d0a946f7e42933f"
+  integrity sha512-CYCxeix1UBMLIARZO4xv/ZNvgAp+Y6ahY1Z693uXpYPLc33B0RiygoTumcu0yJo7jwZ8Ovv64q0saDaNoSG0Aw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.4.1"
+    "@react-types/shared" "^3.3.0"
+
+"@react-aria/label@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.1.1.tgz#03dc5c4813cd1f51760ba48783c186c2eeda1189"
+  integrity sha512-9kZKJonYSXeY6hZULZrsujAb6uXDGEy8qPq0tjTVoTA3+gx26LOmLCLgvHFtxUK1e4s99rHmaSPdOtq5qu3EVQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.3.0"
+    "@react-types/label" "^3.2.1"
+    "@react-types/shared" "^3.2.1"
+
+"@react-aria/slider@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/slider/-/slider-3.0.0.tgz#c3172f84517f6a88de5008ed2bc00cc1f2dcd3da"
+  integrity sha512-IyAzlkgplD1NCxSF9TDL7WxasAOGB2HhosWg1W7WUI9BvzHLeHWsJdpCbTeqHYIlyjZbAdgI2G48NntZU77CyA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/focus" "^3.2.3"
+    "@react-aria/i18n" "^3.1.3"
+    "@react-aria/interactions" "^3.3.0"
+    "@react-aria/label" "^3.1.1"
+    "@react-aria/utils" "^3.5.0"
+    "@react-stately/radio" "^3.2.1"
+    "@react-stately/slider" "^3.0.0"
+    "@react-types/radio" "^3.1.1"
+    "@react-types/slider" "^3.0.0"
+
+"@react-aria/ssr@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.0.1.tgz#5f7c111f9ecd184b8f6140139703c1ee552dca30"
+  integrity sha512-rweMNcSkUO4YkcmgFIoZFvgPyHN2P9DOjq3VOHnZ8SG3Y4TTvSY6Iv90KgzeEfmWCUqqt65FYH4JgrpGNToEMw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-aria/utils@^3.3.0", "@react-aria/utils@^3.4.0", "@react-aria/utils@^3.4.1", "@react-aria/utils@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.5.0.tgz#b377461591f5c8e2157b1635e28ed03cd58e2a22"
+  integrity sha512-HjeqT4//N2Jz2WNg3qAg1MpxAjcP+aPR1fq8yXm812za2/bA5rUSZqN0EXHZ9/+NdQhnZoRPNyXN/BJMZJe+Ig==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.0.1"
+    "@react-types/shared" "^3.3.0"
+    clsx "^1.1.1"
+
+"@react-aria/visually-hidden@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.2.1.tgz#c022c562346140a473242448045add59269a74fd"
+  integrity sha512-ba7bQD09MuzUghtPyrQoXHgQnRRfOu039roVKPz2em9gHD0Wy4ap2UPwlzx35KzNq6FdCzMDZeSZHSnUWlzKnw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/interactions" "^3.2.1"
+    "@react-aria/utils" "^3.3.0"
+    clsx "^1.1.1"
+
+"@react-stately/radio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/radio/-/radio-3.2.1.tgz#d3fb0b28c2e7accdee47912c9802ab4a886a3092"
+  integrity sha512-WGYMWCDJQOicFLf+bW2CbAnlRWaqsUd028WpsS41GWyIx/w7DVpUeGFwTSvyCXC5SCQZuambsWHgXNz8Ng5WIA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-stately/utils" "^3.1.1"
+    "@react-types/radio" "^3.1.1"
+
+"@react-stately/slider@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@react-stately/slider/-/slider-3.0.0.tgz#f0dd7b6df931828b42d93e693bc4da75852bb440"
+  integrity sha512-KAzAhDOF+diyC2k3SPebK9VUKvuXT6wR3BLaAKJYvWMP4EWxoDhRCyc7tHJRKeoCqKiT2qbYd6D1lQDA01foew==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/i18n" "^3.1.3"
+    "@react-aria/utils" "^3.5.0"
+    "@react-stately/utils" "^3.1.1"
+    "@react-types/slider" "^3.0.0"
+
+"@react-stately/utils@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.1.1.tgz#e2f2c3ef81cfc6850a3418cb0f050c33d123620a"
+  integrity sha512-htG4TicI4SKxfD5sEKYGxlMeQ5/+TuWPtnhRMbRqdmqnfkVxO/PoaQeEF+xUMWM9VCZc69ZFH6Qen1eZ/JfFcQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-types/label@^3.2.1":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@react-types/label/-/label-3.3.0.tgz#ead771eeae330136c78c97a017d827f09ad3ef8b"
+  integrity sha512-cvdUmTxLv165M7ld6YKpU6/VLK2PgUET8uAQuJZZqildr6G7Iw4TUEEw2FB73gUJDb78cCmIoi1VvT/50uLZPw==
+  dependencies:
+    "@react-types/shared" "^3.2.1"
+
+"@react-types/radio@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-types/radio/-/radio-3.1.1.tgz#5b1b11ff3043ac902e8970e49260f2664da80e5e"
+  integrity sha512-neInMjlbZyyGYYyeDJk9BcEejLczvsBiyk/swSUHmQ99eNIjK3ptUHTNdXM1xBBc3zI1SvBxOQr+uGeeEszvxw==
+  dependencies:
+    "@react-types/shared" "^3.2.1"
+
+"@react-types/shared@^3.2.1", "@react-types/shared@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.3.0.tgz#4f959df32f3ae94fcc910546088489144fc8d753"
+  integrity sha512-i/OJplVPIHVok0Bu2Hn9pmz6eyULq2ao6pG/Is8YoDzp33SzumOtXxumgYcaXMJ7wBd2RgPd532m3+RnOY0ndg==
+
+"@react-types/slider@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@react-types/slider/-/slider-3.0.0.tgz#b26550b973fbe8e02b69cd9c650abe546159a81e"
+  integrity sha512-BjSnzPcxw8y+PiNQm81X7dSyJwU86UK8ig0YWA2T2m7XhTvy26AjLmUwRDxhhVXAqRQtvRDLd+uowrb9FnWMcQ==
+  dependencies:
+    "@react-types/shared" "^3.3.0"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -4461,6 +4597,11 @@ clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
 coa@^2.0.2:
   version "2.0.2"
@@ -7657,6 +7798,18 @@ interpret@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+intl-messageformat-parser@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
+  integrity sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=
+
+intl-messageformat@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
+  integrity sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=
+  dependencies:
+    intl-messageformat-parser "1.4.0"
 
 invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"


### PR DESCRIPTION
## New Slider component

### Overview

This PR adds a new Slider component that is to be used inside of forms.

<p align="center">
<img width="450" alt="Slider with the label “label” and set to the value 42%" src="https://user-images.githubusercontent.com/6073968/105357072-92531b80-5bf4-11eb-90aa-a8ff260f83da.png">
</p>

In the provided Storybook story, you can see the minimum requirements (props) that are necessary. In summary, the 3 essential pieces are:
- An external `<label />` that must have a `for` attribute (or `htmlFor` prop) and is saved in a React ref
- An `id` prop passed to `<Slider />` that has the same value as the label's `for` attribute
- A `labelRef` prop passed to `<Slider />` that is the ref to the `<label />` element

### Designs

The slider can be found in the [Figma project](https://www.figma.com/file/hq0BZNB9fzyFSbEUgQIHdK/Marxan-Visual_V02?node-id=1523%3A2317), on the artboard Marxan 07a.

### Testing instructions

The component is available in the Storybook both in Forms / Slider / Default and Forms / Form where you can see it integrated in a complete form.

In its standalone story, you can test disabling it, changing its state and its configuration such as the minimum and maximum values, the step increment and the value formatter.