### PR TITLE
various fixes/improvements to CI workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ test-e2e-api:
 		echo "appending data for $${table_name} with id $${featureid}"; \
 		sed -e "s/\$$feature_id/$$featureid/g" api/test/fixtures/features/$${table_name}.sql | docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.local.yml --env-file .env-test-e2e exec -T test-e2e-postgresql-geo-api psql -U "${GEO_POSTGRES_USER}"; \
 		done;
+	SCENARIOID=$(shell docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.local.yml --env-file .env-test-e2e exec -T test-e2e-postgresql-api psql -X -A -t -U "${API_POSTGRES_USER}" -c "select id from scenarios where name = 'Example scenario 1 Project 1 Org 1'"); \
+	echo "appending data for scenario with id $${SCENARIOID}"; \
+	sed -e "s/\$$user/00000000-0000-0000-0000-000000000000/g" -e "s/\$$scenario/$$SCENARIOID/g" api/test/fixtures/test-geodata.sql | docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.local.yml --env-file .env-test-e2e exec -T test-e2e-postgresql-geo-api psql -U "${GEO_POSTGRES_USER}";
 	# run tests
 	docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.local.yml --env-file .env-test-e2e up --abort-on-container-exit --exit-code-from api api
 	# teardown

--- a/Makefile-ci
+++ b/Makefile-ci
@@ -25,7 +25,10 @@ test-e2e-api:
 		echo "appending data for $${table_name} with id $${featureid}"; \
 		sed -e "s/\$$feature_id/$$featureid/g" api/test/fixtures/features/$${table_name}.sql | docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.ci.yml exec -T test-e2e-postgresql-geo-api psql -U "${GEO_POSTGRES_USER}"; \
 		done;
+	SCENARIOID=$(shell docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.ci.yml --env-file .env-test-e2e exec -T test-e2e-postgresql-api psql -X -A -t -U "${API_POSTGRES_USER}" -c "select id from scenarios where name = 'Example scenario 1 Project 1 Org 1'"); \
+	echo "appending data for scenario with id $${SCENARIOID}"; \
+	sed -e "s/\$$user/00000000-0000-0000-0000-000000000000/g" -e "s/\$$scenario/$$SCENARIOID/g" api/test/fixtures/test-geodata.sql | docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.ci.yml --env-file .env-test-e2e exec -T test-e2e-postgresql-geo-api psql -U "${GEO_POSTGRES_USER}";
 	# run tests
-	docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.ci.yml up --abort-on-container-exit --exit-code-from api api
+	docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.ci.yml -e API_LOGGING_MUTE_ALL=true up --abort-on-container-exit --exit-code-from api api
 	# teardown
 	docker-compose -f docker-compose-test-e2e.yml -f docker-compose-test-e2e.ci.yml rm --stop --force

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ orchestrated via Kubernetes (forthcoming).
      Redis service should listen on the local machine
    * `REDIS_COMMANDER_PORT` (number, required): the port on which the
      Redis Commander service should listen on the local machine
+   * `API_LOGGING_MUTE_ALL` (boolean, optional, default is `false`): can be used
+     to mute all logging (for example, in CI pipelines) irrespective of Node
+     environment and other settings that would normally affect the logging
+     verbosity of the API
 
 The PostgreSQL credentials are used to create a database user when the
 PostgreSQL container is started for the first time. PostgreSQL data is persisted

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -1,4 +1,7 @@
 {
+  "logging": {
+    "muteAll": "API_LOGGING_MUTE_ALL"
+  },
   "postgresApi": {
     "url": "API_POSTGRES_URL",
     "runMigrationsOnStartup": "API_RUN_MIGRATIONS_ON_STARTUP"
@@ -20,6 +23,6 @@
   "redisApi": {
    "connection": {
      "host": "REDIS_HOST"
-     }
    }
+  }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.17.20",
     "ms": "^2.1.3",
     "multer": "^1.4.2",
-    "nestjs-base-service": "0.5.2",
+    "nestjs-base-service": "0.6.0",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",

--- a/api/src/filters/all-exceptions.exception.filter.ts
+++ b/api/src/filters/all-exceptions.exception.filter.ts
@@ -11,6 +11,7 @@ import { omit } from 'lodash';
 
 import * as JSONAPISerializer from 'jsonapi-serializer';
 import { Response } from 'express';
+import { AppConfig } from 'utils/config.utils';
 
 /**
  * Catch-all exception filter. Output error data to logs, and send it as
@@ -21,6 +22,8 @@ import { Response } from 'express';
  */
 @Catch(Error)
 export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger();
+
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response: Response = ctx.getResponse();
@@ -46,7 +49,9 @@ export class AllExceptionsFilter implements ExceptionFilter {
       },
     };
 
-    Logger.error(errorData);
+    if (!AppConfig.get<boolean>('logging.muteAll', false)) {
+      this.logger.error(errorData);
+    }
 
     /**
      * When *not* running in a development environment, we strip off raw error

--- a/api/src/filters/all-exceptions.exception.filter.ts
+++ b/api/src/filters/all-exceptions.exception.filter.ts
@@ -10,6 +10,7 @@ import * as config from 'config';
 import { omit } from 'lodash';
 
 import * as JSONAPISerializer from 'jsonapi-serializer';
+import { Response } from 'express';
 
 /**
  * Catch-all exception filter. Output error data to logs, and send it as
@@ -22,7 +23,7 @@ import * as JSONAPISerializer from 'jsonapi-serializer';
 export class AllExceptionsFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
-    const response = ctx.getResponse();
+    const response: Response = ctx.getResponse();
     const request = ctx.getRequest();
 
     const status =
@@ -62,6 +63,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : errorData,
     );
 
-    response.status(status).json(errorDataForResponse);
+    response
+      .status(status)
+      .header('Content-Type', 'application/json')
+      .header('Content-Disposition', 'inline')
+      .json(errorDataForResponse);
   }
 }

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -47,7 +47,6 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
-  app.useGlobalFilters(new AllExceptionsFilter());
 
   await app.listen(3000);
 }

--- a/api/src/migrations/api/1619711501000-DropNotNullsOnTimeUserMetadataColumns.ts
+++ b/api/src/migrations/api/1619711501000-DropNotNullsOnTimeUserMetadataColumns.ts
@@ -7,7 +7,7 @@ export class DropNotNullsOnTimeUserMetadataColumns1619711501000
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await Promise.all(
-      this.tablesToAlter.map(table => {
+      this.tablesToAlter.map((table) => {
         queryRunner.query(`
 ALTER TABLE ${table}
   ALTER COLUMN created_at DROP NOT NULL,

--- a/api/src/modules/admin-areas/admin-areas.service.ts
+++ b/api/src/modules/admin-areas/admin-areas.service.ts
@@ -21,6 +21,7 @@ import { omit } from 'lodash';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { apiConnections } from '../../ormconfig';
+import { AppConfig } from 'utils/config.utils';
 
 /**
  * Supported admin area levels (sub-national): either level 1 or level 2.
@@ -60,7 +61,9 @@ export class AdminAreasService extends AppBaseService<
     @InjectRepository(AdminArea, apiConnections.geoprocessingDB.name)
     private readonly adminAreasRepository: Repository<AdminArea>,
   ) {
-    super(adminAreasRepository, 'admin_area', 'admin_areas');
+    super(adminAreasRepository, 'admin_area', 'admin_areas', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   get serializerConfig(): JSONAPISerializerConfig<AdminArea> {

--- a/api/src/modules/api-events/api-events.service.ts
+++ b/api/src/modules/api-events/api-events.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { DeleteResult, Repository } from 'typeorm';
@@ -21,6 +21,7 @@ import {
 import { CreateApiEventDTO } from './dto/create.api-event.dto';
 import { UpdateApiEventDTO } from './dto/update.api-event.dto';
 import { AppInfoDTO } from 'dto/info.dto';
+import { AppConfig } from 'utils/config.utils';
 
 @Injectable()
 /**
@@ -32,14 +33,14 @@ export class ApiEventsService extends AppBaseService<
   UpdateApiEventDTO,
   AppInfoDTO
 > {
-  private readonly logger = new Logger(ApiEventsService.name);
-
   constructor(
     @InjectRepository(ApiEvent) readonly repo: Repository<ApiEvent>,
     @InjectRepository(LatestApiEventByTopicAndKind)
     readonly latestEventByTopicAndKindRepo: Repository<LatestApiEventByTopicAndKind>,
   ) {
-    super(repo, apiEventResource.name.singular, apiEventResource.name.plural);
+    super(repo, apiEventResource.name.singular, apiEventResource.name.plural, {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
   get serializerConfig(): JSONAPISerializerConfig<ApiEvent> {
     return {

--- a/api/src/modules/countries/countries.service.ts
+++ b/api/src/modules/countries/countries.service.ts
@@ -12,6 +12,7 @@ import {
   JSONAPISerializerConfig,
 } from 'utils/app-base.service';
 import { apiConnections } from '../../ormconfig';
+import { AppConfig } from 'utils/config.utils';
 
 @Injectable()
 export class CountriesService extends AppBaseService<
@@ -24,7 +25,10 @@ export class CountriesService extends AppBaseService<
     @InjectRepository(Country, apiConnections.geoprocessingDB.name)
     private readonly countriesRepository: Repository<Country>,
   ) {
-    super(countriesRepository, 'country', 'countries', 'gid0');
+    super(countriesRepository, 'country', 'countries', {
+      idProperty: 'gid0',
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   get serializerConfig(): JSONAPISerializerConfig<Country> {

--- a/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/src/modules/geo-features/geo-features.service.ts
@@ -23,6 +23,7 @@ import {
 import { FetchSpecification } from 'nestjs-base-service';
 import { Project } from 'modules/projects/project.api.entity';
 import { apiConnections } from '../../ormconfig';
+import { AppConfig } from 'utils/config.utils';
 
 const geoFeatureFilterKeyNames = [
   'featureClassName',
@@ -63,6 +64,9 @@ export class GeoFeaturesService extends AppBaseService<
       geoFeaturesRepository,
       geoFeatureResource.name.singular,
       geoFeatureResource.name.plural,
+      {
+        logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+      },
     );
   }
 

--- a/api/src/modules/organizations/organizations.service.ts
+++ b/api/src/modules/organizations/organizations.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AppInfoDTO } from 'dto/info.dto';
 import { Repository, SelectQueryBuilder } from 'typeorm';
@@ -12,6 +12,7 @@ import {
   AppBaseService,
   JSONAPISerializerConfig,
 } from 'utils/app-base.service';
+import { AppConfig } from 'utils/config.utils';
 
 const organizationFilterKeyNames = ['name'] as const;
 type OrganizationFilterKeys = keyof Pick<
@@ -27,14 +28,14 @@ export class OrganizationsService extends AppBaseService<
   UpdateOrganizationDTO,
   AppInfoDTO
 > {
-  private readonly logger = new Logger(OrganizationsService.name);
-
   constructor(
     @InjectRepository(Organization)
     protected readonly repository: Repository<Organization>,
     @Inject(UsersService) private readonly usersService: UsersService,
   ) {
-    super(repository, 'organization', 'organizations');
+    super(repository, 'organization', 'organizations', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   get serializerConfig(): JSONAPISerializerConfig<Organization> {

--- a/api/src/modules/projects/projects.service.ts
+++ b/api/src/modules/projects/projects.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AppInfoDTO } from 'dto/info.dto';
 import { Repository, SelectQueryBuilder } from 'typeorm';
@@ -18,6 +18,7 @@ import { Country } from 'modules/countries/country.geo.entity';
 import { AdminArea } from 'modules/admin-areas/admin-area.geo.entity';
 import { AdminAreasService } from 'modules/admin-areas/admin-areas.service';
 import { CountriesService } from 'modules/countries/countries.service';
+import { AppConfig } from 'utils/config.utils';
 
 const projectFilterKeyNames = [
   'name',
@@ -39,7 +40,6 @@ export class ProjectsService extends AppBaseService<
   UpdateProjectDTO,
   AppInfoDTO
 > {
-  private readonly logger = new Logger(ProjectsService.name);
   constructor(
     @InjectRepository(Project)
     protected readonly repository: Repository<Project>,
@@ -53,7 +53,9 @@ export class ProjectsService extends AppBaseService<
     @Inject(PlanningUnitsService)
     private readonly planningUnitsService: PlanningUnitsService,
   ) {
-    super(repository, 'project', 'projects');
+    super(repository, 'project', 'projects', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   get serializerConfig(): JSONAPISerializerConfig<Project> {

--- a/api/src/modules/protected-areas/protected-areas.service.ts
+++ b/api/src/modules/protected-areas/protected-areas.service.ts
@@ -1,6 +1,6 @@
 import { BaseServiceResource } from 'types/resource.interface';
 
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AppInfoDTO } from 'dto/info.dto';
 import { Repository, SelectQueryBuilder } from 'typeorm';
@@ -22,6 +22,7 @@ import {
 import { AdminAreasService } from 'modules/admin-areas/admin-areas.service';
 import { IsBoolean, IsOptional, IsUUID } from 'class-validator';
 import { apiConnections } from '../../ormconfig';
+import { AppConfig } from 'utils/config.utils';
 
 const protectedAreaFilterKeyNames = [
   'fullName',
@@ -66,13 +67,13 @@ export class ProtectedAreasService extends AppBaseService<
   UpdateProtectedAreaDTO,
   AppInfoDTO
 > {
-  private readonly logger = new Logger(ProtectedAreasService.name);
-
   constructor(
     @InjectRepository(ProtectedArea, apiConnections.geoprocessingDB.name)
     protected readonly repository: Repository<ProtectedArea>,
   ) {
-    super(repository, 'protected_area', 'protected_areas');
+    super(repository, 'protected_area', 'protected_areas', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   setFilters(

--- a/api/src/modules/scenarios-features/scenario-features.service.ts
+++ b/api/src/modules/scenarios-features/scenario-features.service.ts
@@ -14,6 +14,7 @@ import { GeoFeature } from '../geo-features/geo-feature.api.entity';
 import { RemoteScenarioFeaturesData } from './entities/remote-scenario-features-data.geo.entity';
 import { RemoteFeaturesData } from './entities/remote-features-data.geo.entity';
 import { UserSearchCriteria } from './search-criteria';
+import { AppConfig } from 'utils/config.utils';
 
 @Injectable()
 export class ScenarioFeaturesService extends AppBaseService<
@@ -30,7 +31,9 @@ export class ScenarioFeaturesService extends AppBaseService<
     @InjectRepository(RemoteScenarioFeaturesData, remoteConnectionName)
     private readonly remoteScenarioFeatures: Repository<RemoteScenarioFeaturesData>,
   ) {
-    super(remoteScenarioFeatures, 'scenario_features', 'scenario_feature');
+    super(remoteScenarioFeatures, 'scenario_features', 'scenario_feature', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   setFilters(

--- a/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/src/modules/scenarios/scenarios.service.ts
@@ -16,6 +16,7 @@ import { Project } from 'modules/projects/project.api.entity';
 import { ProtectedAreasService } from 'modules/protected-areas/protected-areas.service';
 import { ProjectsService } from 'modules/projects/projects.service';
 import { concat } from 'lodash';
+import { AppConfig } from 'utils/config.utils';
 
 const scenarioFilterKeyNames = ['name', 'type', 'projectId', 'status'] as const;
 type ScenarioFilterKeys = keyof Pick<
@@ -31,8 +32,6 @@ export class ScenariosService extends AppBaseService<
   UpdateScenarioDTO,
   AppInfoDTO
 > {
-  private readonly logger = new Logger(ScenariosService.name);
-
   constructor(
     @InjectRepository(Scenario)
     protected readonly repository: Repository<Scenario>,
@@ -44,7 +43,9 @@ export class ScenariosService extends AppBaseService<
     @Inject(forwardRef(() => ProjectsService))
     protected readonly projectsService: ProjectsService,
   ) {
-    super(repository, 'scenario', 'scenarios');
+    super(repository, 'scenario', 'scenarios', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   get serializerConfig(): JSONAPISerializerConfig<Scenario> {

--- a/api/src/modules/users/users.service.ts
+++ b/api/src/modules/users/users.service.ts
@@ -23,6 +23,7 @@ import { UpdateUserPasswordDTO } from './dto/update.user-password';
 import { compare, hash } from 'bcrypt';
 import { AuthenticationService } from 'modules/authentication/authentication.service';
 import { v4 } from 'uuid';
+import { AppConfig } from 'utils/config.utils';
 
 @Injectable()
 export class UsersService extends AppBaseService<
@@ -37,7 +38,9 @@ export class UsersService extends AppBaseService<
     @Inject(forwardRef(() => AuthenticationService))
     private readonly authenticationService: AuthenticationService,
   ) {
-    super(repository, userResource.name.singular, userResource.name.plural);
+    super(repository, userResource.name.singular, userResource.name.plural, {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
   }
 
   get serializerConfig(): JSONAPISerializerConfig<User> {

--- a/api/src/utils/app-base.service.ts
+++ b/api/src/utils/app-base.service.ts
@@ -1,4 +1,8 @@
-import { BaseService, FetchSpecification } from 'nestjs-base-service';
+import {
+  BaseService,
+  BaseServiceOptions,
+  FetchSpecification,
+} from 'nestjs-base-service';
 
 import * as JSONAPISerializer from 'jsonapi-serializer';
 import { Repository, SelectQueryBuilder } from 'typeorm';
@@ -67,9 +71,9 @@ export abstract class AppBaseService<
     protected readonly repository: Repository<Entity>,
     protected alias: string = 'base_entity',
     protected pluralAlias: string = 'base_entities',
-    protected idProperty: string = 'id',
+    protected serviceOptions: BaseServiceOptions,
   ) {
-    super(repository, alias, idProperty);
+    super(repository, alias, serviceOptions);
   }
 
   /**

--- a/api/test/proxy.vector-tiles.e2e-spec.ts
+++ b/api/test/proxy.vector-tiles.e2e-spec.ts
@@ -46,9 +46,8 @@ describe('ProxyVectorTilesModule (e2e)', () => {
 
     it('Should give back a valid request for admin areas', async () => {
       const response = await request(app.getHttpServer())
-        .get(
-          '/api/v1/geoprocessing/administrative-areas/1/preview/tiles/6/30/25.mvt',
-        )
+        .get('/api/v1/administrative-areas/1/preview/tiles/6/30/25.mvt')
+        .set('Accept-Encoding', 'gzip, deflate')
         .set('Authorization', `Bearer ${jwtToken}`)
         .expect(200);
     });
@@ -58,9 +57,7 @@ describe('ProxyVectorTilesModule (e2e)', () => {
      */
     it('Should simulate an error', async () => {
       const response = await request(app.getHttpServer())
-        .get(
-          '/api/v1/geoprocessing/administrative-areas/1/preview/tiles/100/60/30.mvt',
-        )
+        .get('/api/v1/administrative-areas/1/preview/tiles/100/60/30.mvt')
         .set('Authorization', `Bearer ${jwtToken}`)
         .expect(400);
     });
@@ -70,9 +67,7 @@ describe('ProxyVectorTilesModule (e2e)', () => {
      */
     it('Should throw a 400 error if filtering by level other than 0, 1 or 2', async () => {
       const response = await request(app.getHttpServer())
-        .get(
-          '/api/v1/geoprocessing/administrative-areas/3/preview/tiles/6/30/25.mvt',
-        )
+        .get('/api/v1/administrative-areas/3/preview/tiles/6/30/25.mvt')
         .set('Authorization', `Bearer ${jwtToken}`)
         .expect(400);
     });
@@ -82,9 +77,7 @@ describe('ProxyVectorTilesModule (e2e)', () => {
      */
     it('Should throw a 400 error if filtering by  z level greater than 20', async () => {
       const response = await request(app.getHttpServer())
-        .get(
-          '/api/v1/geoprocessing/administrative-areas/3/preview/tiles/21/30/25.mvt',
-        )
+        .get('/api/v1/administrative-areas/3/preview/tiles/21/30/25.mvt')
         .set('Authorization', `Bearer ${jwtToken}`)
         .expect(400);
     });

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -879,15 +879,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ioredis@^4.16.3":
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.22.1.tgz#e03b064189ab20c9edc95ccde6228d2bf81f538c"
-  integrity sha512-GxXT828fkvBeThO68ZJg8cD2haqea5ANBJaxA+UZqLranNkEnQ8N7QLPtykwWbN/sRQz75O7kj+PNmCKF4CEKw==
-
 "@types/http-proxy@^1.17.5":
   version "1.17.5"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.5.tgz#c203c5e6e9dc6820d27a40eb1e511c70a220423d"
   integrity sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ioredis@^4.16.3":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.22.1.tgz#e03b064189ab20c9edc95ccde6228d2bf81f538c"
+  integrity sha512-GxXT828fkvBeThO68ZJg8cD2haqea5ANBJaxA+UZqLranNkEnQ8N7QLPtykwWbN/sRQz75O7kj+PNmCKF4CEKw==
   dependencies:
     "@types/node" "*"
 
@@ -5357,10 +5359,10 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nestjs-base-service@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/nestjs-base-service/-/nestjs-base-service-0.5.2.tgz#4d35ec293ad265c18e3c35d38e730ae7164c9973"
-  integrity sha512-LnawCNq/XJfxeOTIi8x8YFNdAF3JC2xpJ10E2w86SL/366u+F4mbOF8u68xr6xlIf0FaLcKtvXsXrQt8hKQtKg==
+nestjs-base-service@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/nestjs-base-service/-/nestjs-base-service-0.6.0.tgz#dac2cfdb987d6f5b44e814459dd69bd770a3c807"
+  integrity sha512-ZxPmUdyyzm9Bf0lfsxL0L3N9OQPHKJ6ZcyaaB1l0kZK0tgoqqWg4HLkvPDViWCmCLAeO3pptrJ3OOcKP9vlWSw==
   dependencies:
     "@nestjs/common" "7.6.5"
     class-validator "0.13.1"

--- a/geoprocessing/src/filters/all-exceptions.exception.filter.ts
+++ b/geoprocessing/src/filters/all-exceptions.exception.filter.ts
@@ -49,7 +49,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       },
     };
 
-    if (!AppConfig.get<boolean>('logging.muteAll')) {
+    if (!AppConfig.get<boolean>('logging.muteAll', false)) {
       this.logger.error(errorData);
     }
 

--- a/geoprocessing/src/filters/all-exceptions.exception.filter.ts
+++ b/geoprocessing/src/filters/all-exceptions.exception.filter.ts
@@ -11,6 +11,7 @@ import { omit } from 'lodash';
 
 import * as JSONAPISerializer from 'jsonapi-serializer';
 import { Response } from 'express';
+import { AppConfig } from 'src/utils/config.utils';
 
 /**
  * Catch-all exception filter. Output error data to logs, and send it as
@@ -21,6 +22,8 @@ import { Response } from 'express';
  */
 @Catch(Error)
 export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger();
+
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response: Response = ctx.getResponse();
@@ -46,7 +49,9 @@ export class AllExceptionsFilter implements ExceptionFilter {
       },
     };
 
-    Logger.error(errorData);
+    if (!AppConfig.get<boolean>('logging.muteAll')) {
+      this.logger.error(errorData);
+    }
 
     /**
      * When *not* running in a development environment, we strip off raw error

--- a/geoprocessing/src/filters/all-exceptions.exception.filter.ts
+++ b/geoprocessing/src/filters/all-exceptions.exception.filter.ts
@@ -10,6 +10,7 @@ import * as config from 'config';
 import { omit } from 'lodash';
 
 import * as JSONAPISerializer from 'jsonapi-serializer';
+import { Response } from 'express';
 
 /**
  * Catch-all exception filter. Output error data to logs, and send it as
@@ -22,7 +23,7 @@ import * as JSONAPISerializer from 'jsonapi-serializer';
 export class AllExceptionsFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
-    const response = ctx.getResponse();
+    const response: Response = ctx.getResponse();
     const request = ctx.getRequest();
 
     const status =
@@ -62,6 +63,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : errorData,
     );
 
-    response.status(status).json(errorDataForResponse);
+    response
+      .status(status)
+      .header('Content-Type', 'application/json')
+      .header('Content-Disposition', 'inline')
+      .json(errorDataForResponse);
   }
 }


### PR DESCRIPTION
- Allow to mute all logging irrespective of Node env and other settings that would affect Logger verbosity, via `API_LOGGING_MUTE_ALL` envvar

e.g. `docker-compose run -e API_LOGGING_MUTE_ALL=true api yarn test:e2e`

- Backport (manually for now) today's updates to `seed-geoapi-with-test-data` Makefile recipe to local and ci e2e recipes

Missing (moving them to future PRs):

- [ ] ability to run only specific test suites when running the full local CI pipeline (`make test-e2e-api <pattern>`)
- [ ] make `--watch` work
- [ ] run unit tests in CI
- [ ] avoid setting logger configuration in each service