### PR TITLE
Disable generate reports on test success

### DIFF
--- a/e2e-product-testing/cypress.json
+++ b/e2e-product-testing/cypress.json
@@ -1,3 +1,5 @@
 {
-  "testFiles": "**/*.{feature,features}"
+  "testFiles": "**/*.{feature,features}",
+  "screenshotOnRunFailure": true,
+  "videoUploadOnPasses": false
 }


### PR DESCRIPTION
Just 2 options in `cypress.json`

"screenshotOnRunFailure": true,    // Default is true, but letting this here if anytime anyone needs to change it
"videoUploadOnPasses": false

