### PR TITLE
delete user real email when soft deleting a user [MARXAN-184]

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -26,7 +26,11 @@ Unreleased
 ### Changed
 
 - Include `createdAt` and `lastModifiedAt` in responses for some key entities.
-- Allow deleting projects that contain scenarios (cascade deletion in SQL) [MARXAN-218]
+- Allow deleting projects that contain scenarios (cascade deletion in SQL)
+  [MARXAN-218].
+- When soft-deleting a user, their account's email address is set to a random
+  value so that they can sign up again using the same email address in the
+  future, if so they wish [MARXAN-184].
 
 ### Fixed
 

--- a/api/src/modules/users/users.service.ts
+++ b/api/src/modules/users/users.service.ts
@@ -22,6 +22,7 @@ import {
 import { UpdateUserPasswordDTO } from './dto/update.user-password';
 import { compare, hash } from 'bcrypt';
 import { AuthenticationService } from 'modules/authentication/authentication.service';
+import { v4 } from 'uuid';
 
 @Injectable()
 export class UsersService extends AppBaseService<
@@ -131,6 +132,10 @@ export class UsersService extends AppBaseService<
    * the objects (scenarios, etc) to which they are linked, which may not be the
    * desired default behaviour.
    *
+   * When we soft-delete a user, we also set their account's email address to
+   * a random one `@example.com`, so that a new account can be created later
+   * on with the same email address.
+   *
    * @debt We will need to implement hard-deletion later on, so that instance
    * administrators can enforce compliance with relevant data protection
    * regulations.
@@ -138,7 +143,11 @@ export class UsersService extends AppBaseService<
   async markAsDeleted(userId: string): Promise<void> {
     await this.repository.update(
       { id: userId },
-      { isDeleted: true, isActive: false },
+      {
+        isDeleted: true,
+        isActive: false,
+        email: `deleted-account.${v4()}@example.com`,
+      },
     );
     this.authenticationService.invalidateAllTokensOfUser(userId);
   }

--- a/api/src/modules/users/users.service.ts
+++ b/api/src/modules/users/users.service.ts
@@ -170,7 +170,7 @@ export class UsersService extends AppBaseService<
       (await compare(currentAndNewPasswords.currentPassword, user.passwordHash))
     ) {
       user.passwordHash = await hash(currentAndNewPasswords.newPassword, 10);
-      this.repository.save(user);
+      await this.repository.save(user);
       return;
     }
     throw new ForbiddenException(

--- a/api/test/users.e2e-spec.ts
+++ b/api/test/users.e2e-spec.ts
@@ -229,7 +229,7 @@ describe('UsersModule (e2e)', () => {
     });
   });
 
-  describe.skip('Users - password updates which should succeed', () => {
+  describe('Users - password updates which should succeed', () => {
     let jwtToken: string;
 
     beforeAll(async () => {


### PR DESCRIPTION
See https://vizzuality.atlassian.net/browse/MARXAN-184.

Test set `Users - Sign up again` in `users.e2e-spec.ts` cover the changes introduced in this PR.