### PR TITLE
chore: update docker compose config and make targets for API development (API and geoprocessing)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 # Useful when developing on API components only, to avoid spinning services
 # which may not be needed.
 start-api:
-	docker-compose up --build api geoprocessing postgresql-api postgresql-geo-api redis-api
+	docker-compose up --build api geoprocessing
 
 # Start all the services.
 start:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,11 @@ notebooks:
 stop:
 	docker-compose stop
 
-psql:
+psql-api:
 	docker-compose exec postgresql-api psql -U "${API_POSTGRES_USER}"
+
+psql-geo:
+	docker-compose exec postgresql-geo-api psql -U "${GEO_POSTGRES_USER}"
 
 # Stop all containers and remove the postgresql-api container and the named
 # Docker volume used to persists PostgreSQL data

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ endif
 start-api:
 	docker-compose up --build api geoprocessing postgresql-api postgresql-geo-api redis-api
 
+# Start all the services.
 start:
 	docker-compose up --build
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ endif
 
 .PHONY: start
 
+# Start only API and Geoprocessing services
+#
+# Useful when developing on API components only, to avoid spinning services
+# which may not be needed.
+start-api:
+	docker-compose up --build api geoprocessing postgresql-api postgresql-geo-api redis-api
+
 start:
 	docker-compose up --build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     depends_on:
       - postgresql-api
       - postgresql-geo-api
+      - redis-api
   app:
     build:
       context: ./app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,21 +21,21 @@ services:
     depends_on:
       - postgresql-api
       - postgresql-geo-api
-  # app:
-  #   build:
-  #     context: ./app
-  #     dockerfile: Dockerfile
-  #   ports:
-  #     - "${APP_SERVICE_PORT}:3000"
-  #   container_name: marxan-app
-  #   command: start
-  #   volumes:
-  #     - ./app/src:/opt/marxan-app/src
-  #     - ./app/test:/opt/marxan-app/test
-  #   env_file: .env
-  #   environment:
-  #     - NODE_PATH=src
-  #     - NODE_ENV=development
+  app:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    ports:
+      - "${APP_SERVICE_PORT}:3000"
+    container_name: marxan-app
+    command: start
+    volumes:
+      - ./app/src:/opt/marxan-app/src
+      - ./app/test:/opt/marxan-app/test
+    env_file: .env
+    environment:
+      - NODE_PATH=src
+      - NODE_ENV=development
   geoprocessing:
     build:
       context: ./geoprocessing
@@ -83,57 +83,57 @@ services:
       - POSTGRES_PASSWORD=${GEO_POSTGRES_PASSWORD}
       - POSTGRES_USER=${GEO_POSTGRES_USER}
     restart: always
-  # redis-api:
-  #   build:
-  #     context: ./redis
-  #     dockerfile: Dockerfile
-  #   container_name: marxan-redis-api
-  #   ports:
-  #     - "${REDIS_API_SERVICE_PORT}:6379"
-  #   volumes:
-  #     - marxan-cloud-redis-api-data:/data
-  #   environment:
-  #     - REDIS_REPLICATION_MODE=master
-  #   restart: on-failure
-  # postgresql-airflow:
-  #   image: postgres
-  #   container_name: marxan-postgresql-airflow
-  #   environment:
-  #     - POSTGRES_USER=airflow
-  #     - POSTGRES_PASSWORD=airflow
-  #     - POSTGRES_DB=airflow
-  # airflow-scheduler:
-  #   container_name: marxan-airflow-scheduler
-  #   image: apache/airflow:2.0.0
-  #   command: scheduler
-  #   depends_on:
-  #       - postgresql-airflow
-  #   restart: on-failure
-  #   environment:
-  #     - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgresql-airflow/airflow
-  #     - AIRFLOW__CORE__EXECUTOR=LocalExecutor
-  #   volumes:
-  #       - ./airflow/dags:/opt/airflow/dags
-  #       - marxan-airflow-logs:/opt/airflow/logs
-  # airflow-webserver:
-  #   container_name: marxan-airflow-webserver
-  #   image: apache/airflow:2.0.0
-  #   restart: on-failure
-  #   entrypoint: ['sh','./scripts/entrypoint.sh']
-  #   env_file:
-  #       - .env
-  #   environment:
-  #     - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgresql-airflow/airflow
-  #     - AIRFLOW__CORE__EXECUTOR=LocalExecutor
-  #   volumes:
-  #       - ./airflow/dags:/opt/airflow/dags
-  #       - ./airflow/scripts:/opt/airflow/scripts
-  #       - marxan-airflow-logs:/opt/airflow/logs
-  #   ports:
-  #       - "${AIRFLOW_PORT}:8080"
-  #   depends_on:
-  #     - postgresql-airflow
-  #     - airflow-scheduler
+  redis-api:
+    build:
+      context: ./redis
+      dockerfile: Dockerfile
+    container_name: marxan-redis-api
+    ports:
+      - "${REDIS_API_SERVICE_PORT}:6379"
+    volumes:
+      - marxan-cloud-redis-api-data:/data
+    environment:
+      - REDIS_REPLICATION_MODE=master
+    restart: on-failure
+  postgresql-airflow:
+    image: postgres
+    container_name: marxan-postgresql-airflow
+    environment:
+      - POSTGRES_USER=airflow
+      - POSTGRES_PASSWORD=airflow
+      - POSTGRES_DB=airflow
+  airflow-scheduler:
+    container_name: marxan-airflow-scheduler
+    image: apache/airflow:2.0.0
+    command: scheduler
+    depends_on:
+        - postgresql-airflow
+    restart: on-failure
+    environment:
+      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgresql-airflow/airflow
+      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+    volumes:
+      - ./airflow/dags:/opt/airflow/dags
+      - marxan-airflow-logs:/opt/airflow/logs
+  airflow-webserver:
+    container_name: marxan-airflow-webserver
+    image: apache/airflow:2.0.0
+    restart: on-failure
+    entrypoint: ['sh','./scripts/entrypoint.sh']
+    env_file:
+      - .env
+    environment:
+      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgresql-airflow/airflow
+      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+    volumes:
+      - ./airflow/dags:/opt/airflow/dags
+      - ./airflow/scripts:/opt/airflow/scripts
+      - marxan-airflow-logs:/opt/airflow/logs
+    ports:
+      - "${AIRFLOW_PORT}:8080"
+    depends_on:
+      - postgresql-airflow
+      - airflow-scheduler
 
 networks:
   default:

--- a/env.default
+++ b/env.default
@@ -1,7 +1,7 @@
 API_SERVICE_PORT=3030
 # API_AUTH_JWT_SECRET *must* be set for the API to work.
-# `dd if=/dev/urandom bs=1024 count=1 | base64 -w0` is a simple way to set it
-# to a strong random secret.
+# `dd if=/dev/urandom bs=1024 count=1 2>/dev/null | base64 -w0` is a simple way
+# to generate a strong random secret.
 API_AUTH_JWT_SECRET=
 API_RUN_MIGRATIONS_ON_STARTUP=true
 API_POSTGRES_USER=marxan-api


### PR DESCRIPTION
### Overview

Update docker-compose configuration, restoring what we had commented out.

Services that are not needed now will not start anymore if we use `make start-api`.

`make start` will attempt to spin up all the services, though the `app` one is not fully configured yet, so this target should not be used for now.

Additionally, it's now trivial to enter a `psql` console both for the API db (`make psql-api`) and for the geoprocessing db (`make psql-geo`).

### Designs

N/A

### Testing instructions

Stop all the Marxan services (`make stop`).

`make start-api` should start api and geoprocessing services, plus their backing pg services and the redis-api service (not used yet, but we may soon).

`make psql-api` and `make psql-geo` should lead to the psql console for the api and geoprocessing db, respectively.

### Feature relevant tickets

N/A

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file