### PR TITLE
Redirect to referral URL after login

### DIFF
--- a/app/hooks/auth/index.ts
+++ b/app/hooks/auth/index.ts
@@ -1,0 +1,1 @@
+export const SIGN_IN_DEFAULT_REDIRECT = '/projects';

--- a/app/layout/protected/component.tsx
+++ b/app/layout/protected/component.tsx
@@ -16,7 +16,7 @@ const Protected: React.FC = ({ children }: ProtectedProps) => {
 
   // Redirect when session doesn't exist
   if (!loading && !session) {
-    router.push('/auth/sign-in');
+    router.push(`/auth/sign-in?callbackUrl=${window.location.origin}${router.asPath}`);
     return null;
   }
 

--- a/app/layout/sign-in/component.tsx
+++ b/app/layout/sign-in/component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
-import { signIn, signOut, useSession } from 'next-auth/client';
+import { signIn, useSession } from 'next-auth/client';
+import { useRouter } from 'next/router';
 import Wrapper from 'layout/wrapper';
-
 import Link from 'next/link';
 import Button from 'components/button';
 import Loading from 'components/loading';
@@ -16,6 +16,7 @@ import {
 } from 'components/forms/validations';
 
 import { useToasts } from 'hooks/toast';
+import { SIGN_IN_DEFAULT_REDIRECT } from 'hooks/auth';
 
 import EMAIL_SVG from 'svgs/ui/email.svg?sprite';
 import PASSWORD_SVG from 'svgs/ui/password.svg?sprite';
@@ -28,11 +29,13 @@ export const SignIn: React.FC<SignInProps> = () => {
   const [submitting, setSubmitting] = useState(false);
   const { addToast } = useToasts();
   const [session] = useSession();
+  const router = useRouter();
+  const { callbackUrl } = router.query;
 
   const handleSubmit = useCallback(async (data) => {
     setSubmitting(true);
     try {
-      await signIn('credentials', { ...data, callbackUrl: `${window.location.protocol}//${window.location.host}/projects` });
+      await signIn('credentials', { ...data, callbackUrl });
     } catch (err) {
       addToast('error-signin', (
         <>
@@ -46,17 +49,12 @@ export const SignIn: React.FC<SignInProps> = () => {
       setSubmitting(false);
       console.error(err);
     }
-  }, [addToast]);
+  }, [addToast, callbackUrl]);
 
-  // This shouldn't be here, it's here just for testing
-  const handleLogout = useCallback(async () => {
-    signOut();
-  }, []);
-
+  // If session is already initialized, redirect to projects page
   if (session) {
-    return (
-      <Button theme="primary" size="base" onClick={handleLogout}>Logout</Button>
-    );
+    router.push(SIGN_IN_DEFAULT_REDIRECT);
+    return null;
   }
 
   return (

--- a/app/layout/sign-up/component.tsx
+++ b/app/layout/sign-up/component.tsx
@@ -37,14 +37,17 @@ export const SignUp: React.FC<SignUpProps> = () => {
     setSubmitting(true);
 
     try {
-      await AUTHENTICATION
+      const request = await AUTHENTICATION
         .request({
           method: 'POST',
           url: '/sign-up',
           data,
         });
 
-      await signIn('credentials', { ...data, callbackUrl: `${window.location.protocol}//${window.location.host}/projects` });
+      // User is created, so login-in
+      if (request.statusText === 'Created') {
+        await signIn('credentials', data);
+      }
     } catch (error) {
       const { data: { errors } } = error.response;
 

--- a/app/layout/sign-up/component.tsx
+++ b/app/layout/sign-up/component.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useState } from 'react';
 
+import omit from 'lodash/omit';
+
 import Wrapper from 'layout/wrapper';
 
 import Link from 'next/link';
@@ -41,7 +43,7 @@ export const SignUp: React.FC<SignUpProps> = () => {
         .request({
           method: 'POST',
           url: '/sign-up',
-          data,
+          data: omit(data, 'checkbox'),
         });
       // There is an inconsistency on the API
       // where username is used for log in instead of email

--- a/app/layout/sign-up/component.tsx
+++ b/app/layout/sign-up/component.tsx
@@ -37,16 +37,16 @@ export const SignUp: React.FC<SignUpProps> = () => {
     setSubmitting(true);
 
     try {
-      const request = await AUTHENTICATION
+      const signUpResponse = await AUTHENTICATION
         .request({
           method: 'POST',
           url: '/sign-up',
           data,
         });
-
-      // User is created, so login-in
-      if (request.statusText === 'Created') {
-        await signIn('credentials', data);
+      // There is an inconsistency on the API
+      // where username is used for log in instead of email
+      if (signUpResponse.status === 201) {
+        await signIn('credentials', { ...data, username: data.email });
       }
     } catch (error) {
       const { data: { errors } } = error.response;

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import Providers from 'next-auth/providers';
 import AUTHENTICATION from 'services/authentication';
 import USERS from 'services/users';
+import { SIGN_IN_DEFAULT_REDIRECT } from 'hooks/auth';
 
 const options = {
   // Defining custom pages
@@ -77,6 +78,14 @@ const options = {
       };
       session.accessToken = token.accessToken;
       return session;
+    },
+
+    async redirect(callbackUrl) {
+      // By default it should be redirect to /projects
+      if (callbackUrl.includes('/sign-in') || callbackUrl.includes('/sign-up')) {
+        return SIGN_IN_DEFAULT_REDIRECT;
+      }
+      return callbackUrl;
     },
   },
 


### PR DESCRIPTION
### Overview

Redirect to referral URL after login.

### Testing instructions

1. Ensure you are able to sign-in in the page going directly to the URL `/auth/sign-in`.
2. Ensure you are able to sign-in using the Sign-in button on the menu.
3. Ensure you are redirected to sign-in page trying to open a protected page such as `/projects`.
4. You have to see a new param `callbackUrl` in the URL bar. It will be used to redirect to that page after login is success.
5. Ensure you are redirected to `/projects` after Sign up.

### Feature relevant tickets

[MARXAN-122](https://vizzuality.atlassian.net/browse/MARXAN-122?atlOrigin=eyJpIjoiODEwZGVjNGRkMTYxNGMzZThlYWZiYzE5YjVmMWNiZTkiLCJwIjoiaiJ9)
