### PR TITLE
Form: rename status

### DIFF
--- a/app/components/dropdowns/menu/component.tsx
+++ b/app/components/dropdowns/menu/component.tsx
@@ -10,10 +10,15 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   attributes,
   getMenuProps,
   children,
+  onFocus,
+  onBlur,
 }: DropdownMenuProps) => {
   return (
     <div
-      {...getMenuProps()}
+      {...getMenuProps({
+        onFocus,
+        onBlur,
+      })}
       className={cx({
         'focus:outline-none overflow-hidden': true,
         'invisible pointer-events-none': attributes?.popper?.['data-popper-reference-hidden'],

--- a/app/components/dropdowns/multi/component.tsx
+++ b/app/components/dropdowns/multi/component.tsx
@@ -32,6 +32,7 @@ export const MultiDropdown: React.FC<DropdownProps> = ({
   batchSelectionActive,
   batchSelectionLabel = 'Select all',
   onSelect,
+  onBlur,
 }: DropdownProps) => {
   const triggerRef = useRef();
   const menuRef = useRef();
@@ -228,6 +229,7 @@ export const MultiDropdown: React.FC<DropdownProps> = ({
             opened={isOpen}
             attributes={attributes}
             getMenuProps={getMenuProps}
+            onBlur={onBlur}
           >
             {isOpen && (
               <Toggle

--- a/app/components/dropdowns/single/component.tsx
+++ b/app/components/dropdowns/single/component.tsx
@@ -28,6 +28,8 @@ export const SingleDropdown: React.FC<DropdownProps> = ({
   clearSelectionActive,
   clearSelectionLabel = 'Clear selection',
   onSelect,
+  onFocus,
+  onBlur,
 }: DropdownProps) => {
   const triggerRef = useRef();
   const menuRef = useRef();
@@ -172,6 +174,8 @@ export const SingleDropdown: React.FC<DropdownProps> = ({
             opened={isOpen}
             attributes={attributes}
             getMenuProps={getMenuProps}
+            onFocus={onFocus}
+            onBlur={onBlur}
           >
             {isOpen && (
               <Toggle

--- a/app/components/dropdowns/toggle/component.tsx
+++ b/app/components/dropdowns/toggle/component.tsx
@@ -54,7 +54,11 @@ export const DropdownToggle: React.FC<DropdownToggleProps> = ({
         </span>
       )}
 
-      <span className="text-sm leading-none">
+      <span className={cx({
+        'text-sm leading-none': true,
+        'text-white': selectedItems.length,
+      })}
+      >
         {labelDefaultFormatter()}
       </span>
 

--- a/app/components/dropdowns/types.d.ts
+++ b/app/components/dropdowns/types.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, FocusEventHandler } from 'react';
 
 interface DropdownThemeProps {
   theme: 'dark' | 'light';
@@ -30,6 +30,8 @@ export interface DropdownProps extends
   DropdownThemeProps {
   onChange?: (selection: string | string[]) => void;
   onSelect?: (option: DropdownOptionProps | DropdownOptionProps[]) => void;
+  onFocus?: FocusEventHandler;
+  onBlur?: FocusEventHandler;
 }
 
 export interface DropdownOptionProps {
@@ -45,7 +47,9 @@ export interface DropdownMenuProps extends
   children: ReactNode;
   opened: boolean;
   attributes: Record<string, unknown>,
-  getMenuProps: () => void;
+  getMenuProps: (e?:any) => void;
+  onFocus?: FocusEventHandler;
+  onBlur?: FocusEventHandler;
 }
 
 export interface DropdownToggleProps extends

--- a/app/components/forms/checkbox/component.stories.tsx
+++ b/app/components/forms/checkbox/component.stories.tsx
@@ -12,7 +12,7 @@ export default {
         options: ['primary'],
       },
     },
-    state: {
+    status: {
       control: {
         type: 'select',
         options: ['none', 'valid', 'error', 'disabled'],

--- a/app/components/forms/checkbox/component.tsx
+++ b/app/components/forms/checkbox/component.tsx
@@ -5,7 +5,7 @@ const THEME = {
   primary: {
     base:
       'bg-gray-800 border rounded-sm text-primary-500 focus:border-primary-500 focus:outline-none',
-    states: {
+    status: {
       none: 'border-gray-900',
       valid: 'border-gray-900',
       error: 'border-red-500 focus:border-red-500',
@@ -16,17 +16,17 @@ const THEME = {
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   theme?: 'primary';
-  state?: 'none' | 'valid' | 'error' | 'disabled';
+  status?: 'none' | 'valid' | 'error' | 'disabled';
 }
 
 export const Checkbox: React.FC<CheckboxProps> = ({
   theme = 'primary',
-  state = 'none',
+  status = 'none',
   disabled = false,
   className,
   ...props
 }: CheckboxProps) => {
-  const st = disabled ? 'disabled' : state;
+  const st = disabled ? 'disabled' : status;
 
   return (
     <input
@@ -36,7 +36,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       className={cx({
         'form-checkbox': true,
         [THEME[theme].base]: true,
-        [THEME[theme].states[st]]: true,
+        [THEME[theme].status[st]]: true,
         [className]: !!className,
       })}
     />

--- a/app/components/forms/field/component.tsx
+++ b/app/components/forms/field/component.tsx
@@ -27,12 +27,12 @@ export const Field: React.FC<FieldProps> = ({
   const childrenWithProps = React.Children.map(children, (child) => {
     // checking isValidElement is the safe way and avoids a typescript error too
     if (React.isValidElement(child)) {
-      const state = getState(meta);
+      const status = getState(meta);
 
       return React.cloneElement(child, {
         ...input,
         id,
-        state,
+        status,
       });
     }
     return child;

--- a/app/components/forms/input/component.stories.tsx
+++ b/app/components/forms/input/component.stories.tsx
@@ -13,7 +13,7 @@ export default {
         options: ['primary'],
       },
     },
-    state: {
+    status: {
       control: {
         type: 'select',
         options: ['none', 'valid', 'error', 'disabled'],

--- a/app/components/forms/input/component.tsx
+++ b/app/components/forms/input/component.tsx
@@ -5,7 +5,7 @@ const THEME = {
   primary: {
     base:
       'w-full leading-tight text-white bg-gray-800 border rounded focus:outline-none focus:bg-gray-700',
-    states: {
+    status: {
       none: 'border-gray-900',
       valid: 'border-green-500',
       error: 'border-red-500',
@@ -16,17 +16,17 @@ const THEME = {
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   theme?: 'primary';
-  state?: 'none' | 'valid' | 'error' | 'disabled';
+  status?: 'none' | 'valid' | 'error' | 'disabled';
 }
 
 export const Input: React.FC<InputProps> = ({
   theme = 'primary',
-  state = 'none',
+  status = 'none',
   disabled = false,
   className,
   ...props
 }: InputProps) => {
-  const st = disabled ? 'disabled' : state;
+  const st = disabled ? 'disabled' : status;
 
   return (
     <input
@@ -35,7 +35,7 @@ export const Input: React.FC<InputProps> = ({
       className={cx({
         'form-input': true,
         [THEME[theme].base]: true,
-        [THEME[theme].states[st]]: true,
+        [THEME[theme].status[st]]: true,
         [className]: !!className,
       })}
     />

--- a/app/components/forms/radio/component.stories.tsx
+++ b/app/components/forms/radio/component.stories.tsx
@@ -12,7 +12,7 @@ export default {
         options: ['primary'],
       },
     },
-    state: {
+    status: {
       control: {
         type: 'select',
         options: ['none', 'valid', 'error', 'disabled'],

--- a/app/components/forms/radio/component.tsx
+++ b/app/components/forms/radio/component.tsx
@@ -5,7 +5,7 @@ const THEME = {
   primary: {
     base:
       'bg-gray-800 border rounded-full text-primary-500 focus:border-primary-500 focus:outline-none',
-    states: {
+    status: {
       none: 'border-gray-900',
       valid: 'border-gray-900',
       error: 'border-red-500',
@@ -16,17 +16,17 @@ const THEME = {
 
 export interface RadioProps extends InputHTMLAttributes<HTMLInputElement> {
   theme?: 'primary';
-  state?: 'none' | 'valid' | 'error' | 'disabled';
+  status?: 'none' | 'valid' | 'error' | 'disabled';
 }
 
 export const Radio: React.FC<RadioProps> = ({
   theme = 'primary',
-  state = 'none',
+  status = 'none',
   disabled = false,
   className,
   ...props
 }: RadioProps) => {
-  const st = disabled ? 'disabled' : state;
+  const st = disabled ? 'disabled' : status;
 
   return (
     <input
@@ -36,7 +36,7 @@ export const Radio: React.FC<RadioProps> = ({
       className={cx({
         'form-radio': true,
         [THEME[theme].base]: true,
-        [THEME[theme].states[st]]: true,
+        [THEME[theme].status[st]]: true,
         [className]: !!className,
       })}
     />

--- a/app/components/forms/select/component.stories.tsx
+++ b/app/components/forms/select/component.stories.tsx
@@ -13,7 +13,7 @@ export default {
         options: ['dark', 'light'],
       },
     },
-    state: {
+    status: {
       control: {
         type: 'select',
         options: ['none', 'valid', 'error', 'disabled'],

--- a/app/components/forms/slider/component.stories.tsx
+++ b/app/components/forms/slider/component.stories.tsx
@@ -15,7 +15,7 @@ export default {
         options: ['primary'],
       },
     },
-    state: {
+    status: {
       control: {
         type: 'select',
         options: ['none', 'valid', 'error'],
@@ -49,7 +49,7 @@ const Template: Story<SliderProps> = (args: SliderProps) => {
 export const Default = Template.bind({});
 Default.args = {
   theme: 'primary',
-  state: 'none',
+  status: 'none',
   disabled: false,
   formatOptions: { style: 'percent' },
   minValue: 0,

--- a/app/components/forms/slider/component.tsx
+++ b/app/components/forms/slider/component.tsx
@@ -27,10 +27,10 @@ export interface SliderProps {
    */
   theme?: 'primary';
   /**
-   * Validation state of the input. If the `disabled` prop is set to `true`, it is overwritten to
+   * Validation status of the input. If the `disabled` prop is set to `true`, it is overwritten to
    * `'disabled'`.
    */
-  state?: 'none' | 'valid' | 'error' | 'disabled';
+  status?: 'none' | 'valid' | 'error' | 'disabled';
   /**
    * Whether the input is disabled
    */
@@ -79,13 +79,13 @@ export interface SliderProps {
 
 export const Slider: React.FC<SliderProps> = ({
   theme = 'primary',
-  state: rawState = 'none',
+  status: rawState = 'none',
   disabled = false,
   formatOptions = { style: 'percent' },
   labelRef,
   ...rest
 }: SliderProps) => {
-  const state = disabled ? 'disabled' : rawState;
+  const status = disabled ? 'disabled' : rawState;
   const onChangeOverride = rest.onChange
     ? (values: number[]) => rest.onChange(values[0])
     : undefined;
@@ -124,8 +124,8 @@ export const Slider: React.FC<SliderProps> = ({
   );
 
   // When the user clicks the external `<label />`, the hidden range input is focused but the
-  // component's state isn't updated
-  // Calling `setInteractionModality` make sure the component is in the focus state
+  // component's status isn't updated
+  // Calling `setInteractionModality` make sure the component is in the focus status
   React.useEffect(() => {
     const label = labelRef.current;
     // Why `'keyboard'`? This is based on React Aria's on code:
@@ -148,7 +148,7 @@ export const Slider: React.FC<SliderProps> = ({
       {...groupProps}
       className={cx({
         [THEME[theme].base]: true,
-        'opacity-30': state === 'disabled',
+        'opacity-30': status === 'disabled',
       })}
     >
       <div
@@ -175,7 +175,7 @@ export const Slider: React.FC<SliderProps> = ({
         <Thumb
           {...rest}
           theme={theme}
-          state={state}
+          status={status}
           sliderState={sliderState}
           trackRef={trackRef}
           isDisabled={disabled}

--- a/app/components/forms/slider/thumb/component.tsx
+++ b/app/components/forms/slider/thumb/component.tsx
@@ -10,7 +10,7 @@ const THEME = {
   primary: {
     thumb:
       'absolute top-0 w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
-    states: {
+    status: {
       default: 'border-white',
       dragging: 'border-white opacity-80',
       focused: 'border-white ring-2 ring-primary-500',
@@ -23,7 +23,7 @@ const THEME = {
 
 export interface ThumbProps {
   theme: 'primary';
-  state: 'none' | 'valid' | 'error' | 'disabled';
+  status: 'none' | 'valid' | 'error' | 'disabled';
   sliderState: SliderState;
   trackRef: React.MutableRefObject<HTMLElement | null>;
   isDisabled: boolean;
@@ -32,7 +32,7 @@ export interface ThumbProps {
 
 export const Thumb: React.FC<ThumbProps> = ({
   theme,
-  state: rawState,
+  status: rawState,
   sliderState,
   trackRef,
   isDisabled,
@@ -54,15 +54,15 @@ export const Thumb: React.FC<ThumbProps> = ({
 
   const { focusProps, isFocusVisible } = useFocusRing();
 
-  let state: keyof typeof THEME.primary.states;
+  let status: keyof typeof THEME.primary.status;
   if (isFocusVisible) {
-    state = 'focused';
+    status = 'focused';
   } else if (sliderState.isThumbDragging(0)) {
-    state = 'dragging';
+    status = 'dragging';
   } else if (rawState === 'none') {
-    state = 'default';
+    status = 'default';
   } else {
-    state = rawState;
+    status = rawState;
   }
 
   const mergedInputProps = mergeProps(inputProps, focusProps, {
@@ -76,7 +76,7 @@ export const Thumb: React.FC<ThumbProps> = ({
       {...thumbProps}
       className={cx({
         [THEME[theme].thumb]: true,
-        [THEME[theme].states[state]]: true,
+        [THEME[theme].status[status]]: true,
       })}
       style={{
         left: `${sliderState.getThumbPercent(0) * 100}%`,

--- a/app/components/forms/textarea/component.stories.tsx
+++ b/app/components/forms/textarea/component.stories.tsx
@@ -12,7 +12,7 @@ export default {
         options: ['primary'],
       },
     },
-    state: {
+    status: {
       control: {
         type: 'select',
         options: ['none', 'valid', 'error', 'disabled'],

--- a/app/components/forms/textarea/component.tsx
+++ b/app/components/forms/textarea/component.tsx
@@ -5,7 +5,7 @@ const THEME = {
   primary: {
     base:
       'leading-tight text-white bg-gray-800 border rounded focus:outline-none focus:bg-gray-700',
-    states: {
+    status: {
       none: 'border-gray-900',
       valid: 'border-green-500',
       error: 'border-red-500',
@@ -17,17 +17,17 @@ const THEME = {
 export interface TextareaProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   theme?: 'primary';
-  state?: 'none' | 'valid' | 'error' | 'disabled';
+  status?: 'none' | 'valid' | 'error' | 'disabled';
 }
 
 export const Textarea: React.FC<TextareaProps> = ({
   theme = 'primary',
-  state = 'none',
+  status = 'none',
   disabled = false,
   className,
   ...props
 }: TextareaProps) => {
-  const st = disabled ? 'disabled' : state;
+  const st = disabled ? 'disabled' : status;
 
   return (
     <textarea
@@ -36,7 +36,7 @@ export const Textarea: React.FC<TextareaProps> = ({
       className={cx({
         'form-textarea w-full': true,
         [THEME[theme].base]: true,
-        [THEME[theme].states[st]]: true,
+        [THEME[theme].status[st]]: true,
         [className]: !!className,
       })}
     />


### PR DESCRIPTION
## Renaming state => status to prevent overlapping with other libraries and default React states

### Overview

This PR adds:
- renaming
- onFocus and onBlur added to select