### PR TITLE
[MARXAN-105] API - scenarios: only enforce minimum prop set as compulsory

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -22,8 +22,14 @@ import { AllExceptionsFilter } from 'filters/all-exceptions.exception.filter';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot(apiConnections.default),
-    TypeOrmModule.forRoot(apiConnections.geoprocessingDB),
+    TypeOrmModule.forRoot({
+      ...apiConnections.default,
+      keepConnectionAlive: true,
+    }),
+    TypeOrmModule.forRoot({
+      ...apiConnections.geoprocessingDB,
+      keepConnectionAlive: true,
+    }),
     CountriesModule,
     GeoModule,
     OrganizationsModule,

--- a/api/src/migrations/api/1611329857558-initialDataMetadataEntities.ts
+++ b/api/src/migrations/api/1611329857558-initialDataMetadataEntities.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class initialDataMetadataEntities1611329857558
+export class InitialDataMetadataEntities1611329857558
   implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/api/src/migrations/api/1613988195000-UpdateNullableColumnsForProjectsAndScenarios.ts
+++ b/api/src/migrations/api/1613988195000-UpdateNullableColumnsForProjectsAndScenarios.ts
@@ -5,7 +5,7 @@ export class UpdateNullableColumnsForProjectsAndScenarios1613988195000
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
 ALTER TABLE projects
-  ADD COLUMN country_id varchar(2) REFERENCES countries(iso_3166_1_alpha2),
+  ADD COLUMN country_id varchar(3),
   ADD COLUMN admin_region_id uuid,
   ADD COLUMN extent geometry;
 
@@ -24,7 +24,7 @@ ALTER TABLE scenarios
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
 ALTER TABLE scenarios
-  ADD COLUMN country_id varchar(2) REFERENCES countries(iso_3166_1_alpha2),
+  ADD COLUMN country_id varchar(3),
   ADD COLUMN admin_region_id uuid,
   ADD COLUMN extent geometry;
   

--- a/api/src/migrations/api/1613988195000-UpdateNullableColumnsForProjectsAndScenarios.ts
+++ b/api/src/migrations/api/1613988195000-UpdateNullableColumnsForProjectsAndScenarios.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateNullableColumnsForProjectsAndScenarios1613988195000
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+ALTER TABLE projects
+  ADD COLUMN country_id varchar(2) REFERENCES countries(iso_3166_1_alpha2),
+  ADD COLUMN admin_region_id uuid,
+  ADD COLUMN extent geometry;
+
+ALTER TABLE scenarios
+  DROP COLUMN country_id,
+  DROP COLUMN admin_region_id,
+  DROP COLUMN extent;
+
+ALTER TABLE scenarios
+  ALTER COLUMN number_of_runs DROP NOT NULL,
+  ALTER COLUMN blm DROP NOT NULL,
+  ALTER COLUMN status DROP NOT NULL;
+`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+ALTER TABLE scenarios
+  ADD COLUMN country_id varchar(2) REFERENCES countries(iso_3166_1_alpha2),
+  ADD COLUMN admin_region_id uuid,
+  ADD COLUMN extent geometry;
+  
+ALTER TABLE projects
+  DROP COLUMN country_id,
+  DROP COLUMN admin_region_id,
+  DROP COLUMN extent;
+
+ALTER TABLE scenarios
+  ALTER COLUMN number_of_runs SET NULL,
+  ALTER COLUMN blm SET NULL,
+  ALTER COLUMN status SET NULL;
+`);
+  }
+}

--- a/api/src/modules/projects/dto/create.project.dto.ts
+++ b/api/src/modules/projects/dto/create.project.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID, Length } from 'class-validator';
 import { Dictionary } from 'lodash';
 
 export class CreateProjectDTO {
@@ -6,11 +7,27 @@ export class CreateProjectDTO {
   name: string;
 
   @ApiPropertyOptional()
-  description: string;
+  description?: string;
 
   @ApiProperty()
+  @IsUUID()
   organizationId: string;
 
   @ApiPropertyOptional()
-  metadata: Dictionary<string>;
+  @IsString()
+  @Length(3)
+  @IsOptional()
+  country?: string;
+
+  @ApiPropertyOptional()
+  @IsUUID()
+  @IsOptional()
+  adminRegionId?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  extent?: Record<string, unknown>;
+
+  @ApiPropertyOptional()
+  metadata?: Dictionary<string>;
 }

--- a/api/src/modules/projects/dto/create.project.dto.ts
+++ b/api/src/modules/projects/dto/create.project.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID, Length } from 'class-validator';
+import {
+  IsAlpha,
+  IsOptional,
+  IsString,
+  IsUppercase,
+  IsUUID,
+  Length,
+} from 'class-validator';
 import { Dictionary } from 'lodash';
 
 export class CreateProjectDTO {
@@ -13,11 +20,15 @@ export class CreateProjectDTO {
   @IsUUID()
   organizationId: string;
 
-  @ApiPropertyOptional()
-  @IsString()
-  @Length(3)
+  @ApiPropertyOptional({
+    description: 'ISO 3166-1 alpha3 country code (uppercase)',
+    example: 'ESP',
+  })
+  @IsAlpha()
+  @IsUppercase()
+  @Length(3, 3)
   @IsOptional()
-  country?: string;
+  countryId?: string;
 
   @ApiPropertyOptional()
   @IsUUID()

--- a/api/src/modules/projects/project.api.entity.ts
+++ b/api/src/modules/projects/project.api.entity.ts
@@ -13,6 +13,7 @@ import {
 } from 'typeorm';
 import { Organization } from 'modules/organizations/organization.api.entity';
 import { TimeUserEntityMetadata } from 'types/time-user-entity-metadata';
+import { Country } from 'modules/countries/country.api.entity';
 
 @Entity('projects')
 export class Project extends TimeUserEntityMetadata {
@@ -41,6 +42,34 @@ export class Project extends TimeUserEntityMetadata {
 
   @Column('uuid', { name: 'organization_id' })
   organizationId: string;
+
+  /**
+   * The country where this project is located.
+   */
+  @ApiProperty()
+  @ManyToOne((_type) => Country)
+  @JoinColumn({
+    name: 'country_id',
+    referencedColumnName: 'alpha3',
+  })
+  country: Country;
+
+  /**
+   * The smallest administrative region that contains the whole project's
+   * geometry.
+   *
+   * @todo Check description.
+   */
+  @ApiProperty()
+  @Column('uuid', { name: 'admin_region_id' })
+  adminRegionId: string;
+
+  /**
+   * Extent of the project
+   */
+  @ApiPropertyOptional()
+  @Column('geometry')
+  extent: Record<string, unknown> | null;
 
   /**
    * JSONB storage for non-relational attributes

--- a/api/src/modules/projects/project.api.entity.ts
+++ b/api/src/modules/projects/project.api.entity.ts
@@ -46,13 +46,8 @@ export class Project extends TimeUserEntityMetadata {
   /**
    * The country where this project is located.
    */
-  @ApiProperty()
-  @ManyToOne((_type) => Country)
-  @JoinColumn({
-    name: 'country_id',
-    referencedColumnName: 'alpha3',
-  })
-  country: Country;
+  @Column('uuid', { name: 'country_id' })
+  countryId: string;
 
   /**
    * The smallest administrative region that contains the whole project's

--- a/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -4,9 +4,7 @@ import {
   IsInt,
   IsNumber,
   IsOptional,
-  IsString,
   IsUUID,
-  Length,
   Max,
   Min,
 } from 'class-validator';

--- a/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  IsEnum,
   IsInt,
+  IsNumber,
   IsOptional,
   IsString,
   IsUUID,
@@ -20,18 +22,12 @@ export class CreateScenarioDTO {
   description?: string;
 
   @ApiProperty()
+  @IsEnum(ScenarioType)
   type: ScenarioType;
 
   @ApiProperty()
+  @IsUUID()
   projectId: string;
-
-  @ApiProperty()
-  @IsString()
-  @Length(3)
-  country: string;
-
-  @ApiProperty()
-  extent: Record<string, unknown>;
 
   @ApiPropertyOptional()
   @IsOptional()
@@ -44,10 +40,18 @@ export class CreateScenarioDTO {
   @Max(100)
   wdpaThreshold?: number;
 
-  @ApiProperty()
-  @IsUUID()
-  adminRegionId: string;
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  numberOfRuns?: number;
 
   @ApiPropertyOptional()
+  @IsNumber()
+  @IsOptional()
+  boundaryLengthModifier: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
   metadata?: Dictionary<string>;
 }

--- a/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -49,7 +49,7 @@ export class CreateScenarioDTO {
   @ApiPropertyOptional()
   @IsNumber()
   @IsOptional()
-  boundaryLengthModifier: number;
+  boundaryLengthModifier?: number;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -20,7 +20,7 @@ export class CreateScenarioDTO {
   description?: string;
 
   @ApiProperty()
-  @IsEnum(ScenarioType)
+  @IsEnum(Object.values(ScenarioType))
   type: ScenarioType;
 
   @ApiProperty()

--- a/api/src/modules/scenarios/scenario.api.entity.ts
+++ b/api/src/modules/scenarios/scenario.api.entity.ts
@@ -71,24 +71,6 @@ export class Scenario extends TimeUserEntityMetadata {
   projectId: string;
 
   /**
-   * The country where this scenario is located.
-   */
-  @ApiProperty()
-  @ManyToOne((_type) => Country)
-  @JoinColumn({
-    name: 'country_id',
-    referencedColumnName: 'alpha2',
-  })
-  country: Country;
-
-  /**
-   * Extent of the scenario
-   */
-  @ApiPropertyOptional()
-  @Column('geometry')
-  extent: Record<string, unknown> | null;
-
-  /**
    * Filter for WDPA data selection.
    *
    * @todo Improve description, add examples.
@@ -107,39 +89,22 @@ export class Scenario extends TimeUserEntityMetadata {
    */
   @ApiPropertyOptional()
   @Column('integer', { name: 'wdpa_threshold' })
-  @IsInt()
   @IsOptional()
-  @Min(0)
-  @Max(100)
   wdpaThreshold: number | null;
-
-  /**
-   * The smallest administrative region that contains the whole scenario's
-   * geometry.
-   *
-   * @todo Check description.
-   */
-  @ApiProperty()
-  @Column('uuid', { name: 'admin_region_id' })
-  @IsUUID()
-  adminRegionId: string;
 
   /**
    * Number of runs for Marxan calculations.
    */
-  @ApiProperty()
+  @ApiPropertyOptional()
   @Column('integer', { name: 'number_of_runs' })
-  @IsInt()
-  @Min(0)
-  numberOfRuns: number;
+  numberOfRuns?: number;
 
   /**
    * Boundary Length Modifier
    */
-  @ApiProperty()
+  @ApiPropertyOptional()
   @Column('double precision', { name: 'blm' })
-  @IsNumber()
-  boundaryLengthModifier: number;
+  boundaryLengthModifier?: number;
 
   /**
    * JSONB storage for non-relational attributes
@@ -157,7 +122,7 @@ export class Scenario extends TimeUserEntityMetadata {
    */
   @ApiProperty({ enum: JobStatus, enumName: 'JobStatus' })
   @Column('enum')
-  status: JobStatus;
+  status?: JobStatus;
 
   /**
    * Parent scenario.

--- a/api/src/modules/scenarios/scenario.api.entity.ts
+++ b/api/src/modules/scenarios/scenario.api.entity.ts
@@ -10,16 +10,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { User } from 'modules/users/user.api.entity';
-import { Country } from 'modules/countries/country.api.entity';
-import {
-  IsArray,
-  IsInt,
-  IsNumber,
-  IsOptional,
-  IsUUID,
-  Max,
-  Min,
-} from 'class-validator';
+import { IsArray, IsOptional } from 'class-validator';
 import { TimeUserEntityMetadata } from 'types/time-user-entity-metadata';
 
 /**
@@ -128,7 +119,6 @@ export class Scenario extends TimeUserEntityMetadata {
    * Parent scenario.
    */
   @ApiPropertyOptional()
-  @IsUUID()
   @IsOptional()
   @Column('uuid', { name: 'parent_id' })
   parentScenario: Scenario;

--- a/api/test/auth.e2e-spec.ts
+++ b/api/test/auth.e2e-spec.ts
@@ -21,18 +21,14 @@ describe('AppController (e2e)', () => {
   });
 
   describe('Authentication', () => {
-    let jwtToken: string;
-
     it('Retrieves a JWT token when authenticating with valid credentials', async () => {
-      const response = await request(app.getHttpServer())
+      await request(app.getHttpServer())
         .post('/auth/sign-in')
         .send({
           username: E2E_CONFIG.users.aa.username,
           password: E2E_CONFIG.users.aa.password,
         })
         .expect(201);
-
-      jwtToken = response.body.accessToken;
     });
 
     it('Fails to authenticate a user with an incorrect password', async () => {
@@ -51,46 +47,6 @@ describe('AppController (e2e)', () => {
         .expect(401);
 
       expect(response.body.accessToken).not.toBeDefined();
-    });
-
-    it('Gets projects', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/v1/projects')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .expect(200);
-
-      const resources = response.body.data;
-
-      expect(resources[0].type).toBe('projects');
-    });
-
-    let anOrganization: { id: string; type: 'organizations' };
-
-    it('Gets organizations', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/v1/organizations')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .expect(200);
-
-      const resources = response.body.data;
-      anOrganization = resources[0];
-      expect(resources[0].type).toBe('organizations');
-    });
-
-    it('Creates a project', async () => {
-      const response = await request(app.getHttpServer())
-        .post('/api/v1/projects')
-        .set('Authorization', `Bearer ${jwtToken}`)
-        .send({
-          name: 'Test Project 1234',
-          description: 'Description for this awesome project',
-          organizationId: anOrganization.id,
-        })
-        .expect(201);
-
-      const resources = response.body.data;
-
-      expect(resources.type).toBe('projects');
     });
   });
 });

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -12,6 +12,7 @@ export const E2E_CONFIG = {
     valid: {
       minimal: {
         name: faker.random.words(5),
+        type: ScenarioType.marxan,
         projectId: null,
       },
       complete:

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -9,7 +9,12 @@ export const E2E_CONFIG = {
     },
   },
   scenarios: {
-    validScenarios: [
+    valid: {
+      minimal: {
+        name: faker.random.words(5),
+        projectId: null,
+      },
+      complete:
       {
         name: faker.random.words(5),
         type: ScenarioType.marxan,
@@ -33,6 +38,12 @@ export const E2E_CONFIG = {
         boundaryLengthModifier: 0,
         status: JobStatus.created,
       },
-    ],
+    },
+    invalid: {
+      missingRequiredFields: {
+        name: faker.random.words(3),
+        description: faker.lorem.sentence(),
+      },
+    },
   },
 };

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -8,17 +8,25 @@ export const E2E_CONFIG = {
       password: 'aauserpassword',
     },
   },
+  organizations: {
+    valid: {
+      minimal: () => ({
+        name: faker.random.words(3),
+        description: faker.lorem.sentence(),
+      }),
+    },
+  },
   projects: {
     valid: {
-      minimal: {
+      minimal: () => ({
         name: faker.random.words(5),
         organizationId: null,
-      },
-      complete: {
+      }),
+      complete: (options: { countryCode: string }) => ({
         name: faker.random.words(5),
         organizationId: null,
         description: faker.lorem.paragraphs(2),
-        countryId: faker.address.countryCode(),
+        countryId: options.countryCode,
         adminRegionId: faker.random.uuid(),
         extent: {
           type: 'Polygon',
@@ -35,22 +43,22 @@ export const E2E_CONFIG = {
           [faker.random.word()]: faker.random.words(3),
           [faker.random.word()]: faker.random.uuid(),
         },
-      },
+      }),
     },
     invalid: {
-      incomplete: {
+      incomplete: () => ({
         name: faker.random.words(5),
-      },
+      }),
     },
   },
   scenarios: {
     valid: {
-      minimal: {
+      minimal: () => ({
         name: faker.random.words(5),
         type: ScenarioType.marxan,
         projectId: null,
-      },
-      complete: {
+      }),
+      complete: () => ({
         name: faker.random.words(5),
         type: ScenarioType.marxan,
         projectId: null,
@@ -59,13 +67,13 @@ export const E2E_CONFIG = {
         numberOfRuns: 100,
         boundaryLengthModifier: 0,
         status: JobStatus.created,
-      },
+      }),
     },
     invalid: {
-      missingRequiredFields: {
+      missingRequiredFields: () => ({
         name: faker.random.words(3),
         description: faker.lorem.sentence(),
-      },
+      }),
     },
   },
 };

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -8,21 +8,17 @@ export const E2E_CONFIG = {
       password: 'aauserpassword',
     },
   },
-  scenarios: {
+  projects: {
     valid: {
       minimal: {
         name: faker.random.words(5),
-        type: ScenarioType.marxan,
-        projectId: null,
+        organizationId: null,
       },
-      complete:
-      {
+      complete: {
         name: faker.random.words(5),
-        type: ScenarioType.marxan,
-        projectId: null,
+        organizationId: null,
         description: faker.lorem.paragraphs(2),
-        metadata: {},
-        country: 'esp',
+        countryId: faker.address.countryCode(),
         adminRegionId: faker.random.uuid(),
         extent: {
           type: 'Polygon',
@@ -35,6 +31,31 @@ export const E2E_CONFIG = {
             ],
           ],
         },
+        metadata: {
+          [faker.random.word()]: faker.random.words(3),
+          [faker.random.word()]: faker.random.uuid(),
+        },
+      },
+    },
+    invalid: {
+      incomplete: {
+        name: faker.random.words(5),
+      },
+    },
+  },
+  scenarios: {
+    valid: {
+      minimal: {
+        name: faker.random.words(5),
+        type: ScenarioType.marxan,
+        projectId: null,
+      },
+      complete: {
+        name: faker.random.words(5),
+        type: ScenarioType.marxan,
+        projectId: null,
+        description: faker.lorem.paragraphs(2),
+        metadata: {},
         numberOfRuns: 100,
         boundaryLengthModifier: 0,
         status: JobStatus.created,

--- a/api/test/organizations.e2e-spec.ts
+++ b/api/test/organizations.e2e-spec.ts
@@ -2,8 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
-import * as faker from 'faker';
 import { E2E_CONFIG } from './e2e.config';
+import { CreateProjectDTO } from 'modules/projects/dto/create.project.dto';
 
 describe('OrganizationsController (e2e)', () => {
   let app: INestApplication;
@@ -51,10 +51,7 @@ describe('OrganizationsController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .post('/api/v1/organizations')
         .set('Authorization', `Bearer ${jwtToken}`)
-        .send({
-          name: faker.random.words(3),
-          description: faker.lorem.sentence(),
-        })
+        .send(E2E_CONFIG.organizations.valid.minimal())
         .expect(201);
 
       anOrganization = response.body.data;
@@ -75,14 +72,15 @@ describe('OrganizationsController (e2e)', () => {
     let aProject: { id: string; type: 'organizations' };
 
     it('Creates a project in the newly created organization', async () => {
+      const createProjectDTO: CreateProjectDTO = {
+        ...E2E_CONFIG.projects.valid.minimal(),
+        organizationId: anOrganization.id,
+      };
+
       const response = await request(app.getHttpServer())
         .post('/api/v1/projects')
         .set('Authorization', `Bearer ${jwtToken}`)
-        .send({
-          name: faker.lorem.words(3),
-          description: faker.lorem.sentence(),
-          organizationId: anOrganization.id,
-        })
+        .send(createProjectDTO)
         .expect(201);
 
       aProject = response.body.data;
@@ -110,5 +108,10 @@ describe('OrganizationsController (e2e)', () => {
 
       expect(resources).toBeUndefined();
     });
+
+    /**
+     * @debt We should test that deleting an organization which contains
+     * projects must fail.
+     */
   });
 });

--- a/api/test/projects.e2e-spec.ts
+++ b/api/test/projects.e2e-spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { E2E_CONFIG } from './e2e.config';
+import { CreateProjectDTO } from 'modules/projects/dto/create.project.dto';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  let jwtToken: string;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/auth/sign-in')
+      .send({
+        username: E2E_CONFIG.users.aa.username,
+        password: E2E_CONFIG.users.aa.password,
+      })
+      .expect(201);
+
+    jwtToken = response.body.accessToken;
+  });
+
+  afterEach(async () => {
+    await Promise.all([app.close()]);
+  });
+
+  describe('Projects', () => {
+    let anOrganization: { id: string; type: 'organizations' };
+    let minimalProject: { id: string; type: 'projects' };
+    let completeProject: { id: string; type: 'projects' };
+
+    it('Gets organizations', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/organizations')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+      anOrganization = resources[0];
+      expect(resources[0].type).toBe('organizations');
+    });
+
+    it('Creating a project with incomplete data should fail', async () => {
+      await request(app.getHttpServer())
+        .post('/api/v1/projects')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(E2E_CONFIG.projects.invalid.incomplete)
+        .expect(400);
+    });
+
+    it('Creating a project with minimum required data should succeed', async () => {
+      const createScenarioDTO: CreateProjectDTO = {
+        ...E2E_CONFIG.projects.valid.minimal,
+        organizationId: anOrganization.id,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/projects')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(createScenarioDTO)
+        .expect(201);
+
+      const resources = response.body.data;
+      minimalProject = resources;
+      expect(resources.type).toBe('projects');
+    });
+
+    it('Creating a project with complete data should succeed', async () => {
+      const createScenarioDTO: CreateProjectDTO = {
+        ...E2E_CONFIG.projects.valid.complete,
+        organizationId: anOrganization.id,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/projects')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(createScenarioDTO)
+        .expect(201);
+
+      const resources = response.body.data;
+      completeProject = resources;
+      expect(resources.type).toBe('projects');
+    });
+
+    it('Gets projects', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/projects')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .expect(200);
+
+      const resources = response.body.data;
+
+      expect(resources[0].type).toBe('projects');
+    });
+
+    it('Deleting existing projects should succeed', async () => {
+      const response1 = await request(app.getHttpServer())
+        .delete(`/api/v1/projects/${minimalProject.id}`)
+        .expect(200);
+
+      expect(response1.body.data).toBeUndefined();
+
+      const response2 = await request(app.getHttpServer())
+        .delete(`/api/v1/projects/${completeProject.id}`)
+        .expect(200);
+
+      expect(response2.body.data).toBeUndefined();
+    });
+  });
+});

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
-import * as faker from 'faker';
 import { E2E_CONFIG } from './e2e.config';
 import { CreateScenarioDTO } from 'modules/scenarios/dto/create.scenario.dto';
 

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -52,13 +52,13 @@ describe('ScenariosModule (e2e)', () => {
       await request(app.getHttpServer())
         .post('/api/v1/scenarios')
         .set('Authorization', `Bearer ${jwtToken}`)
-        .send(E2E_CONFIG.scenarios.invalid.missingRequiredFields)
+        .send(E2E_CONFIG.scenarios.invalid.missingRequiredFields())
         .expect(400);
     });
 
     it('Creating a scenario with minimum required data should succeed', async () => {
       const createScenarioDTO: CreateScenarioDTO = {
-        ...E2E_CONFIG.scenarios.valid.minimal,
+        ...E2E_CONFIG.scenarios.valid.minimal(),
         projectId: projects[0].id,
       };
 
@@ -74,7 +74,7 @@ describe('ScenariosModule (e2e)', () => {
 
     it('Creating a scenario with complete data should succeed', async () => {
       const createScenarioDTO: CreateScenarioDTO = {
-        ...E2E_CONFIG.scenarios.valid.complete,
+        ...E2E_CONFIG.scenarios.valid.complete(),
         projectId: projects[0].id,
       };
 

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -59,7 +59,7 @@ describe('ScenariosModule (e2e)', () => {
 
     it('Creating a scenario with minimum required data should succeed', async () => {
       const createScenarioDTO: CreateScenarioDTO = {
-        ...E2E_CONFIG.scenarios.valid.complete,
+        ...E2E_CONFIG.scenarios.valid.minimal,
         projectId: projects[0].id,
       };
 

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -57,6 +57,22 @@ describe('ScenariosModule (e2e)', () => {
         .expect(400);
     });
 
+    it('Creating a scenario with minimum required data should succeed', async () => {
+      const createScenarioDTO: CreateScenarioDTO = {
+        ...E2E_CONFIG.scenarios.valid.complete,
+        projectId: projects[0].id,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/scenarios')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(createScenarioDTO)
+        .expect(201);
+
+      aScenario = response.body.data;
+      expect(aScenario.type).toBe('scenarios');
+    });
+
     it('Creating a scenario with complete data should succeed', async () => {
       const createScenarioDTO: CreateScenarioDTO = {
         ...E2E_CONFIG.scenarios.valid.complete,

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -53,16 +53,13 @@ describe('ScenariosModule (e2e)', () => {
       await request(app.getHttpServer())
         .post('/api/v1/scenarios')
         .set('Authorization', `Bearer ${jwtToken}`)
-        .send({
-          name: faker.random.words(3),
-          description: faker.lorem.sentence(),
-        })
+        .send(E2E_CONFIG.scenarios.invalid.missingRequiredFields)
         .expect(400);
     });
 
     it('Creating a scenario with complete data should succeed', async () => {
       const createScenarioDTO: CreateScenarioDTO = {
-        ...E2E_CONFIG.scenarios.validScenarios[0],
+        ...E2E_CONFIG.scenarios.valid.complete,
         projectId: projects[0].id,
       };
 


### PR DESCRIPTION
### Overview

Remove not-needed constraints on creation of scenarios. Only the fields listed below are now required.

### Designs

N/A

### Testing instructions

`make test-e2e-api`. It includes a new test that makes sure a scenario is created successfully with only the minimum set of compulsory props (`name`, `projectId`, `type`).

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-105

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file