### PR TITLE
Add missing postgres db name env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       - NODE_PATH=src
       - NODE_ENV=development
+
   geoprocessing:
     build:
       context: ./geoprocessing
@@ -69,6 +70,7 @@ services:
       - postgresql-api
       - api
       - redis
+
   postgresql-api:
     build:
       context: ./postgresql
@@ -81,7 +83,9 @@ services:
     environment:
       - POSTGRES_PASSWORD=${API_POSTGRES_PASSWORD}
       - POSTGRES_USER=${API_POSTGRES_USER}
+      - POSTGRES_DB=${API_POSTGRES_DB}
     restart: on-failure
+
   postgresql-geo-api:
     build:
       context: ./postgresql
@@ -94,7 +98,9 @@ services:
     environment:
       - POSTGRES_PASSWORD=${GEO_POSTGRES_PASSWORD}
       - POSTGRES_USER=${GEO_POSTGRES_USER}
+      - POSTGRES_DB=${GEO_POSTGRES_DB}
     restart: always
+
   redis:
     build:
       context: ./redis
@@ -105,6 +111,7 @@ services:
     ports:
       - "${REDIS_API_SERVICE_PORT}:6379"
     restart: on-failure
+
   # Admin gui for redis
   redis-commander:
     image: rediscommander/redis-commander
@@ -117,6 +124,7 @@ services:
       - '${REDIS_COMMANDER_PORT}:8081'
     depends_on:
       - redis
+
   postgresql-airflow:
     image: postgres
     container_name: marxan-postgresql-airflow
@@ -124,6 +132,7 @@ services:
       - POSTGRES_USER=airflow
       - POSTGRES_PASSWORD=airflow
       - POSTGRES_DB=airflow
+
   airflow-scheduler:
     container_name: marxan-airflow-scheduler
     image: apache/airflow:2.0.0
@@ -137,6 +146,7 @@ services:
     volumes:
       - ./airflow/dags:/opt/airflow/dags
       - marxan-airflow-logs:/opt/airflow/logs
+
   airflow-webserver:
     container_name: marxan-airflow-webserver
     image: apache/airflow:2.0.0


### PR DESCRIPTION
On startup, the postgres docker images create a DB named after POSTGRES_DB env var, falling back to the POSTGRES_USER if POSTGRES_DB was not defined. As POSTGRES_DB was not passed explicitly, the DB would always have the name of the DB user, which is fine unless you specify different values for user and db on the project's .env file, for example

https://registry.hub.docker.com/_/postgres/

Also, added a few empty lines to this very dense docker compose file. seems like those are free, and they really help my 6:30AM brain read the file.