### PR TITLE
[MARXAN-138] Update project creation and update endpoints with props required by design

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -27,6 +27,9 @@ Unreleased
 - Strict typing for JSON:API serializable field sets
 - Support for omitting specific fields from getAll results (blocklisting) where
   a whitelisting approach is not desirable/practical.
+- Projects
+  - handle planning unit grid shape, planning unit area, L1 and L2 admin area
+    ids.
 
 ### Changed
 

--- a/api/src/migrations/api/1614252349000-UpdateProjectsTable.ts
+++ b/api/src/migrations/api/1614252349000-UpdateProjectsTable.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Countries are handled in the geoprocessing db, as a view over the
+ * admin_regions table, so we don't need this in the API db.
+ */
+
+export class UpdateProjectsTable1614252349000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+CREATE TYPE planning_unit_grid_shape AS ENUM (
+  'square',
+  'hexagon',
+  'from_shapefile'
+);
+
+ALTER TABLE projects
+  DROP COLUMN admin_region_id,
+  ADD COLUMN admin_area_l1_id varchar,
+  ADD COLUMN admin_area_l2_id varchar,
+  ADD COLUMN planning_unit_grid_shape planning_unit_grid_shape,
+  ADD COLUMN planning_unit_area_km2 float
+`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+ALTER TABLE projects
+  DROP COLUMN admin_area_l1_id,
+  DROP COLUMN admin_area_l2_id,
+  ADD COLUMN admin_region_id uuid,
+  DROP COLUMN planning_unit_grid_type,
+  DROP COLUMN planning_unit_area_km2;
+
+DROP type planning_unit_grid_type;
+`);
+  }
+}

--- a/api/src/modules/admin-areas/admin-area.geo.entity.ts
+++ b/api/src/modules/admin-areas/admin-area.geo.entity.ts
@@ -4,6 +4,10 @@ import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('admin_regions')
 export class AdminArea extends Country {
+  get id() {
+    return this.gid0;
+  }
+
   /**
    * Country id (ISO 3166-1 alpha-3).
    */

--- a/api/src/modules/projects/dto/create.project.dto.ts
+++ b/api/src/modules/projects/dto/create.project.dto.ts
@@ -1,12 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsAlpha,
+  IsEnum,
+  IsNumber,
   IsOptional,
+  IsString,
   IsUppercase,
   IsUUID,
   Length,
 } from 'class-validator';
 import { Dictionary } from 'lodash';
+import { PlanningUnitGridShape } from '../project.api.entity';
 
 export class CreateProjectDTO {
   @ApiProperty()
@@ -30,9 +34,29 @@ export class CreateProjectDTO {
   countryId?: string;
 
   @ApiPropertyOptional()
-  @IsUUID()
+  @IsString()
   @IsOptional()
   adminRegionId?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  adminAreaLevel1Id?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  adminAreaLevel2Id?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(Object.values(PlanningUnitGridShape))
+  planningUnitGridShape?: PlanningUnitGridShape;
+
+  @ApiProperty()
+  @IsOptional()
+  @IsNumber()
+  planningUnitAreakm2?: number;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/api/src/modules/projects/project.api.entity.ts
+++ b/api/src/modules/projects/project.api.entity.ts
@@ -14,6 +14,12 @@ import {
 import { Organization } from 'modules/organizations/organization.api.entity';
 import { TimeUserEntityMetadata } from 'types/time-user-entity-metadata';
 
+export enum PlanningUnitGridShape {
+  square = 'square',
+  hexagon = 'hexagon',
+  fromShapefile = 'from_shapefile',
+}
+
 @Entity('projects')
 export class Project extends TimeUserEntityMetadata {
   @ApiProperty()
@@ -44,19 +50,45 @@ export class Project extends TimeUserEntityMetadata {
 
   /**
    * The country where this project is located.
+   *
+   * Uses the gid0 property of the Country entity.
    */
-  @Column('uuid', { name: 'country_id' })
+  @Column('character varying', { name: 'country_id' })
   countryId: string;
 
   /**
-   * The smallest administrative region that contains the whole project's
-   * geometry.
-   *
-   * @todo Check description.
+   * Administrative area (level 1) on which this project is focused.
    */
   @ApiProperty()
-  @Column('uuid', { name: 'admin_region_id' })
-  adminRegionId: string;
+  @Column('character varying', { name: 'admin_area_l1_id' })
+  adminAreaLevel1Id?: string;
+
+  /**
+   * Administrative area (level 2) on which this project is focused.
+   */
+  @ApiProperty()
+  @Column('character varying', { name: 'admin_area_l2_id' })
+  adminAreaLevel2Id?: string;
+
+  /**
+   * Shape of the planning units.
+   *
+   * Planning unit grids are generated algorithmically if the shape chosen is
+   * square or hexagon; if users want to upload their own shapefile, we set this
+   * to fromShapefile, and handle the upload of the shapefile separately.
+   */
+  @ApiProperty()
+  @Column('enum', { name: 'planning_unit_grid_shape' })
+  planningUnitGridShape?: PlanningUnitGridShape;
+
+  /**
+   * Area of planning units in km2.
+   *
+   * This is only used if the chosen shape is `square` or `hexagon`.
+   */
+  @ApiProperty()
+  @Column('float', { name: 'planning_unit_area_km2' })
+  planningUnitAreakm2?: number;
 
   /**
    * Extent of the project

--- a/api/src/modules/projects/projects.service.ts
+++ b/api/src/modules/projects/projects.service.ts
@@ -33,7 +33,16 @@ export class ProjectsService extends AppBaseService<
 
   get serializerConfig(): JSONAPISerializerConfig<Project> {
     return {
-      attributes: ['name', 'description', 'users'],
+      attributes: [
+        'name',
+        'description',
+        'users',
+        'countryId',
+        'adminAreaLevel1Id',
+        'adminAreaLevel2Id',
+        'planningUnitGridShape',
+        'planningUnitAreakm2',
+      ],
       keyForAttribute: 'camelCase',
       users: {
         ref: 'id',
@@ -49,8 +58,6 @@ export class ProjectsService extends AppBaseService<
           'name',
           'description',
           'type',
-          'country',
-          'extent',
           'wdpaFilter',
           'wdpaThreshold',
           'adminRegionId',

--- a/api/test/countries.e2e-spec.ts
+++ b/api/test/countries.e2e-spec.ts
@@ -36,7 +36,7 @@ describe('CountriesModule (e2e)', () => {
   });
 
   describe('Countries', () => {
-    let aCountry: JSONAPICountryData;
+    let _aCountry: JSONAPICountryData;
     let aLevel1AdminArea: JSONAPIAdminAreaData;
     const countryCodeForTests = 'ESP';
 

--- a/api/test/e2e.config.ts
+++ b/api/test/e2e.config.ts
@@ -2,6 +2,7 @@ import * as faker from 'faker';
 import { CreateOrganizationDTO } from 'modules/organizations/dto/create.organization.dto';
 import { CreateProjectDTO } from 'modules/projects/dto/create.project.dto';
 import { CreateScenarioDTO } from 'modules/scenarios/dto/create.scenario.dto';
+import { PlanningUnitGridShape } from 'modules/projects/project.api.entity';
 import { JobStatus, ScenarioType } from 'modules/scenarios/scenario.api.entity';
 import { CreateUserDTO } from 'modules/users/dto/create.user.dto';
 import { UpdateUserDTO } from 'modules/users/dto/update.user.dto';
@@ -76,12 +77,15 @@ export const E2E_CONFIG: {
         name: faker.random.words(5),
         organizationId: faker.random.uuid(),
       }),
-      complete: (options: { countryCode: string }) => ({
+      complete: (options: { countryCode: string }): CreateProjectDTO => ({
         name: faker.random.words(5),
         organizationId: faker.random.uuid(),
         description: faker.lorem.paragraphs(2),
         countryId: options.countryCode,
-        adminRegionId: faker.random.uuid(),
+        adminAreaLevel1Id: faker.random.alphaNumeric(7),
+        adminAreaLevel2Id: faker.random.alphaNumeric(12),
+        planningUnitGridShape: PlanningUnitGridShape.hexagon,
+        planningUnitAreakm2: 10,
         extent: {
           type: 'Polygon',
           coordinates: [


### PR DESCRIPTION
### Overview

**This PR is ready for review, but it will need to be rebased on `develop` before merging**

Adds ability to supply l1 and l2 area ids, PU grid shape (`square`, `hexagon` or `from_shapefile` - though we don't handle shapefile uploads yet), and PU area.

### Designs

N/A

### Testing instructions

We have e2e tests in `test/projects.e2e-spec.ts`, but something like this is what should be tested (`organizationId` need to match a real id on the target instance):

```
curl --location --request POST 'https://marxan49.westeurope.cloudapp.azure.com/api/v1/projects' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer <token>' \
--data-raw '{
        "name": "test project 29423409",
        "organizationId": "bd1689c8-8246-42d5-9005-4aaa8aeb0049",
        "description": "A Description For A Great Project",
        "countryId": "ESP",
        "adminAreaLevel1Id": "ESP.1_1",
        "adminAreaLevel2Id": "ESP.1.7_1",
        "planningUnitGridShape": "hexagon",
        "planningUnitAreakm2": 10,
        "extent": {
          "type": "Polygon",
          "coordinates": [
            [
              [-10.0, -10.0],
              [10.0, -10.0],
              [10.0, 10.0],
              [-10.0, -10.0]
            ]
          ]
        },
        "metadata": {
          "keyAbcd": "asdfaserasfad",
          "keyEfgh": "safsdiubvtltr"
        }
      }'
```

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-138

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [x] Update CHANGELOG file