### PR TITLE
Fix accessibility issues with the Select component

### DIFF
--- a/app/components/forms/select/menu/component.tsx
+++ b/app/components/forms/select/menu/component.tsx
@@ -8,17 +8,10 @@ export const SelectMenu: React.FC<SelectMenuProps> = ({
   theme,
   opened,
   attributes,
-  getMenuProps,
   children,
-  onFocus,
-  onBlur,
 }: SelectMenuProps) => {
   return (
     <div
-      {...getMenuProps({
-        onFocus,
-        onBlur,
-      })}
       className={cx({
         'focus:outline-none overflow-hidden': true,
         'invisible pointer-events-none': attributes?.popper?.['data-popper-reference-hidden'],

--- a/app/components/forms/select/types.d.ts
+++ b/app/components/forms/select/types.d.ts
@@ -48,9 +48,6 @@ export interface SelectMenuProps extends
   children: ReactNode;
   opened: boolean;
   attributes: Record<string, unknown>,
-  getMenuProps: (e?:any) => void;
-  onFocus?: FocusEventHandler;
-  onBlur?: FocusEventHandler;
 }
 
 export interface SelectToggleProps extends
@@ -59,6 +56,6 @@ export interface SelectToggleProps extends
   SelectThemeProps {
   opened: boolean;
   selectedItems: SelectOptionProps[];
-  getToggleButtonProps: (e?:any) => void;
-  getDropdownProps?: (e?:any) => void;
+  getToggleButtonProps: (e?: any) => void;
+  getDropdownProps?: (e?: any) => void;
 }


### PR DESCRIPTION
## Fix accessibility issues with the Select component

### Overview

This PR fixes issues where the select's options and choices would not be correctly announced to screen reader users.

### Testing instructions

1. Open http://192.168.10.161:6006/iframe.html?id=components-forms-select--default&viewMode=story in Safari
2. Activate Voiceover: <kbd>fn</kbd> + <kbd>⌘</kbd> + <kbd>F5</kbd>
3. Press the tab key <kbd>⇥</kbd> to focus on the component
4. Open the menu: <kbd>control ^</kbd> + <kbd>option ⌥</kbd> + <kbd>space</kbd>
5. Move to an option by pressing <kbd>control ^</kbd> + <kbd>option ⌥</kbd> + <kbd>down arrow ⬇️</kbd>

Make sure the option is correctly announced by the screen reader.

6. Toggle on and off an option by pressing:  <kbd>control ^</kbd> + <kbd>option ⌥</kbd> + <kbd>space</kbd>

Make sure the screen reader correctly announce when the option is removed or selected.

7. Toggle off Voiceover: <kbd>fn</kbd> + <kbd>⌘</kbd> + <kbd>F5</kbd>

If at any moment you find Voiceover too chatty, you can silence it by pressing <kbd>control ^</kbd>. 

### Feature relevant tickets

Not tracked.