### PR TITLE
use mockReturnThis() for convenience

### DIFF
--- a/api/src/filters/all-exceptions.exception.filter.spec.ts
+++ b/api/src/filters/all-exceptions.exception.filter.spec.ts
@@ -8,9 +8,7 @@ describe('AllExceptionFilter class spec (unit)', () => {
    * Common Mocks
    */
   const responseMock = {
-    status: jest.fn(function () {
-      return this;
-    }),
+    status: jest.fn().mockReturnThis(),
     json: jest.fn(),
     url: 'fakeUrl',
   };


### PR DESCRIPTION
Most importantly, this also avoids having to explicitly type `this`.

This PR basically lets the changed code work with the fully strict TS settings we just introduced (the change was not included in the PR where we introduced fully strict settings because the code affected by this was merged after creating the fully-strict branch)