### PR TITLE
[MARXAN-128] Allow to delete one's own user

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -40,7 +40,11 @@ async function bootstrap() {
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerOptions);
   SwaggerModule.setup('/swagger', app, swaggerDocument);
 
-  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
   app.useGlobalFilters(new AllExceptionsFilter());
 
   await app.listen(3000);

--- a/api/src/modules/admin-areas/admin-area.geo.entity.ts
+++ b/api/src/modules/admin-areas/admin-area.geo.entity.ts
@@ -4,10 +4,6 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('admin_regions')
 export class AdminArea extends Country {
-  get id() {
-    return this.gid0;
-  }
-
   /**
    * Country id (ISO 3166-1 alpha-3).
    */

--- a/api/src/modules/authentication/authentication.module.ts
+++ b/api/src/modules/authentication/authentication.module.ts
@@ -17,7 +17,6 @@ export const logger = new Logger('Authentication');
 @Module({
   imports: [
     forwardRef(() => UsersModule),
-    UsersModule,
     PassportModule,
     JwtModule.register({
       secret: AppConfig.get('auth.jwt.secret'),

--- a/api/src/modules/authentication/authentication.service.ts
+++ b/api/src/modules/authentication/authentication.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 
 import { User } from 'modules/users/user.api.entity';
@@ -57,6 +62,7 @@ export interface JwtDataPayload {
 @Injectable()
 export class AuthenticationService {
   constructor(
+    @Inject(forwardRef(() => UsersService))
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
     @InjectRepository(IssuedAuthnToken)

--- a/api/src/modules/countries/country.geo.entity.ts
+++ b/api/src/modules/countries/country.geo.entity.ts
@@ -1,45 +1,33 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { Dictionary } from 'lodash';
+import { ApiProperty } from '@nestjs/swagger';
 import { Column, Entity, PrimaryColumn } from 'typeorm';
-
-export interface LocalName {
-  /**
-   * Local name of a country.
-   *
-   * E.g. "Italia"
-   */
-  name: string;
-
-  /**
-   * Locale code for this name, composed of the dash-separated two-letter
-   * ISO-639 language code and the two-letter ISO 3166-1 alpha2 code.
-   *
-   * E.g. "it-IT"
-   */
-  locale: string;
-}
 
 @Entity('countries')
 export class Country {
-  @ApiProperty()
-  @PrimaryColumn('character varying', { name: 'iso_3166_1_alpha2' })
-  @Transform((_) => fakerStatic.address.countryCode())
-  alpha2: string;
+  get id() {
+    return this.gid0;
+  }
 
+  /**
+   * Country id (ISO 3166-1 alpha-3).
+   */
   @ApiProperty()
-  @PrimaryColumn('character varying', { name: 'iso_3166_1_alpha3' })
-  @Transform((_) => fakerStatic.address.countryCode())
-  alpha3: string;
+  @PrimaryColumn('character varying', { name: 'gid_0' })
+  gid0: string;
 
+  /**
+   * Country name
+   */
   @ApiProperty()
-  @Column('character varying')
-  @Transform((_) => fakerStatic.address.country())
-  name: string;
+  @Column('character varying', { name: 'name_0' })
+  name0: string;
 
-  @ApiPropertyOptional()
-  @Column('jsonb', { name: 'local_names' })
-  localNames: Dictionary<LocalName>;
+  /**
+   * @todo Add description. Also we can probably do better than using the `any`
+   * type.
+   */
+  @ApiProperty()
+  @Column('geometry', { name: 'the_geom' })
+  theGeom: any;
 }
 
 export class JSONAPICountryData {

--- a/api/src/modules/users/dto/create.user.dto.ts
+++ b/api/src/modules/users/dto/create.user.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MaxLength } from 'class-validator';
-import { Dictionary } from 'lodash';
 
 export class CreateUserDTO {
   @ApiProperty()
@@ -10,10 +9,10 @@ export class CreateUserDTO {
   displayName: string | null;
 
   @ApiPropertyOptional()
-  fname: string | null;
+  fname?: string | null;
 
   @ApiPropertyOptional()
-  lname: string | null;
+  lname?: string | null;
 
   @ApiProperty()
   /**
@@ -30,5 +29,5 @@ export class CreateUserDTO {
   password: string;
 
   @ApiPropertyOptional()
-  metadata: Dictionary<string>;
+  metadata?: Record<string, unknown>;
 }

--- a/api/src/modules/users/users.module.ts
+++ b/api/src/modules/users/users.module.ts
@@ -1,12 +1,16 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { UsersController } from './users.controller';
 import { User } from './user.api.entity';
 import { UsersService } from './users.service';
+import { AuthenticationModule } from 'modules/authentication/authentication.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    forwardRef(() => AuthenticationModule),
+  ],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],

--- a/api/src/modules/users/users.service.ts
+++ b/api/src/modules/users/users.service.ts
@@ -9,7 +9,10 @@ import { UpdateUserDTO } from './dto/update.user.dto';
 import { AppInfoDTO } from 'dto/info.dto';
 
 import * as faker from 'faker';
-import { AppBaseService, JSONAPISerializerConfig } from 'utils/app-base.service';
+import {
+  AppBaseService,
+  JSONAPISerializerConfig,
+} from 'utils/app-base.service';
 import { AuthenticationService } from 'modules/authentication/authentication.service';
 
 @Injectable()

--- a/api/src/modules/users/users.service.ts
+++ b/api/src/modules/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ILike, Repository } from 'typeorm';
 import { User } from './user.api.entity';
@@ -9,10 +9,8 @@ import { UpdateUserDTO } from './dto/update.user.dto';
 import { AppInfoDTO } from 'dto/info.dto';
 
 import * as faker from 'faker';
-import {
-  AppBaseService,
-  JSONAPISerializerConfig,
-} from 'utils/app-base.service';
+import { AppBaseService, JSONAPISerializerConfig } from 'utils/app-base.service';
+import { AuthenticationService } from 'modules/authentication/authentication.service';
 
 @Injectable()
 export class UsersService extends AppBaseService<
@@ -24,6 +22,8 @@ export class UsersService extends AppBaseService<
   constructor(
     @InjectRepository(User)
     protected readonly repository: Repository<User>,
+    @Inject(forwardRef(() => AuthenticationService))
+    private readonly authenticationService: AuthenticationService,
   ) {
     super(repository, 'user', 'users');
   }
@@ -87,5 +87,6 @@ export class UsersService extends AppBaseService<
       { id: userId },
       { isDeleted: true, isActive: false },
     );
+    this.authenticationService.invalidateAllTokensOfUser(userId);
   }
 }

--- a/api/test/auth.e2e-spec.ts
+++ b/api/test/auth.e2e-spec.ts
@@ -25,8 +25,8 @@ describe('AppController (e2e)', () => {
       await request(app.getHttpServer())
         .post('/auth/sign-in')
         .send({
-          username: E2E_CONFIG.users.aa.username,
-          password: E2E_CONFIG.users.aa.password,
+          username: E2E_CONFIG.users.basic.aa.username,
+          password: E2E_CONFIG.users.basic.aa.password,
         })
         .expect(201);
     });
@@ -34,7 +34,7 @@ describe('AppController (e2e)', () => {
     it('Fails to authenticate a user with an incorrect password', async () => {
       const response = await request(app.getHttpServer())
         .post('/auth/sign-in')
-        .send({ email: E2E_CONFIG.users.aa.username, password: 'wrong' })
+        .send({ email: E2E_CONFIG.users.basic.aa.username, password: 'wrong' })
         .expect(401);
 
       expect(response.body.accessToken).not.toBeDefined();

--- a/api/test/countries.e2e-spec.ts
+++ b/api/test/countries.e2e-spec.ts
@@ -23,8 +23,8 @@ describe('CountriesModule (e2e)', () => {
     const response = await request(app.getHttpServer())
       .post('/auth/sign-in')
       .send({
-        username: E2E_CONFIG.users.aa.username,
-        password: E2E_CONFIG.users.aa.password,
+        username: E2E_CONFIG.users.basic.aa.username,
+        password: E2E_CONFIG.users.basic.aa.password,
       })
       .expect(201);
 

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -1,11 +1,65 @@
 import * as faker from 'faker';
+import { CreateOrganizationDTO } from 'modules/organizations/dto/create.organization.dto';
+import { CreateProjectDTO } from 'modules/projects/dto/create.project.dto';
+import { CreateScenarioDTO } from 'modules/scenarios/dto/create.scenario.dto';
 import { JobStatus, ScenarioType } from 'modules/scenarios/scenario.api.entity';
+import { CreateUserDTO } from 'modules/users/dto/create.user.dto';
+import { UpdateUserDTO } from 'modules/users/dto/update.user.dto';
 
-export const E2E_CONFIG = {
+export const E2E_CONFIG: {
   users: {
-    aa: {
-      username: 'aa@example.com',
-      password: 'aauserpassword',
+    basic: {
+      aa: Partial<CreateUserDTO> & { username: string };
+      bb: Partial<CreateUserDTO> & { username: string };
+    };
+    updated: {
+      bb: () => Partial<UpdateUserDTO>;
+    };
+  };
+  organizations: {
+    valid: {
+      minimal: () => Partial<CreateOrganizationDTO>;
+    };
+  };
+  projects: {
+    valid: {
+      minimal: () => Partial<CreateProjectDTO>;
+      complete: (options: unknown) => Partial<CreateProjectDTO>;
+    };
+    invalid: {
+      incomplete: () => Partial<CreateProjectDTO>;
+    };
+  };
+  scenarios: {
+    valid: {
+      minimal: () => Partial<CreateScenarioDTO>;
+      complete: () => Partial<CreateScenarioDTO>;
+    };
+    invalid: {
+      missingRequiredFields: () => Partial<CreateScenarioDTO>;
+    };
+  };
+} = {
+  users: {
+    basic: {
+      aa: {
+        username: 'aa@example.com',
+        password: 'aauserpassword',
+      },
+      bb: {
+        username: 'bb@example.com',
+        password: 'bbuserpassword',
+      },
+    },
+    updated: {
+      bb: () => ({
+        fname: faker.name.firstName(),
+        lname: faker.name.lastName(),
+        displayName: `${faker.name.title()} ${faker.name.firstName} ${
+          faker.name.firstName
+        }`,
+        metadata: { key1: 'value1', key2: 2, key3: true },
+      }),
     },
   },
   organizations: {
@@ -20,11 +74,11 @@ export const E2E_CONFIG = {
     valid: {
       minimal: () => ({
         name: faker.random.words(5),
-        organizationId: null,
+        organizationId: faker.random.uuid(),
       }),
       complete: (options: { countryCode: string }) => ({
         name: faker.random.words(5),
-        organizationId: null,
+        organizationId: faker.random.uuid(),
         description: faker.lorem.paragraphs(2),
         countryId: options.countryCode,
         adminRegionId: faker.random.uuid(),
@@ -56,12 +110,12 @@ export const E2E_CONFIG = {
       minimal: () => ({
         name: faker.random.words(5),
         type: ScenarioType.marxan,
-        projectId: null,
+        projectId: faker.random.uuid(),
       }),
       complete: () => ({
         name: faker.random.words(5),
         type: ScenarioType.marxan,
-        projectId: null,
+        projectId: faker.random.uuid(),
         description: faker.lorem.paragraphs(2),
         metadata: {},
         numberOfRuns: 100,

--- a/api/test/organizations.e2e-spec.ts
+++ b/api/test/organizations.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { E2E_CONFIG } from './e2e.config';
@@ -16,13 +16,18 @@ describe('OrganizationsController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+      }),
+    );
     await app.init();
 
     const response = await request(app.getHttpServer())
       .post('/auth/sign-in')
       .send({
-        username: E2E_CONFIG.users.aa.username,
-        password: E2E_CONFIG.users.aa.password,
+        username: E2E_CONFIG.users.basic.aa.username,
+        password: E2E_CONFIG.users.basic.aa.password,
       })
       .expect(201);
 
@@ -72,7 +77,7 @@ describe('OrganizationsController (e2e)', () => {
     let aProject: { id: string; type: 'organizations' };
 
     it('Creates a project in the newly created organization', async () => {
-      const createProjectDTO: CreateProjectDTO = {
+      const createProjectDTO: Partial<CreateProjectDTO> = {
         ...E2E_CONFIG.projects.valid.minimal(),
         organizationId: anOrganization.id,
       };

--- a/api/test/projects.e2e-spec.ts
+++ b/api/test/projects.e2e-spec.ts
@@ -21,8 +21,8 @@ describe('ProjectsModule (e2e)', () => {
     const response = await request(app.getHttpServer())
       .post('/auth/sign-in')
       .send({
-        username: E2E_CONFIG.users.aa.username,
-        password: E2E_CONFIG.users.aa.password,
+        username: E2E_CONFIG.users.basic.aa.username,
+        password: E2E_CONFIG.users.basic.aa.password,
       })
       .expect(201);
 
@@ -59,7 +59,7 @@ describe('ProjectsModule (e2e)', () => {
     });
 
     it('Creating a project with minimum required data should succeed', async () => {
-      const createScenarioDTO: CreateProjectDTO = {
+      const createProjectDTO: Partial<CreateProjectDTO> = {
         ...E2E_CONFIG.projects.valid.minimal(),
         organizationId: anOrganization.id,
       };
@@ -67,7 +67,7 @@ describe('ProjectsModule (e2e)', () => {
       const response = await request(app.getHttpServer())
         .post('/api/v1/projects')
         .set('Authorization', `Bearer ${jwtToken}`)
-        .send(createScenarioDTO)
+        .send(createProjectDTO)
         .expect(201);
 
       const resources = response.body.data;
@@ -76,7 +76,7 @@ describe('ProjectsModule (e2e)', () => {
     });
 
     it('Creating a project with complete data should succeed', async () => {
-      const createScenarioDTO: CreateProjectDTO = {
+      const createProjectDTO: Partial<CreateProjectDTO> = {
         ...E2E_CONFIG.projects.valid.complete({ countryCode: 'ESP' }),
         organizationId: anOrganization.id,
       };
@@ -84,7 +84,7 @@ describe('ProjectsModule (e2e)', () => {
       const response = await request(app.getHttpServer())
         .post('/api/v1/projects')
         .set('Authorization', `Bearer ${jwtToken}`)
-        .send(createScenarioDTO)
+        .send(createProjectDTO)
         .expect(201);
 
       const resources = response.body.data;

--- a/api/test/scenarios.e2e-spec.ts
+++ b/api/test/scenarios.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { E2E_CONFIG } from './e2e.config';
@@ -16,13 +16,18 @@ describe('ScenariosModule (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+      }),
+    );
     await app.init();
 
     const response = await request(app.getHttpServer())
       .post('/auth/sign-in')
       .send({
-        username: E2E_CONFIG.users.aa.username,
-        password: E2E_CONFIG.users.aa.password,
+        username: E2E_CONFIG.users.basic.aa.username,
+        password: E2E_CONFIG.users.basic.aa.password,
       })
       .expect(201);
 
@@ -57,7 +62,7 @@ describe('ScenariosModule (e2e)', () => {
     });
 
     it('Creating a scenario with minimum required data should succeed', async () => {
-      const createScenarioDTO: CreateScenarioDTO = {
+      const createScenarioDTO: Partial<CreateScenarioDTO> = {
         ...E2E_CONFIG.scenarios.valid.minimal(),
         projectId: projects[0].id,
       };
@@ -73,7 +78,7 @@ describe('ScenariosModule (e2e)', () => {
     });
 
     it('Creating a scenario with complete data should succeed', async () => {
-      const createScenarioDTO: CreateScenarioDTO = {
+      const createScenarioDTO: Partial<CreateScenarioDTO> = {
         ...E2E_CONFIG.scenarios.valid.complete(),
         projectId: projects[0].id,
       };

--- a/api/test/users.e2e-spec.ts
+++ b/api/test/users.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as faker from 'faker';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { E2E_CONFIG } from './e2e.config';
+
+describe('UsersModule (e2e)', () => {
+  let app: INestApplication;
+
+  let jwtToken: string;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/auth/sign-in')
+      .send({
+        // In most tests we use seed user `aa@example.com` but here we use
+        // bb@example.com to avoid messing with the main user we use in e2e
+        // tests.
+        username: E2E_CONFIG.users.basic.bb.username,
+        password: E2E_CONFIG.users.basic.bb.password,
+      })
+      .expect(201);
+
+    jwtToken = response.body.accessToken;
+  });
+
+  afterEach(async () => {
+    await Promise.all([app.close()]);
+  });
+
+  describe('Users', () => {
+    const aNewPassword = faker.random.alphaNumeric(18);
+
+    it('A user should be able to read their own metadata', async () => {
+      const results = await request(app.getHttpServer())
+        .get('/api/v1/users/me')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send()
+        .expect(200);
+
+      expect(results);
+    });
+
+    it('A user should be able to update their own metadata', async () => {
+      await request(app.getHttpServer())
+        .patch('/api/v1/users')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send(E2E_CONFIG.users.updated.bb())
+        .expect(200);
+    });
+
+    it('A user should not be able to change their password as part of the user update lifecycle', async () => {
+      await request(app.getHttpServer())
+        .patch('/api/v1/users/me/')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          ...E2E_CONFIG.users.updated.bb(),
+          password: faker.random.alphaNumeric(),
+        })
+        .expect(403);
+    });
+
+    it('A user should be able to change their password if they provide the correct current password', async () => {
+      await request(app.getHttpServer())
+        .patch('/api/v1/users/me/password')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          currentPassword: E2E_CONFIG.users.basic.bb.password,
+          password: aNewPassword,
+        })
+        .expect(200);
+    });
+
+    it('A user should be not able to change their password if they provide an incorrect current password', async () => {
+      await request(app.getHttpServer())
+        .patch('/api/v1/users/me/password')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          currentPassword: faker.random.uuid(),
+          password: aNewPassword,
+        })
+        .expect(403);
+    });
+
+    it('A user should be able to change their password if they provide the correct current password (take 2, back to initial password)', async () => {
+      await request(app.getHttpServer())
+        .patch('/api/v1/users/me/password')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          currentPassword: aNewPassword,
+          password: E2E_CONFIG.users.basic.bb.password,
+        })
+        .expect(200);
+    });
+
+    it('A user should be able to delete their own account', async () => {
+      await request(app.getHttpServer())
+        .delete('/api/v1/users/me')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send()
+        .expect(200);
+    });
+
+    it('Once a user account is marked as deleted, the user should be logged out', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/users/me')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send()
+        .expect(401);
+    });
+
+    it('Once a user account is marked as deleted, the user should not be able to log back in', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/sign-in')
+        .send({
+          username: E2E_CONFIG.users.basic.bb.username,
+          password: E2E_CONFIG.users.basic.bb.password,
+        })
+        .expect(401);
+    });
+  });
+});


### PR DESCRIPTION
### Overview

`DELETE /api/v1/users/me` should (soft-) delete one's own user

Basically we set `isActive = false` and `isDeleted = true`, which flags the user for deletion **and** prevents them from logging in, while keeping the actual user account in the db.

We don't deal with the details of physically deleting the user at this stage - this would mean taking some decisions on "detaching" the user account from db entities it may be linked to. We may need to do something here because of data protection compliance, but we could also potentially deal with this by removing personal identification data from users flagged for deletion, without having to deal with more complexity which could be avoided in this phase.

### Designs

N/A

### Testing instructions

`DELETE /api/v1/users/me` should succeed for logged-in users

After this, any existing and still-valid (timestamp-wise) JWT tokens must be rejected, and it should not be possible to obtain new JWT tokens via `POST /api/v1/auth/sign-in`.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-128

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [x] Update CHANGELOG file