### PR TITLE
[MARXAN-81] return object vs singleton in single responses

### DIFF
--- a/api/src/modules/countries/countries.controller.ts
+++ b/api/src/modules/countries/countries.controller.ts
@@ -34,7 +34,7 @@ export class CountriesController {
     description: 'Find all countries',
   })
   @ApiOkResponse({
-    type: Country,
+    type: CountryResult,
   })
   @ApiUnauthorizedResponse()
   @ApiForbiddenResponse()
@@ -42,7 +42,7 @@ export class CountriesController {
   @Get()
   async findAll(
     @Pagination() pagination: FetchSpecification,
-  ): Promise<Country[]> {
+  ): Promise<CountryResult> {
     const results = await this.service.findAllPaginated(pagination);
     return this.service.serialize(results.data, results.metadata);
   }
@@ -50,7 +50,7 @@ export class CountriesController {
   @ApiOperation({ description: 'Find country by id' })
   @ApiOkResponse({ type: CountryResult })
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Country> {
-    return await this.service.getById(id);
+  async findOne(@Param('id') id: string): Promise<CountryResult> {
+    return await this.service.serialize(await this.service.getById(id));
   }
 }

--- a/api/src/modules/countries/countries.controller.ts
+++ b/api/src/modules/countries/countries.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import { Country, CountryResult } from './country.api.entity';
+import { CountryResult } from './country.api.entity';
 import { CountriesService } from './countries.service';
 import {
   ApiBearerAuth,

--- a/api/src/modules/organizations/organizations.controller.ts
+++ b/api/src/modules/organizations/organizations.controller.ts
@@ -51,7 +51,7 @@ export class OrganizationsController {
     description: 'Find all organizations',
   })
   @ApiOkResponse({
-    type: Organization,
+    type: OrganizationResult,
   })
   @ApiUnauthorizedResponse({
     description: 'Unauthorized.',
@@ -64,7 +64,7 @@ export class OrganizationsController {
   @Get()
   async findAll(
     @Pagination() pagination: FetchSpecification,
-  ): Promise<Organization[]> {
+  ): Promise<OrganizationResult> {
     const results = await this.service.findAllPaginated(pagination);
     return this.service.serialize(results.data, results.metadata);
   }
@@ -72,8 +72,8 @@ export class OrganizationsController {
   @ApiOperation({ description: 'Find organization by id' })
   @ApiOkResponse({ type: OrganizationResult })
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Organization> {
-    return await this.service.serialize([await this.service.getById(id)]);
+  async findOne(@Param('id') id: string): Promise<OrganizationResult> {
+    return await this.service.serialize(await this.service.getById(id));
   }
 
   @ApiOperation({ description: 'Create organization' })

--- a/api/src/modules/organizations/organizations.controller.ts
+++ b/api/src/modules/organizations/organizations.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
-import { Organization, OrganizationResult } from './organization.api.entity';
+import { OrganizationResult } from './organization.api.entity';
 import { OrganizationsService } from './organizations.service';
 
 import {
@@ -83,9 +83,9 @@ export class OrganizationsController {
     @Body(new ValidationPipe()) dto: CreateOrganizationDTO,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<OrganizationResult> {
-    return await this.service.serialize([
+    return await this.service.serialize(
       await this.service.create(dto, { authenticatedUser: req.user }),
-    ]);
+    );
   }
 
   @ApiOperation({ description: 'Update organization' })
@@ -95,7 +95,7 @@ export class OrganizationsController {
     @Param('id') id: string,
     @Body(new ValidationPipe()) dto: UpdateOrganizationDTO,
   ): Promise<OrganizationResult> {
-    return await this.service.serialize([await this.service.update(id, dto)]);
+    return await this.service.serialize(await this.service.update(id, dto));
   }
 
   @ApiOperation({ description: 'Delete organization' })

--- a/api/src/modules/projects/projects.controller.ts
+++ b/api/src/modules/projects/projects.controller.ts
@@ -82,7 +82,7 @@ export class ProjectsController {
   @ApiOkResponse({ type: ProjectResult })
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<ProjectResult> {
-    return await this.service.serialize([await this.service.getById(id)]);
+    return await this.service.serialize(await this.service.getById(id));
   }
 
   @ApiOperation({ description: 'Create project' })

--- a/api/src/modules/projects/projects.controller.ts
+++ b/api/src/modules/projects/projects.controller.ts
@@ -92,9 +92,9 @@ export class ProjectsController {
     @Body(new ValidationPipe()) dto: CreateProjectDTO,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProjectResult> {
-    return await this.service.serialize([
+    return await this.service.serialize(
       await this.service.create(dto, { authenticatedUser: req.user }),
-    ]);
+    );
   }
 
   @ApiOperation({ description: 'Update project' })
@@ -104,7 +104,7 @@ export class ProjectsController {
     @Param('id') id: string,
     @Body(new ValidationPipe()) dto: UpdateProjectDTO,
   ): Promise<ProjectResult> {
-    return await this.service.serialize([await this.service.update(id, dto)]);
+    return await this.service.serialize(await this.service.update(id, dto));
   }
 
   @ApiOperation({ description: 'Delete project' })

--- a/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/src/modules/scenarios/scenarios.controller.ts
@@ -77,9 +77,9 @@ export class ScenariosController {
     @Body(new ValidationPipe()) dto: CreateScenarioDTO,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ScenarioResult> {
-    return await this.service.serialize([
+    return await this.service.serialize(
       await this.service.create(dto, { authenticatedUser: req.user }),
-    ]);
+    );
   }
 
   @ApiOperation({ description: 'Update scenario' })
@@ -89,7 +89,7 @@ export class ScenariosController {
     @Param('id') id: string,
     @Body(new ValidationPipe()) dto: UpdateScenarioDTO,
   ): Promise<ScenarioResult> {
-    return await this.service.serialize([await this.service.update(id, dto)]);
+    return await this.service.serialize(await this.service.update(id, dto));
   }
 
   @ApiOperation({ description: 'Delete scenario' })

--- a/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/src/modules/scenarios/scenarios.controller.ts
@@ -67,7 +67,7 @@ export class ScenariosController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<ScenarioResult> {
-    return await this.service.serialize([await this.service.getById(id)]);
+    return await this.service.serialize(await this.service.getById(id));
   }
 
   @ApiOperation({ description: 'Create scenario' })

--- a/api/src/utils/app-base.service.ts
+++ b/api/src/utils/app-base.service.ts
@@ -69,7 +69,7 @@ export abstract class AppBaseService<
     return query.getManyAndCount();
   }
 
-  async getSerializedData(data: Entity[], meta?: PaginationMeta) {
+  async getSerializedData(data: Entity | Entity[], meta?: PaginationMeta) {
     const serializer = new JSONAPISerializer.Serializer(this.pluralAlias, {
       ...this.serializerConfig,
       meta,
@@ -79,7 +79,7 @@ export abstract class AppBaseService<
   }
 
   async serialize(
-    entities: Entity[],
+    entities: Entity | Entity[],
     paginationMeta?: PaginationMeta,
   ): Promise<any> {
     return this.getSerializedData(entities, paginationMeta);

--- a/api/test/app.e2e-spec.ts
+++ b/api/test/app.e2e-spec.ts
@@ -90,7 +90,7 @@ describe('AppController (e2e)', () => {
 
       const resources = response.body.data;
 
-      expect(resources[0].type).toBe('projects');
+      expect(resources.type).toBe('projects');
     });
   });
 });

--- a/api/test/organizations.e2e-spec.ts
+++ b/api/test/organizations.e2e-spec.ts
@@ -57,9 +57,8 @@ describe('OrganizationsController (e2e)', () => {
         })
         .expect(201);
 
-      const resources = response.body.data;
+      anOrganization = response.body.data;
 
-      anOrganization = resources[0];
       expect(anOrganization.type).toBe('organizations');
     });
 
@@ -86,8 +85,7 @@ describe('OrganizationsController (e2e)', () => {
         })
         .expect(201);
 
-      const resources = response.body.data;
-      aProject = resources[0];
+      aProject = response.body.data;
       expect(aProject.type).toBe('projects');
     });
 

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -72,10 +72,8 @@ describe('ScenariosModule (e2e)', () => {
         .send(createScenarioDTO)
         .expect(201);
 
-      const resources = response.body.data;
-      aScenario = resources[0];
+      aScenario = response.body.data;
       expect(aScenario.type).toBe('scenarios');
-      expect(resources.length).toBe(1);
     });
 
     it('Gets scenarios', async () => {


### PR DESCRIPTION
### Overview

Fixes https://vizzuality.atlassian.net/browse/MARXAN-81 and updates all current controllers (GET :id, POST, PATCH) to return the correct data shape.

### Designs

N/A

### Testing instructions

See acceptance tests in issue, but basically the e2e should do the work - they are updated to check what the acceptance tests ask.

```
docker-compose exec api yarn test:e2e test
```

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-81

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [x] Update CHANGELOG file