### PR TITLE
[MARXAN-2] catch-all exceptions filter

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -38,6 +38,8 @@ Unreleased
   well as via the TypeORM CLI util.
 - Setup of E2E tests.
 - Support for pagination of plural responses.
+- Catch-all error handling via exception filter.
+- Serialization of error response payloads as JSON:API errors.
 
 ### Changed
 

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -17,6 +17,8 @@ import { GeoModule } from 'modules/geo/geo.module';
 import { apiConnections } from './ormconfig';
 import { OrganizationsModule } from 'modules/organizations/organizations.module';
 import { PaginationMiddleware } from 'middleware/pagination.middleware';
+import { APP_FILTER } from '@nestjs/core';
+import { AllExceptionsFilter } from 'filters/all-exceptions.exception.filter';
 
 @Module({
   imports: [
@@ -31,7 +33,13 @@ import { PaginationMiddleware } from 'middleware/pagination.middleware';
     AuthenticationModule,
   ],
   controllers: [AppController, PingController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_FILTER,
+      useClass: AllExceptionsFilter,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   /**

--- a/api/src/filters/all-exceptions.exception.filter.ts
+++ b/api/src/filters/all-exceptions.exception.filter.ts
@@ -1,0 +1,27 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/api/src/filters/all-exceptions.exception.filter.ts
+++ b/api/src/filters/all-exceptions.exception.filter.ts
@@ -4,24 +4,47 @@ import {
   ArgumentsHost,
   HttpException,
   HttpStatus,
+  Logger,
 } from '@nestjs/common';
+import * as config from 'config';
 
-@Catch()
+/**
+ * Catch-all exception filter.
+ *
+ *
+ */
+@Catch(Error)
 export class AllExceptionsFilter implements ExceptionFilter {
-  catch(exception: unknown, host: ArgumentsHost) {
+  catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
     const request = ctx.getRequest();
+
+    Logger.error(`Error: ${JSON.stringify(exception, null, 2)}`);
 
     const status =
       exception instanceof HttpException
         ? exception.getStatus()
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
+    // In development environments only, add full error details to the response.
+    const errorDetails =
+      config.util.getEnv('NODE_ENV') === 'development'
+        ? {
+            type: Object.getPrototypeOf(exception)?.name,
+            raw: exception,
+            stack: exception.stack,
+          }
+        : undefined;
+
     response.status(status).json({
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
+      error: {
+        message: exception.message,
+        ...errorDetails,
+      },
     });
   }
 }

--- a/api/src/filters/all-exceptions.exception.filter.ts
+++ b/api/src/filters/all-exceptions.exception.filter.ts
@@ -7,11 +7,16 @@ import {
   Logger,
 } from '@nestjs/common';
 import * as config from 'config';
+import { omit } from 'lodash';
+
+const JSONAPIError = require('jsonapi-serializer').Error;
 
 /**
- * Catch-all exception filter.
+ * Catch-all exception filter. Output error data to logs, and send it as
+ * response payload, serialized according to JSON:API spec.
  *
- *
+ * @debt The error handling logic for general cases should be moved to a utility
+ * module, with option to extend it for specific per-service scenarios.
  */
 @Catch(Error)
 export class AllExceptionsFilter implements ExceptionFilter {
@@ -20,31 +25,43 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const response = ctx.getResponse();
     const request = ctx.getRequest();
 
-    Logger.error(`Error: ${JSON.stringify(exception, null, 2)}`);
-
     const status =
       exception instanceof HttpException
         ? exception.getStatus()
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
-    // In development environments only, add full error details to the response.
-    const errorDetails =
-      config.util.getEnv('NODE_ENV') === 'development'
-        ? {
-            type: Object.getPrototypeOf(exception)?.name,
-            raw: exception,
-            stack: exception.stack,
-          }
-        : undefined;
-
-    response.status(status).json({
-      statusCode: status,
-      timestamp: new Date().toISOString(),
-      path: request.url,
-      error: {
-        message: exception.message,
-        ...errorDetails,
+    /**
+     * Core error data.
+     */
+    const errorData = {
+      status: status,
+      title: exception.message,
+      meta: {
+        timestamp: new Date().toISOString(),
+        path: request.url,
+        type: Object.getPrototypeOf(exception)?.name,
+        rawError: exception,
+        stack: exception.stack,
       },
-    });
+    };
+
+    Logger.error(errorData);
+
+    /**
+     * When *not* running in a development environment, we strip off raw error
+     * details and stack trace.
+     *
+     * @todo We should remove raw error details from the HTTP response payload
+     * even in development environments at some point, but for the time being
+     * these should help frontend devs and other API users report bugs or other
+     * issues without having to look at logs.
+     */
+    const errorDataForResponse = new JSONAPIError(
+      config.util.getEnv('NODE_ENV') !== 'development'
+        ? omit(errorData, ['meta.rawError', 'meta.stack'])
+        : errorData,
+    );
+
+    response.status(status).json(errorDataForResponse);
   }
 }

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -6,6 +6,7 @@ import * as helmet from 'helmet';
 import { CorsUtils } from './utils/cors.utils';
 import { AppConfig } from 'utils/config.utils';
 import { ValidationPipe } from '@nestjs/common';
+import { AllExceptionsFilter } from 'filters/all-exceptions.exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -40,6 +41,7 @@ async function bootstrap() {
   SwaggerModule.setup('/swagger', app, swaggerDocument);
 
   app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalFilters(new AllExceptionsFilter());
 
   await app.listen(3000);
 }

--- a/api/src/modules/authentication/authentication.controller.ts
+++ b/api/src/modules/authentication/authentication.controller.ts
@@ -21,7 +21,6 @@ import {
   AccessToken,
   AuthenticationService,
 } from 'modules/authentication/authentication.service';
-import { User } from 'modules/users/user.api.entity';
 import { LoginDto } from './dto/login.dto';
 import { SignUpDto } from './dto/sign-up.dto';
 import { LocalAuthGuard } from './local-auth.guard';
@@ -38,7 +37,7 @@ export class AuthenticationController {
   })
   async login(
     @Request() req: RequestWithAuthenticatedUser,
-    @Body(new ValidationPipe()) dto: LoginDto,
+    @Body(new ValidationPipe()) _dto: LoginDto,
   ): Promise<AccessToken> {
     return this.authenticationService.login(req.user);
   }
@@ -49,7 +48,7 @@ export class AuthenticationController {
   @ApiBadRequestResponse()
   @ApiForbiddenResponse()
   async signUp(
-    @Request() req: Request,
+    @Request() _req: Request,
     @Body(new ValidationPipe()) signupDto: SignUpDto,
   ): Promise<void> {
     await this.authenticationService.createUser(signupDto);

--- a/api/src/modules/authentication/authentication.service.ts
+++ b/api/src/modules/authentication/authentication.service.ts
@@ -96,6 +96,7 @@ export class AuthenticationService {
    */
   async createUser(signupDto: SignUpDto): Promise<Partial<User>> {
     const user = new User();
+    user.displayName = signupDto.displayName;
     user.passwordHash = await hash(signupDto.password, 10);
     user.email = signupDto.email;
     /**

--- a/api/src/modules/authentication/authentication.service.ts
+++ b/api/src/modules/authentication/authentication.service.ts
@@ -10,7 +10,6 @@ import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IssuedAuthnToken } from './issued-authn-token.api.entity';
 import ms = require('ms');
-import { LoginDto } from './dto/login.dto';
 import { SignUpDto } from './dto/sign-up.dto';
 
 /**

--- a/api/src/modules/authentication/dto/sign-up.dto.ts
+++ b/api/src/modules/authentication/dto/sign-up.dto.ts
@@ -1,15 +1,23 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsDefined, IsEmail, IsNotEmpty, IsString } from 'class-validator';
-
-import { LoginDto } from './login.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDefined,
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 /**
  * @todo Allow to provide fname/lname/display name on signup (and any other
- * relevant user data), if needed. Probably We could just start with email and
- * password, and once the user has validated their email address we can let them
- * log in and set any other info.
+ * relevant user data), if needed. Probably We could just start with
+ * displayName, email and password, following the designs, and once the user has
+ * validated their email address we can let them log in and set any other info.
  */
 export class SignUpDto {
+  @IsOptional()
+  @IsString()
+  displayName: string;
+
   @IsEmail()
   @IsNotEmpty()
   @IsDefined()

--- a/api/src/modules/organizations/organizations.service.ts
+++ b/api/src/modules/organizations/organizations.service.ts
@@ -6,8 +6,6 @@ import { CreateOrganizationDTO } from './dto/create.organization.dto';
 import { UpdateOrganizationDTO } from './dto/update.organization.dto';
 import { Organization } from './organization.api.entity';
 
-import JSONAPISerializer = require('jsonapi-serializer');
-
 import * as faker from 'faker';
 import { UsersService } from 'modules/users/users.service';
 import { AppBaseService } from 'utils/app-base.service';

--- a/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -17,7 +17,7 @@ export class CreateScenarioDTO {
 
   @ApiPropertyOptional()
   @IsOptional()
-  description: string;
+  description?: string;
 
   @ApiProperty()
   type: ScenarioType;
@@ -30,24 +30,24 @@ export class CreateScenarioDTO {
   @Length(3)
   country: string;
 
-  @ApiPropertyOptional()
-  @IsOptional()
-  extent: Record<string, unknown> | null;
+  @ApiProperty()
+  extent: Record<string, unknown>;
 
   @ApiPropertyOptional()
   @IsOptional()
-  wdpaFilter: Record<string, unknown> | null;
+  wdpaFilter?: Record<string, unknown>;
 
   @ApiPropertyOptional()
   @IsInt()
   @IsOptional()
   @Min(0)
   @Max(100)
-  wdpaThreshold: number | null;
+  wdpaThreshold?: number;
 
+  @ApiProperty()
   @IsUUID()
   adminRegionId: string;
 
   @ApiPropertyOptional()
-  metadata: Dictionary<string>;
+  metadata?: Dictionary<string>;
 }

--- a/api/src/modules/scenarios/scenario.api.entity.ts
+++ b/api/src/modules/scenarios/scenario.api.entity.ts
@@ -27,8 +27,8 @@ import { TimeUserEntityMetadata } from 'types/time-user-entity-metadata';
  * kinds in the future).
  */
 export enum ScenarioType {
-  standard = 'Standard',
-  marxanWithZones = 'Marxan with zones',
+  marxan = 'marxan',
+  marxanWithZones = 'marxan-with-zones',
 }
 
 export enum JobStatus {

--- a/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/src/modules/scenarios/scenarios.service.ts
@@ -64,7 +64,7 @@ export class ScenariosService extends AppBaseService<
       id: faker.random.uuid(),
       name: faker.lorem.words(5),
       description: faker.lorem.sentence(),
-      type: ScenarioType.standard,
+      type: ScenarioType.marxan,
       extent: {},
       wdpaFilter: {},
       wdpaThreshold: faker.random.number(100),

--- a/api/test/app.e2e-spec.ts
+++ b/api/test/app.e2e-spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
-import * as faker from 'faker';
+import { E2E_CONFIG } from './e2e.config';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -27,8 +27,8 @@ describe('AppController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .post('/auth/sign-in')
         .send({
-          username: 'aa@example.com',
-          password: 'aauserpassword',
+          username: E2E_CONFIG.users.aa.username,
+          password: E2E_CONFIG.users.aa.password,
         })
         .expect(201);
 

--- a/api/test/app.e2e-spec.ts
+++ b/api/test/app.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('AppController (e2e)', () => {
 
     it('Retrieves a JWT token when authenticating with valid credentials', async () => {
       const response = await request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/auth/sign-in')
         .send({
           username: 'aa@example.com',
           password: 'aauserpassword',
@@ -37,8 +37,8 @@ describe('AppController (e2e)', () => {
 
     it('Fails to authenticate a user with an incorrect password', async () => {
       const response = await request(app.getHttpServer())
-        .post('/auth/login')
-        .send({ email: 'test@example.com', password: 'wrong' })
+        .post('/auth/sign-in')
+        .send({ email: E2E_CONFIG.users.aa.username, password: 'wrong' })
         .expect(401);
 
       expect(response.body.accessToken).not.toBeDefined();
@@ -46,7 +46,7 @@ describe('AppController (e2e)', () => {
 
     it('Fails to authenticate a non-existing user', async () => {
       const response = await request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/auth/sign-in')
         .send({ email: 'test@example.com', password: 'wrong' })
         .expect(401);
 

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -1,0 +1,38 @@
+import * as faker from 'faker';
+import { JobStatus, ScenarioType } from 'modules/scenarios/scenario.api.entity';
+
+export const E2E_CONFIG = {
+  users: {
+    aa: {
+      username: 'aa@example.com',
+      password: 'aauserpassword',
+    },
+  },
+  scenarios: {
+    validScenarios: [
+      {
+        name: faker.random.words(5),
+        type: ScenarioType.marxan,
+        projectId: null,
+        description: faker.lorem.paragraphs(2),
+        metadata: {},
+        country: 'esp',
+        adminRegionId: faker.random.uuid(),
+        extent: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-10.0, -10.0],
+              [10.0, -10.0],
+              [10.0, 10.0],
+              [-10.0, -10.0],
+            ],
+          ],
+        },
+        numberOfRuns: 100,
+        boundaryLengthModifier: 0,
+        status: JobStatus.created,
+      },
+    ],
+  },
+};

--- a/api/test/organizations.e2e-spec.ts
+++ b/api/test/organizations.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 import * as faker from 'faker';
+import { E2E_CONFIG } from './e2e.config';
 
 describe('OrganizationsController (e2e)', () => {
   let app: INestApplication;
@@ -20,8 +21,8 @@ describe('OrganizationsController (e2e)', () => {
     const response = await request(app.getHttpServer())
       .post('/auth/sign-in')
       .send({
-        username: 'aa@example.com',
-        password: 'aauserpassword',
+        username: E2E_CONFIG.users.aa.username,
+        password: E2E_CONFIG.users.aa.password,
       })
       .expect(201);
 

--- a/api/test/organizations.e2e-spec.ts
+++ b/api/test/organizations.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('OrganizationsController (e2e)', () => {
     await app.init();
 
     const response = await request(app.getHttpServer())
-      .post('/auth/login')
+      .post('/auth/sign-in')
       .send({
         username: 'aa@example.com',
         password: 'aauserpassword',

--- a/api/test/organizations.e2e-spec.ts
+++ b/api/test/organizations.e2e-spec.ts
@@ -56,11 +56,11 @@ describe('OrganizationsController (e2e)', () => {
         })
         .expect(201);
 
-        const resources = response.body.data;
+      const resources = response.body.data;
 
-        anOrganization = resources[0];
-        expect(anOrganization.type).toBe('organizations');
-      });
+      anOrganization = resources[0];
+      expect(anOrganization.type).toBe('organizations');
+    });
 
     it('Gets organizations', async () => {
       const response = await request(app.getHttpServer())

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, Logger } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+import * as faker from 'faker';
+import { E2E_CONFIG } from './e2e.config';
+import { Project } from 'modules/projects/project.api.entity';
+import { CreateScenarioDTO } from 'modules/scenarios/dto/create.scenario.dto';
+import { inspect } from 'util';
+
+describe('ScenariosModule (e2e)', () => {
+  let app: INestApplication;
+
+  let jwtToken: string;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/auth/sign-in')
+      .send({
+        username: E2E_CONFIG.users.aa.username,
+        password: E2E_CONFIG.users.aa.password,
+      })
+      .expect(201);
+
+    jwtToken = response.body.accessToken;
+  });
+
+  afterEach(async () => {
+    await Promise.all([app.close()]);
+  });
+
+  describe('Scenarios', () => {
+    let aScenario: { id: string; type: 'scenarios' };
+    let projects: { id: string }[] = [];
+
+    it('Gets scenarios', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/scenarios')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+
+      expect(resources[0].type).toBe('scenarios');
+    });
+
+    it('Gets projects', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/projects')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+      projects = resources;
+      expect(resources[0].type).toBe('projects');
+    });
+
+    it('Creating a scenario with incomplete data should fail', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/scenarios')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          name: faker.random.words(3),
+          description: faker.lorem.sentence(),
+        })
+        .expect(400);
+
+      const resources = response.body.data;
+    });
+
+    it('Creating a scenario with complete data should succeed', async () => {
+      const createScenarioDTO: CreateScenarioDTO = {
+        ...E2E_CONFIG.scenarios.validScenarios[0],
+        projectId: projects[0].id,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/scenarios')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(createScenarioDTO)
+        .expect(201)
+
+      const resources = response.body.data;
+      aScenario = resources[0];
+      expect(aScenario.type).toBe('scenarios');
+      expect(resources.length).toBe(1);
+    });
+
+    it('Gets scenarios (paginated; pages of up to 5 items, no explicit page number - should default to 1)', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/scenarios?page[size]=5')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+      expect(resources[0].type).toBe('scenarios');
+      expect(resources.length).toBeLessThanOrEqual(5);
+      expect(resources.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Gets scenarios (paginated; pages of up to 5 items, first page)', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/scenarios?page[size]=5&page[number]=1')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+      expect(resources[0].type).toBe('scenarios');
+      expect(resources.length).toBeLessThanOrEqual(5);
+      expect(resources.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Deletes the newly created scenario', async () => {
+      const response = await request(app.getHttpServer())
+        .delete('/api/v1/scenarios/' + aScenario.id)
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+
+      expect(resources).toBeUndefined();
+    });
+  });
+});

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -1,12 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, Logger } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 import * as faker from 'faker';
 import { E2E_CONFIG } from './e2e.config';
-import { Project } from 'modules/projects/project.api.entity';
 import { CreateScenarioDTO } from 'modules/scenarios/dto/create.scenario.dto';
-import { inspect } from 'util';
 
 describe('ScenariosModule (e2e)', () => {
   let app: INestApplication;
@@ -63,7 +61,7 @@ describe('ScenariosModule (e2e)', () => {
     });
 
     it('Creating a scenario with incomplete data should fail', async () => {
-      const response = await request(app.getHttpServer())
+      await request(app.getHttpServer())
         .post('/api/v1/scenarios')
         .set('Authorization', `Bearer ${jwtToken}`)
         .send({
@@ -71,8 +69,6 @@ describe('ScenariosModule (e2e)', () => {
           description: faker.lorem.sentence(),
         })
         .expect(400);
-
-      const resources = response.body.data;
     });
 
     it('Creating a scenario with complete data should succeed', async () => {
@@ -85,7 +81,7 @@ describe('ScenariosModule (e2e)', () => {
         .post('/api/v1/scenarios')
         .set('Authorization', `Bearer ${jwtToken}`)
         .send(createScenarioDTO)
-        .expect(201)
+        .expect(201);
 
       const resources = response.body.data;
       aScenario = resources[0];


### PR DESCRIPTION
### Overview

Basic but hopefully effective catch-all exception filter.

Catches all uncaught exceptions that inherit from the base `Error` exception class.

Logs errors to logs.

In non-development environments, sends error code, message, request path and timestamp in API response for requests that trigger errors.

In development environments, also sends raw exception and stack trace 🚀 

I suppose we could avoid ever sending this info in the HTTP response and just log it. I'd keep it as is for now (it may help frontend devs to report issues without having to go and look at logs), and we can revisit later on.

### Designs

N/A

### Testing instructions

Send some malformed requests to random API endpoints (maybe easier if a POST one) - error details should show in the API logs and in the response.

### Feature relevant tickets

https://www.pivotaltracker.com/story/show/176865443

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [x] Update CHANGELOG file