### PR TITLE
Fix issue with TypeORM loading entities from the dist folder

### DIFF
--- a/api/src/ormconfig.ts
+++ b/api/src/ormconfig.ts
@@ -25,7 +25,7 @@ export const apiConnections: {
     type: 'postgres',
     url: AppConfig.get('postgresApi.url'),
     ssl: false,
-    entities: [__dirname + '/modules/**/*.api.entity.ts'],
+    entities: [__dirname + '/modules/**/*.api.entity.{ts,js}'],
     // Logging may be: ['query', 'error', 'schema', 'warn', 'info', 'log'] Use
     // 'query' if needing to see the actual generated SQL statements (this should
     // be limited to `NODE_ENV=development`). Use 'error' for least verbose
@@ -56,7 +56,7 @@ export const apiConnections: {
     type: 'postgres',
     url: AppConfig.get('postgresGeoApi.url'),
     ssl: false,
-    entities: [__dirname + '/modules/**/*.geo.entity.ts'],
+    entities: [__dirname + '/modules/**/*.geo.entity.{ts,js}'],
     logging: ['error'],
     cache: false,
     // Migrations for this db/data source are handled in the geoprocessing


### PR DESCRIPTION
In some scenarios, when running the api natively, TypeORM will load the "compiled" entities (.js file from the dist folder) and thus will fail to load some entities.