### PR TITLE
Scenarios: header title and navigate between pages

### DIFF
--- a/app/layout/header/component.tsx
+++ b/app/layout/header/component.tsx
@@ -5,15 +5,14 @@ import Link from 'next/link';
 
 import Wrapper from 'layout/wrapper';
 import User from 'layout/header/user';
+import Title from 'layout/header/title';
 
 import Icon from 'components/icon';
 import Button from 'components/button';
 
 import { useAuth } from 'hooks/authentication';
-import { useProject } from 'hooks/projects';
 
 import LOGO_SVG from 'svgs/logo.svg?sprite';
-import { useRouter } from 'next/router';
 
 export interface HeaderProps {
   size: 'base' | 'lg',
@@ -30,9 +29,6 @@ const SIZE = {
 
 export const Header: React.FC<HeaderProps> = ({ size }:HeaderProps) => {
   const auth = useAuth();
-  const { query } = useRouter();
-  const { pid } = query;
-  const { data: projectData } = useProject(pid);
 
   return (
     <header
@@ -53,9 +49,7 @@ export const Header: React.FC<HeaderProps> = ({ size }:HeaderProps) => {
             </a>
           </Link>
 
-          {projectData?.name && (
-            <h1 className="font-medium font-heading">{projectData.name}</h1>
-          )}
+          <Title />
 
           {auth.user && (
             <User />

--- a/app/layout/header/title/component.tsx
+++ b/app/layout/header/title/component.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { useProject } from 'hooks/projects';
+import { useScenario } from 'hooks/scenarios';
+import { useRouter } from 'next/router';
+import { useTransition, animated } from 'react-spring';
+
+export interface TitleProps {
+}
+
+export const Title: React.FC<TitleProps> = () => {
+  const { query } = useRouter();
+  const { pid, sid } = query;
+  const { data: projectData, isLoading: projectIsLoading } = useProject(pid);
+  const { data: scenarioData, isLoading: scenarioIsLoading } = useScenario(sid);
+
+  const transitions = useTransition(!projectIsLoading && !scenarioIsLoading, null, {
+    from: { opacity: 0, transform: 'translateY(-5px)' },
+    enter: { opacity: 1, transform: 'translateY(0)' },
+    leave: { opacity: 0, transform: 'translateY(-5px)' },
+  });
+
+  return (
+    <>
+      {transitions.map(({ item, key, props }) => item && (
+        <animated.div key={key} style={props} className="flex divide-x">
+          {projectData?.name && (
+            <h1 className="font-medium font-heading px-2.5">{projectData.name}</h1>
+          )}
+
+          {scenarioData?.name && (
+            <h1 className="font-medium font-heading px-2.5 opacity-50">{scenarioData.name}</h1>
+          )}
+        </animated.div>
+      ))}
+    </>
+  );
+};
+
+export default Title;

--- a/app/layout/header/title/index.ts
+++ b/app/layout/header/title/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/app/layout/scenarios/sidebar/name/component.tsx
+++ b/app/layout/scenarios/sidebar/name/component.tsx
@@ -22,7 +22,7 @@ export interface ScenariosSidebarProps {
 
 export const ScenariosSidebar: React.FC<ScenariosSidebarProps> = () => {
   const [submitting, setSubmitting] = useState(false);
-  const { query } = useRouter();
+  const { query, push } = useRouter();
   const { pid } = query;
 
   const mutation = useSaveScenario();
@@ -32,13 +32,17 @@ export const ScenariosSidebar: React.FC<ScenariosSidebarProps> = () => {
 
     await mutation.mutate({
       ...data,
+      type: 'marxan',
       projectId: pid,
     }, {
+      onSuccess: ({ data: s }) => {
+        push(`/projects/${pid}/scenarios/${s.id}/edit`);
+      },
       onError: () => {
         setSubmitting(false);
       },
     });
-  }, [mutation, pid]);
+  }, [mutation, pid, push]);
 
   return (
     <Pill>

--- a/app/pages/projects/[pid]/scenarios/[sid]/edit.tsx
+++ b/app/pages/projects/[pid]/scenarios/[sid]/edit.tsx
@@ -4,11 +4,26 @@ import Head from 'next/head';
 import Header from 'layout/header';
 import Protected from 'layout/protected';
 
+import { useProject } from 'hooks/projects';
+import { useScenario } from 'hooks/scenarios';
+import { useRouter } from 'next/router';
+
 const EditScenarioPage: React.FC = () => {
+  const { query } = useRouter();
+  const { pid, sid } = query;
+  const { data: projectData } = useProject(pid);
+  const { data: scenarioData } = useScenario(sid);
+
   return (
     <Protected>
       <Head>
-        <title>Edit Scenario</title>
+        <title>
+          {projectData?.name}
+          {' '}
+          -
+          {' Edit '}
+          {scenarioData?.name}
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 

--- a/app/pages/projects/[pid]/scenarios/[sid]/index.tsx
+++ b/app/pages/projects/[pid]/scenarios/[sid]/index.tsx
@@ -4,16 +4,32 @@ import Head from 'next/head';
 import Header from 'layout/header';
 import Protected from 'layout/protected';
 
+import { useProject } from 'hooks/projects';
+import { useScenario } from 'hooks/scenarios';
+import { useRouter } from 'next/router';
+
 const ShowScenarioPage: React.FC = () => {
+  const { query } = useRouter();
+  const { pid, sid } = query;
+  const { data: projectData } = useProject(pid);
+  const { data: scenarioData } = useScenario(sid);
+
   return (
     <Protected>
       <Head>
-        <title>Scenario [id]</title>
+        <title>
+          {projectData?.name}
+          {' '}
+          -
+          {' '}
+          {scenarioData?.name}
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main>
         <Header size="base" />
+
       </main>
     </Protected>
   );


### PR DESCRIPTION
## Scenarios

### Overview

This PR adds:
- Scenario creation by typing name
- Navigate to edit page
- Header title depending on Project and Scenario loader

### Designs

https://www.figma.com/file/hq0BZNB9fzyFSbEUgQIHdK/Marxan-Visual_V02?node-id=1523%3A1468

### Testing instructions

http://localhost:3000/projects/b0a14339-732a-430b-a01d-6bc06494b05f/scenarios/new
https://marxan-git-feature-scenarios-name-vizzuality1.vercel.app/projects/b0a14339-732a-430b-a01d-6bc06494b05f/scenarios/new

try one of them to create a new scenario

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-105
