### PR TITLE
chore: add scenario-pu-request entity definition

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -25,6 +25,7 @@ import { AdminAreasModule } from 'modules/admin-areas/admin-areas.module';
 import { ApiEventsModule } from 'modules/api-events/api-events.module';
 import { ProtectedAreasModule } from 'modules/protected-areas/protected-areas.module';
 import { ProxyModule } from 'modules/proxy/proxy.module';
+import { AnalysisModule } from './modules/analysis/analysis.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { ProxyModule } from 'modules/proxy/proxy.module';
     UsersModule,
     AuthenticationModule,
     ProxyModule,
+    AnalysisModule,
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/src/modules/analysis/analysis-input.ts
+++ b/api/src/modules/analysis/analysis-input.ts
@@ -1,0 +1,14 @@
+import { MultiPolygon } from 'geojson';
+
+export interface AnalysisInput {
+  include?: {
+    pu?: string[];
+    geo?: MultiPolygon;
+    shape?: MultiPolygon;
+  };
+  exclude?: {
+    pu?: string[];
+    geo?: MultiPolygon;
+    shape?: MultiPolygon;
+  };
+}

--- a/api/src/modules/analysis/analysis.module.ts
+++ b/api/src/modules/analysis/analysis.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { PlanningUnitsModule } from '../planning-units/planning-units.module';
+import { ScenarioPuRequestModule } from './scenario-pu-request/scenario-pu-request.module';
+
 import { AnalysisService } from './analysis.service';
 import { ArePuidsAllowed } from './are-puids-allowed';
 
 @Module({
   imports: [
     // Base Service for processing entity config
-    // Module with Base Service for scenarios_pu_data
+    ScenarioPuRequestModule,
     PlanningUnitsModule,
   ],
   providers: [

--- a/api/src/modules/analysis/analysis.module.ts
+++ b/api/src/modules/analysis/analysis.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { PlanningUnitsModule } from '../planning-units/planning-units.module';
+import { AnalysisService } from './analysis.service';
+import { ArePuidsAllowed } from './are-puids-allowed';
+
+@Module({
+  imports: [
+    // Base Service for processing entity config
+    // Module with Base Service for scenarios_pu_data
+    PlanningUnitsModule,
+  ],
+  providers: [
+    {
+      provide: ArePuidsAllowed,
+      useValue: {}, // replace with useClass of Service extending (BaseService of scenarios_pu_data) with required functionality
+    },
+    AnalysisService,
+  ],
+  exports: [AnalysisService],
+})
+export class AnalysisModule {}

--- a/api/src/modules/analysis/analysis.service.ts
+++ b/api/src/modules/analysis/analysis.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { PlanningUnitsService } from '../planning-units/planning-units.service';
+import { AsyncJob, JobStatus } from './async-job';
+import { ArePuidsAllowed } from './are-puids-allowed';
+import { AnalysisInput } from './analysis-input';
+
+type Success = true;
+
+@Injectable()
+export class AnalysisService {
+  constructor(
+    // TODO Inject Base Service for processing entity config
+    private readonly puUuidValidator: ArePuidsAllowed,
+    private readonly jobScheduler: PlanningUnitsService,
+  ) {}
+
+  /**
+   * we could use Either from fp-ts as a return value
+   */
+  async update(
+    scenarioId: string,
+    constraints: AnalysisInput,
+  ): Promise<Success> {
+    const targetPuIds = [
+      ...(constraints.include?.pu ?? []),
+      ...(constraints.exclude?.pu ?? []),
+    ];
+    if (targetPuIds.length > 0) {
+      await this.puUuidValidator.validate(scenarioId, targetPuIds);
+    }
+
+    // TODO add processing entity config creation
+
+    // TODO should it trigger the job? (.executeCalculations)
+
+    return true;
+  }
+
+  async executeCalculations(scenarioId: string): Promise<AsyncJob> {
+    // await this.jobScheduler.create({
+    //   /**??*/
+    // });
+
+    return {
+      id: '0',
+      status: JobStatus.Pending,
+    };
+  }
+}

--- a/api/src/modules/analysis/are-puids-allowed.ts
+++ b/api/src/modules/analysis/are-puids-allowed.ts
@@ -1,0 +1,9 @@
+// Should be implemented by BaseService of `scenarios_pu_data` entity
+export abstract class ArePuidsAllowed {
+  abstract validate(
+    scenarioId: string,
+    puIds: string[],
+  ): Promise<{
+    errors: unknown[];
+  }>;
+}

--- a/api/src/modules/analysis/async-job.ts
+++ b/api/src/modules/analysis/async-job.ts
@@ -1,0 +1,10 @@
+export enum JobStatus {
+  Pending = 'pending',
+  Completed = 'completed',
+  Failed = 'failed',
+}
+
+export interface AsyncJob {
+  id: string;
+  status: JobStatus;
+}

--- a/api/src/modules/analysis/scenario-pu-request/entity/scenario-pu-request.geo.entity.ts
+++ b/api/src/modules/analysis/scenario-pu-request/entity/scenario-pu-request.geo.entity.ts
@@ -1,0 +1,86 @@
+import { Check, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Geometry } from 'geojson';
+
+export const scenarioPuRequestEntityName = 'scenario_pu_requested_status';
+
+/**
+ *  represents spatial data using longitude and latitude coordinates on the Earth's surface as defined in the WGS84 standard, which is also used for the Global Positioning System (GPS)
+ */
+const srid = 4326;
+
+@Entity(scenarioPuRequestEntityName)
+export class ScenarioPuRequestGeo {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'scenario_id', nullable: false })
+  scenarioId!: string;
+
+  @Column({
+    name: 'included_planning_unit_ids',
+    nullable: false,
+    type: 'simple-array',
+    default: () => '', // https://github.com/typeorm/typeorm/issues/1532
+  })
+  includedPlantingUnits!: string[];
+
+  @Column({
+    name: 'excluded_planning_unit_ids',
+    nullable: false,
+    type: 'simple-array',
+    default: () => '',
+  })
+  excludedPlantingUnits!: string[];
+
+  @Column({
+    name: 'included_from_geojson',
+    type: 'geometry',
+    spatialFeatureType: 'MultiPolygon',
+    srid,
+    nullable: true,
+  })
+  @Check(
+    'scenario_included_pu_geojson_valid_check',
+    'ST_IsValid(included_from_geojson)',
+  )
+  includedFromGeoJson!: Geometry | null;
+
+  @Column({
+    name: 'included_from_shapefile',
+    type: 'geometry',
+    spatialFeatureType: 'MultiPolygon',
+    srid,
+    nullable: true,
+  })
+  @Check(
+    'scenario_included_pu_shapefile_valid_check',
+    'ST_IsValid(included_from_shapefile)',
+  )
+  includedFromShapefile!: Geometry | null;
+
+  @Column({
+    name: 'excluded_from_geojson',
+    type: 'geometry',
+    spatialFeatureType: 'MultiPolygon',
+    srid,
+    nullable: true,
+  })
+  @Check(
+    'scenario_excluded_pu_geojson_valid_check',
+    'ST_IsValid(excluded_from_geojson)',
+  )
+  excludedFromGeoJson!: Geometry | null;
+
+  @Column({
+    name: 'excluded_from_shapefile',
+    type: 'geometry',
+    spatialFeatureType: 'MultiPolygon',
+    srid,
+    nullable: true,
+  })
+  @Check(
+    'scenario_excluded_pu_shapefile_valid_check',
+    'ST_IsValid(excluded_from_shapefile)',
+  )
+  excludedFromShapefile!: Geometry | null;
+}

--- a/api/src/modules/analysis/scenario-pu-request/scenario-pu-request.module.ts
+++ b/api/src/modules/analysis/scenario-pu-request/scenario-pu-request.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DbConnections } from '../../../ormconfig.connections';
+import { ScenarioPuRequestGeo } from './entity/scenario-pu-request.geo.entity';
+import { ScenarioPuRequestsService } from './scenario-pu-requests.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature(
+      [ScenarioPuRequestGeo],
+      DbConnections.geoprocessingDB,
+    ),
+  ],
+  providers: [ScenarioPuRequestsService],
+  exports: [ScenarioPuRequestsService],
+})
+export class ScenarioPuRequestModule {}

--- a/api/src/modules/analysis/scenario-pu-request/scenario-pu-requests.service.ts
+++ b/api/src/modules/analysis/scenario-pu-request/scenario-pu-requests.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  AppBaseService,
+  JSONAPISerializerConfig,
+} from '../../../utils/app-base.service';
+import { DbConnections } from '../../../ormconfig.connections';
+import { ScenarioPuRequestGeo } from './entity/scenario-pu-request.geo.entity';
+
+@Injectable()
+export class ScenarioPuRequestsService extends AppBaseService<
+  ScenarioPuRequestGeo,
+  ScenarioPuRequestGeo,
+  never,
+  never // not yet needed
+> {
+  constructor(
+    @InjectRepository(ScenarioPuRequestGeo, DbConnections.geoprocessingDB)
+    private readonly puData: Repository<ScenarioPuRequestGeo>,
+  ) {
+    super(
+      puData,
+      'scenario_planning_unit_request',
+      'scenario_planning_unit_requests',
+    );
+  }
+
+  get serializerConfig(): JSONAPISerializerConfig<ScenarioPuRequestGeo> {
+    return {
+      attributes: [
+        'id',
+        'scenarioId',
+        'excludedFromGeoJson',
+        'excludedFromShapefile',
+        'excludedPlantingUnits',
+        'includedFromGeoJson',
+        'includedFromShapefile',
+        'includedPlantingUnits',
+      ],
+      keyForAttribute: 'camelCase',
+    };
+  }
+}

--- a/api/test/scenario-pu-requests/scenario-pu-requests.integration.e2e-spec.ts
+++ b/api/test/scenario-pu-requests/scenario-pu-requests.integration.e2e-spec.ts
@@ -1,0 +1,58 @@
+import { INestApplication } from '@nestjs/common';
+import { bootstrapApplication } from '../utils/api-application';
+import { ScenarioPuRequestsService } from '../../src/modules/analysis/scenario-pu-request/scenario-pu-requests.service';
+import { createWorld, World } from './steps/world';
+
+let app: INestApplication;
+let service: ScenarioPuRequestsService;
+
+let world: World;
+
+beforeAll(async () => {
+  app = await bootstrapApplication();
+  service = app.get(ScenarioPuRequestsService);
+  world = await createWorld(app);
+});
+
+afterAll(async () => {
+  await world.cleanup();
+});
+
+describe(`when trying to push invalid data`, () => {
+  it(`should fail on constraint check`, async () => {
+    await expect(world.WhenInsertingInvalidMultiPolygon()).rejects.toThrow();
+  });
+
+  it(`should fail on non allowed spatial type (spatialFeatureType)`, async () => {
+    await expect(world.WhenInsertingNonMultiPolygon()).rejects.toThrow();
+  });
+});
+
+describe(`scenarios-pu-data fetch`, () => {
+  let result: unknown;
+
+  beforeEach(async () => {
+    // Asset
+    await world.WhenScenarioPuRequestIsAvailable();
+
+    // Act
+    result = await service.findAll();
+  });
+
+  it(`returns valid data`, () => {
+    expect(result).toEqual([
+      expect.arrayContaining([
+        expect.objectContaining({
+          scenarioId: world.scenarioId,
+          includedPlantingUnits: expect.any(Array),
+          excludedPlantingUnits: [],
+          includedFromGeoJson: expect.any(Object),
+          includedFromShapefile: expect.any(Object),
+          excludedFromGeoJson: expect.any(Object),
+          excludedFromShapefile: expect.any(Object),
+        }),
+      ]),
+      expect.any(Number),
+    ]);
+  });
+});

--- a/api/test/scenario-pu-requests/steps/data/sample-multi-polygon.ts
+++ b/api/test/scenario-pu-requests/steps/data/sample-multi-polygon.ts
@@ -1,0 +1,56 @@
+import { Geometry, MultiPolygon } from 'geojson';
+import { v4 } from 'uuid';
+
+export const invalidPuIds = (): string[] => [v4(), 'non-uuid'];
+export const validPuIds = (): string[] => [v4(), v4()];
+
+export const geometryBannedBySpatialFlag = (): Geometry => ({
+  type: 'LineString',
+  coordinates: [],
+});
+
+export const invalidMultiPolygon = (): MultiPolygon => ({
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [102.0, 2.0],
+        [104.0, 5.0],
+        [103.0, 3.0],
+      ],
+    ],
+  ],
+});
+
+export const sampleGeometry = (): Geometry => sampleMultiPolygonJson();
+
+export const sampleMultiPolygonJson = (): MultiPolygon => ({
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [102.0, 2.0],
+        [103.0, 2.0],
+        [103.0, 3.0],
+        [102.0, 3.0],
+        [102.0, 2.0],
+      ],
+    ],
+    [
+      [
+        [100.0, 0.0],
+        [101.0, 0.0],
+        [101.0, 1.0],
+        [100.0, 1.0],
+        [100.0, 0.0],
+      ],
+      [
+        [100.2, 0.2],
+        [100.8, 0.2],
+        [100.8, 0.8],
+        [100.2, 0.8],
+        [100.2, 0.2],
+      ],
+    ],
+  ],
+});

--- a/api/test/scenario-pu-requests/steps/world.ts
+++ b/api/test/scenario-pu-requests/steps/world.ts
@@ -1,0 +1,76 @@
+import { INestApplication } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { ScenarioPuRequestGeo } from '../../../src/modules/analysis/scenario-pu-request/entity/scenario-pu-request.geo.entity';
+import { DbConnections } from '../../../src/ormconfig.connections';
+import {
+  geometryBannedBySpatialFlag,
+  invalidMultiPolygon,
+  invalidPuIds,
+  sampleGeometry,
+  validPuIds,
+} from './data/sample-multi-polygon';
+
+export interface World {
+  scenarioId: string;
+  WhenScenarioPuRequestIsAvailable: () => Promise<void>;
+  WhenInsertingInvalidMultiPolygon: () => Promise<void>;
+  WhenInsertingNonMultiPolygon: () => Promise<void>;
+  cleanup: () => Promise<void>;
+}
+
+export const createWorld = async (app: INestApplication): Promise<World> => {
+  const scenarioId = v4();
+  const repo: Repository<ScenarioPuRequestGeo> = await app.get(
+    getRepositoryToken(ScenarioPuRequestGeo, DbConnections.geoprocessingDB),
+  );
+
+  return {
+    scenarioId,
+    WhenInsertingNonMultiPolygon: async () =>
+      repo
+        .save(
+          repo.create({
+            scenarioId,
+            excludedFromGeoJson: sampleGeometry(),
+            excludedFromShapefile: sampleGeometry(),
+            includedFromGeoJson: geometryBannedBySpatialFlag(),
+            includedFromShapefile: sampleGeometry(),
+          }),
+        )
+        .then(() => undefined),
+    WhenInsertingInvalidMultiPolygon: async () =>
+      repo
+        .save(
+          repo.create({
+            scenarioId,
+            excludedFromGeoJson: sampleGeometry(),
+            excludedFromShapefile: sampleGeometry(),
+            includedFromGeoJson: invalidMultiPolygon(),
+            includedFromShapefile: sampleGeometry(),
+          }),
+        )
+        .then(() => undefined),
+    WhenScenarioPuRequestIsAvailable: async () =>
+      repo
+        .save(
+          repo.create({
+            scenarioId,
+            includedPlantingUnits: validPuIds(),
+            excludedFromGeoJson: sampleGeometry(),
+            excludedFromShapefile: sampleGeometry(),
+            includedFromGeoJson: sampleGeometry(),
+            includedFromShapefile: sampleGeometry(),
+          }),
+        )
+        .then(() => undefined),
+    cleanup: async () =>
+      repo
+        .delete({
+          scenarioId,
+        })
+        .then(() => undefined),
+  };
+};

--- a/geoprocessing/src/migrations/geoprocessing/1620204540793-ScenarioPuRequestedStatus.ts
+++ b/geoprocessing/src/migrations/geoprocessing/1620204540793-ScenarioPuRequestedStatus.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ScenarioPuRequestedStatus1620204540793
+  implements MigrationInterface {
+  name = 'ScenarioPuRequestedStatus1620204540793';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "scenario_pu_requested_status" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "scenario_id" character varying NOT NULL, "included_planning_unit_ids" text NOT NULL DEFAULT '', "excluded_planning_unit_ids" text NOT NULL DEFAULT '', "included_from_geojson" geometry(MultiPolygon,4326), "included_from_shapefile" geometry(MultiPolygon,4326), "excluded_from_geojson" geometry(MultiPolygon,4326), "excluded_from_shapefile" geometry(MultiPolygon,4326), CONSTRAINT "scenario_included_pu_geojson_valid_check" CHECK (ST_IsValid(included_from_geojson)), CONSTRAINT "scenario_included_pu_shapefile_valid_check" CHECK (ST_IsValid(included_from_shapefile)), CONSTRAINT "scenario_excluded_pu_geojson_valid_check" CHECK (ST_IsValid(excluded_from_geojson)), CONSTRAINT "scenario_excluded_pu_shapefile_valid_check" CHECK (ST_IsValid(excluded_from_shapefile)), CONSTRAINT "PK_cd23f24dfce04b5c64cd7179c6d" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "scenario_pu_requested_status"`);
+  }
+}


### PR DESCRIPTION
## `scenario-pu-request` entity & service

Please keep in mind that migration **was fully generated** from `.entity` code. 

Things to keep in mind: validating if given `(ex)includedPlantingUnits` are `uuids` isn't that straightforward (even with using class-validator and `@BeforeSave/Update` hooks). As we have a task to validate if those are allowed anyway, decided to drop the validation out of the entity model.

### Overview

#### Fail on inserting invalid MultiPolygon (db constraint check)
```
[102.0, 2.0],
[104.0, 5.0],
[103.0, 3.0],
```
![image](https://user-images.githubusercontent.com/3466388/117122443-36249980-ad96-11eb-8429-e44ba01f840d.png)

#### Fail on non MultiPolygon
![image](https://user-images.githubusercontent.com/3466388/117123177-ff9b4e80-ad96-11eb-835b-e4fe710be906.png)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file