### PR TITLE
(chore) improve jest ci workflow part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ seed-geoapi-with-test-data:
 	SCENARIOID=$(shell docker-compose exec -T postgresql-api psql -X -A -t -U "${API_POSTGRES_USER}" -c "select id from scenarios where name = 'Example scenario 1 Project 1 Org 1'"); \
 	USERID=$(shell docker-compose exec -T postgresql-api psql -X -A -t -U "${API_POSTGRES_USER}" -c "select id from users limit 1"); \
 	echo "appending data for scenario with id $${SCENARIOID}"; \
-	sed -e "s/\$$user/$$USERID/g" -e "s/\$$scenario/$$SCENARIOID/g" api/test/fixtures/test-geodata.sql | docker-compose exec -T postgresql-geo-api psql -U "${GEO_POSTGRES_USER}";
+	sed -e "s/\$$user/00000000-0000-0000-0000-000000000000/g" -e "s/\$$scenario/$$SCENARIOID/g" api/test/fixtures/test-geodata.sql | docker-compose exec -T postgresql-geo-api psql -U "${GEO_POSTGRES_USER}";
 
 # need notebook service to execute a expecific notebook. this requires a full geodb
 generate-geo-test-data: extract-geo-test-data

--- a/api/test/fixtures/seed-all.sh
+++ b/api/test/fixtures/seed-all.sh
@@ -1,0 +1,23 @@
+apk add coreutils sed bash
+cd /opt
+export PGPASSWORD=$GEO_POSTGRES_PASSWORD
+# load test data - API
+psql -U $API_POSTGRES_USER < ./test-data.sql
+# load test data - geoprocessing db
+sed -e "s/\$user/00000000-0000-0000-0000-000000000000/g" ./test-admin-data.sql | psql -h postgresql-geo-api -U $GEO_POSTGRES_USER
+sed -e "s/\$user/00000000-0000-0000-0000-000000000000/g" ./test-wdpa-data.sql | psql -h postgresql-geo-api -U $GEO_POSTGRES_USER
+psql -U $API_POSTGRES_USER < ./test-features.sql
+for i in ./features/*.sql
+do
+	table_name=`basename -s .sql $i`;
+	featureid=`psql -X -A -t -U $API_POSTGRES_USER -c "select id from features where feature_class_name = '$table_name'"`
+	echo "appending data for ${table_name} with id ${featureid}";
+	sed -e "s/\$feature_id/${featureid}/g" ./features/${table_name}.sql | psql -h postgresql-geo-api -U $GEO_POSTGRES_USER
+done
+
+psql -X -A -t -U $API_POSTGRES_USER -c "select id from scenarios where name = 'Example scenario 1 Project 1 Org 1'"
+
+SCENARIOID=$(psql -X -A -t -U $API_POSTGRES_USER -c "select id from scenarios where name = 'Example scenario 1 Project 1 Org 1'")
+echo "appending data for scenario with id ${SCENARIOID}"
+sed -e "s/\$user/00000000-0000-0000-0000-000000000000/g" -e "s/\$scenario/${SCENARIOID}/g" ./test-geodata.sql | psql -h postgresql-geo-api -U $GEO_POSTGRES_USER
+	

--- a/docker-compose-test-e2e.yml
+++ b/docker-compose-test-e2e.yml
@@ -60,7 +60,7 @@ services:
       dockerfile: Dockerfile
     container_name: marxan-test-e2e-postgresql-api
     volumes:
-      - ./api/test/fixtures/test-data.sql:/docker-entrypoint-initdb.d/test-data.sql
+      - "./api/test/fixtures:/opt:ro"
     ports:
       - "${POSTGRES_API_SERVICE_PORT}:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,8 @@ services:
     ports:
       - "${POSTGRES_API_SERVICE_PORT}:5432"
     volumes:
-      - marxan-cloud-postgresql-api-data:/var/lib/postgresql/data
+      - "marxan-cloud-postgresql-api-data:/var/lib/postgresql/data"
+      - "./api/test/fixtures:/opt:ro"
     environment:
       - POSTGRES_PASSWORD=${API_POSTGRES_PASSWORD}
       - POSTGRES_USER=${API_POSTGRES_USER}


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

I have looked far and wide, but failed to understand why setting envvars from docker output (when we run `SELECT id...` via psql) works flakily when running `make test-e2e-api` locally and never works in GH Actions.

Since this blocks being able to run CI pipelines, I am proposing here to move the steps of a makefile recipe through which we inject data into a shell script that we run **within the api db container** (`api/test/fixtures/seed-all.sh`).

This also requires installing some APK packages - I'm currently doing this in the script itself.

In my view, this feels a bit hacky, but so far I couldn't think of a different (and not overengineered) way to make these tests work.

Data injection now works *locally* - I would suggest to review this PR and then merge it to see how things work in GH Actions.

We'll then need to fix/update some tests that are now failing, but this will be for a distinct PR.

### Testing instructions

`make test-e2e-api` should run migrations and inject seed data (no errors shown). Some tests will fail (see above - this is ok for now).

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file