### PR TITLE
[MARXAN-142] Changed Button component to support Links as Buttons

### DIFF
--- a/app/components/button/component.tsx
+++ b/app/components/button/component.tsx
@@ -1,4 +1,5 @@
-import React, { ButtonHTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
+import Link from 'next/link';
 import cx from 'classnames';
 
 const THEME = {
@@ -21,12 +22,45 @@ const SIZE = {
   xl: 'text-base px-14 py-3',
 };
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
+export interface AnchorButtonProps {
   theme: 'primary' | 'primary-alt' | 'white' | 'secondary' | 'secondary-alt' | 'danger';
   size: 'xs' | 's' | 'base' | 'lg' | 'xl';
   className?: string;
 }
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, AnchorButtonProps {}
+
+export interface AnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement>, AnchorButtonProps {
+  disabled?: boolean;
+}
+
+export interface LinkButtonProps extends AnchorButtonProps {
+  href?: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+export const Anchor: React.FC<AnchorProps> = ({
+  children,
+  theme = 'primary',
+  size = 'base',
+  className,
+  disabled,
+  ...restProps
+}: AnchorProps) => (
+  <a
+    className={cx({
+      'flex items-center justify-center rounded-4xl focus:outline-blue': true,
+      [THEME[theme]]: true,
+      [SIZE[size]]: true,
+      [className]: !!className,
+      'opacity-50 pointer-events-none': disabled,
+    })}
+    {...restProps}
+  >
+    {children}
+  </a>
+);
 
 export const Button: React.FC<ButtonProps> = ({
   children,
@@ -52,4 +86,27 @@ export const Button: React.FC<ButtonProps> = ({
   </button>
 );
 
-export default Button;
+// We consider a link button when href attribute exits
+export const LinkButton = ({ href, ...restProps }: LinkButtonProps) => {
+  if (href) {
+    // External URL should be render using <a>
+    if (href.includes('http')) {
+      // Anchor element doesn't support disabled attribute
+      // https://www.w3.org/TR/2014/REC-html5-20141028/disabled-elements.html
+      if (restProps.disabled) {
+        return (
+          <span {...restProps}>{restProps.children}</span>
+        );
+      }
+      return (<Anchor href={href} {...restProps} />);
+    }
+    return (
+      <Link href={href}>
+        <Anchor {...restProps} />
+      </Link>
+    );
+  }
+  return <Button {...restProps} />;
+};
+
+export default LinkButton;

--- a/app/layout/header/component.tsx
+++ b/app/layout/header/component.tsx
@@ -8,7 +8,7 @@ import User from 'layout/header/user';
 import Title from 'layout/header/title';
 
 import Icon from 'components/icon';
-import Button from 'components/button';
+import LinkButton from 'components/button';
 
 import { useMe } from 'hooks/me';
 
@@ -55,17 +55,13 @@ export const Header: React.FC<HeaderProps> = ({ size }:HeaderProps) => {
 
           {!user && (
             <div className="flex items-center gap-4">
-              <Link href="/auth/sign-in">
-                <Button theme="secondary-alt" size="s">
-                  Sign in
-                </Button>
-              </Link>
+              <LinkButton href="/auth/sign-in" theme="secondary-alt" size="s">
+                Sign in
+              </LinkButton>
 
-              <Link href="/auth/sign-up">
-                <Button theme="primary" size="s">
-                  Sign up
-                </Button>
-              </Link>
+              <LinkButton href="/auth/sign-up" theme="primary" size="s">
+                Sign up
+              </LinkButton>
             </div>
           )}
         </nav>


### PR DESCRIPTION
## Changed the Button component to support `<Link>` and `<a>`

### Overview

After a small discussion about how to do it, we decided to use the same Button component where we will decide depending on the `href` property how to render it. So, when href property exists it will be rendered using `<Link>`, in case of external links it will be `<a>`. And by default, and when href doesn't exist it will be a regular <Button>.

### Testing instructions

There are some links you can check on `/layout/header/component.tsx`.
Also, you can play with it on the Storybook site.

### Feature relevant tickets
[MARXAN-142](https://vizzuality.atlassian.net/browse/MARXAN-142)

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file