### PR TITLE
MARXAN - 448 Cost surface - scenarioId guard

### DIFF
--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -6,7 +6,7 @@ import { Project } from './project.api.entity';
 import { CreateProjectDTO } from './dto/create.project.dto';
 import { UpdateProjectDTO } from './dto/update.project.dto';
 import { UsersService } from '@marxan-api/modules/users/users.service';
-import { ScenariosService } from '@marxan-api/modules/scenarios/scenarios.service';
+import { ScenariosCrudService } from '@marxan-api/modules/scenarios/scenarios-crud.service';
 import { PlanningUnitsService } from '@marxan-api/modules/planning-units/planning-units.service';
 import {
   AppBaseService,
@@ -41,8 +41,8 @@ export class ProjectsCrudService extends AppBaseService<
   constructor(
     @InjectRepository(Project)
     protected readonly repository: Repository<Project>,
-    @Inject(forwardRef(() => ScenariosService))
-    protected readonly scenariosService: ScenariosService,
+    @Inject(forwardRef(() => ScenariosCrudService))
+    protected readonly scenariosService: ScenariosCrudService,
     @Inject(UsersService) protected readonly usersService: UsersService,
     @Inject(AdminAreasService)
     protected readonly adminAreasService: AdminAreasService,

--- a/api/apps/api/src/modules/scenarios/dto/scenario-feature.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-feature.serializer.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { PaginationMeta } from '@marxan-api/utils/app-base.service';
+import { ScenarioFeaturesService } from '@marxan-api/modules/scenarios-features';
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+
+@Injectable()
+export class ScenarioFeatureSerializer {
+  constructor(private readonly featuresCrud: ScenarioFeaturesService) {}
+
+  async serialize(
+    entities: Partial<GeoFeature> | (Partial<GeoFeature> | undefined)[],
+    paginationMeta?: PaginationMeta,
+  ): Promise<any> {
+    return this.featuresCrud.serialize(entities, paginationMeta);
+  }
+}

--- a/api/apps/api/src/modules/scenarios/dto/scenario.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario.serializer.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ScenarioSerializer {}

--- a/api/apps/api/src/modules/scenarios/dto/scenario.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario.serializer.ts
@@ -1,4 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { PaginationMeta } from '@marxan-api/utils/app-base.service';
+import { Scenario } from '../scenario.api.entity';
+import { ScenariosCrudService } from '../scenarios-crud.service';
 
 @Injectable()
-export class ScenarioSerializer {}
+export class ScenarioSerializer {
+  constructor(private readonly scenariosCrudService: ScenariosCrudService) {}
+
+  async serialize(
+    entities: Partial<Scenario> | (Partial<Scenario> | undefined)[],
+    paginationMeta?: PaginationMeta,
+  ): Promise<any> {
+    return this.scenariosCrudService.serialize(entities, paginationMeta);
+  }
+}

--- a/api/apps/api/src/modules/scenarios/scenario.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenario.service.ts
@@ -1,0 +1,21 @@
+import { HttpService, Injectable } from '@nestjs/common';
+import { AppConfig } from '@marxan-api/utils/config.utils';
+import { ScenariosCrudService } from '@marxan-api/modules/scenarios/scenarios-crud.service';
+import { ScenarioFeaturesService } from '@marxan-api/modules/scenarios-features';
+import { AdjustPlanningUnits } from '@marxan-api/modules/analysis/entry-points/adjust-planning-units';
+import { CostSurfaceFacade } from '@marxan-api/modules/scenarios/cost-surface/cost-surface.facade';
+
+@Injectable()
+export class ScenarioService {
+  private readonly geoprocessingUrl: string = AppConfig.get(
+    'geoprocessing.url',
+  ) as string;
+
+  constructor(
+    public readonly service: ScenariosCrudService,
+    private readonly scenarioFeatures: ScenarioFeaturesService,
+    private readonly updatePlanningUnits: AdjustPlanningUnits,
+    private readonly costSurface: CostSurfaceFacade,
+    private readonly httpService: HttpService,
+  ) {}
+}

--- a/api/apps/api/src/modules/scenarios/scenario.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenario.service.ts
@@ -1,9 +1,19 @@
 import { HttpService, Injectable } from '@nestjs/common';
+import { FetchSpecification } from 'nestjs-base-service';
+
+import { AppInfoDTO } from '@marxan-api/dto/info.dto';
 import { AppConfig } from '@marxan-api/utils/config.utils';
-import { ScenariosCrudService } from '@marxan-api/modules/scenarios/scenarios-crud.service';
 import { ScenarioFeaturesService } from '@marxan-api/modules/scenarios-features';
 import { AdjustPlanningUnits } from '@marxan-api/modules/analysis/entry-points/adjust-planning-units';
-import { CostSurfaceFacade } from '@marxan-api/modules/scenarios/cost-surface/cost-surface.facade';
+import { apiGlobalPrefixes } from '@marxan-api/api.config';
+
+import { CostSurfaceFacade } from './cost-surface/cost-surface.facade';
+import { ScenariosCrudService } from './scenarios-crud.service';
+import { JobStatus } from './scenario.api.entity';
+
+import { CreateScenarioDTO } from './dto/create.scenario.dto';
+import { UpdateScenarioDTO } from './dto/update.scenario.dto';
+import { UpdateScenarioPlanningUnitLockStatusDto } from './dto/update-scenario-planning-unit-lock-status.dto';
 
 @Injectable()
 export class ScenarioService {
@@ -12,10 +22,96 @@ export class ScenarioService {
   ) as string;
 
   constructor(
-    public readonly service: ScenariosCrudService,
+    private readonly crudService: ScenariosCrudService,
     private readonly scenarioFeatures: ScenarioFeaturesService,
     private readonly updatePlanningUnits: AdjustPlanningUnits,
     private readonly costSurface: CostSurfaceFacade,
     private readonly httpService: HttpService,
   ) {}
+
+  async findAll(fetchSpecification: FetchSpecification) {
+    return this.crudService.findAllPaginated(fetchSpecification);
+  }
+
+  async getById(scenarioId: string, fetchSpecification?: FetchSpecification) {
+    return this.crudService.getById(scenarioId, fetchSpecification);
+  }
+
+  async remove(scenarioId: string): Promise<void> {
+    await this.assertScenario(scenarioId);
+    return this.crudService.remove(scenarioId);
+  }
+
+  async create(input: CreateScenarioDTO, info: AppInfoDTO) {
+    return this.crudService.create(input, info);
+  }
+
+  async update(scenarioId: string, input: UpdateScenarioDTO) {
+    await this.assertScenario(scenarioId);
+    return this.crudService.update(scenarioId, input);
+  }
+
+  async getFeatures(scenarioId: string) {
+    await this.assertScenario(scenarioId);
+    return (
+      await this.scenarioFeatures.findAll(undefined, {
+        params: {
+          scenarioId,
+        },
+      })
+    )[0];
+  }
+
+  async getPendingJobs(_scenarioId: string) {
+    return {
+      status: JobStatus.running,
+    };
+  }
+
+  async changeLockStatus(
+    scenarioId: string,
+    input: UpdateScenarioPlanningUnitLockStatusDto,
+  ) {
+    await this.assertScenario(scenarioId);
+    // TODO implement more flexible error results to propagate 4xx
+    await this.updatePlanningUnits.update(scenarioId, {
+      include: {
+        geo: input.byGeoJson?.include,
+        pu: input.byId?.include,
+      },
+      exclude: {
+        pu: input.byId?.exclude,
+        geo: input.byGeoJson?.exclude,
+      },
+    });
+    return;
+  }
+
+  processCostSurfaceShapefile(scenarioId: string, file: Express.Multer.File) {
+    this.costSurface.convert(scenarioId, file);
+    return;
+  }
+
+  async uploadLockInShapeFile(scenarioId: string, file: Express.Multer.File) {
+    await this.assertScenario(scenarioId);
+    /**
+     * @validateStatus is required for HttpService to not reject and wrap geoprocessing's response
+     * in case a shapefile is not validated and a status 4xx is sent back.
+     */
+    const { data: geoJson } = await this.httpService
+      .post(
+        `${this.geoprocessingUrl}${apiGlobalPrefixes.v1}/planning-units/planning-unit-shapefile`,
+        file,
+        {
+          headers: { 'Content-Type': 'application/json' },
+          validateStatus: (status) => status <= 499,
+        },
+      )
+      .toPromise();
+    return geoJson;
+  }
+
+  private async assertScenario(scenarioId: string) {
+    await this.crudService.getById(scenarioId);
+  }
 }

--- a/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
@@ -29,7 +29,7 @@ type ScenarioFilterKeys = keyof Pick<
 type ScenarioFilters = Record<ScenarioFilterKeys, string[]>;
 
 @Injectable()
-export class ScenariosService extends AppBaseService<
+export class ScenariosCrudService extends AppBaseService<
   Scenario,
   CreateScenarioDTO,
   UpdateScenarioDTO,

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -20,7 +20,7 @@ import {
   ScenarioResult,
 } from './scenario.api.entity';
 import { Request } from 'express';
-import { ScenariosService } from './scenarios.service';
+import { ScenariosCrudService } from './scenarios-crud.service';
 import {
   FetchSpecification,
   ProcessFetchSpecification,
@@ -56,22 +56,14 @@ import { ApiConsumesShapefile } from '@marxan-api/decorators/shapefile.decorator
 import { CostSurfaceFacade } from './cost-surface/cost-surface.facade';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AppConfig } from '@marxan-api/utils/config.utils';
+import { ScenarioService } from '@marxan-api/modules/scenarios/scenario.service';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
 @ApiTags(scenarioResource.className)
 @Controller(`${apiGlobalPrefixes.v1}/scenarios`)
 export class ScenariosController {
-  private readonly geoprocessingUrl: string = AppConfig.get(
-    'geoprocessing.url',
-  ) as string;
-  constructor(
-    public readonly service: ScenariosService,
-    private readonly scenarioFeatures: ScenarioFeaturesService,
-    private readonly updatePlanningUnits: AdjustPlanningUnits,
-    private readonly costSurface: CostSurfaceFacade,
-    private readonly httpService: HttpService,
-  ) {}
+  constructor(private readonly scenariosService: ScenarioService) {}
 
   @ApiOperation({
     description: 'Find all scenarios',
@@ -165,6 +157,7 @@ export class ScenariosController {
       .toPromise();
     return geoJson;
   }
+
   @ApiOperation({ description: 'Update scenario' })
   @ApiOkResponse({ type: ScenarioResult })
   @Patch(':id')

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -49,7 +49,7 @@ import { uploadOptions } from '@marxan-api/utils/file-uploads.utils';
 import { ShapefileGeoJSONResponseDTO } from './dto/shapefile.geojson.response.dto';
 import { ApiConsumesShapefile } from '@marxan-api/decorators/shapefile.decorator';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ScenarioService } from './scenario.service';
+import { ScenariosService } from './scenarios.service';
 import { ScenarioSerializer } from './dto/scenario.serializer';
 import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 
@@ -59,7 +59,7 @@ import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 @Controller(`${apiGlobalPrefixes.v1}/scenarios`)
 export class ScenariosController {
   constructor(
-    private readonly service: ScenarioService,
+    private readonly service: ScenariosService,
     private readonly scenarioSerializer: ScenarioSerializer,
     private readonly scenarioFeatureSerializer: ScenarioFeatureSerializer,
   ) {}
@@ -83,7 +83,7 @@ export class ScenariosController {
   async findAll(
     @ProcessFetchSpecification() fetchSpecification: FetchSpecification,
   ): Promise<ScenarioResult> {
-    const results = await this.service.findAll(fetchSpecification);
+    const results = await this.service.findAllPaginated(fetchSpecification);
     return this.scenarioSerializer.serialize(results.data, results.metadata);
   }
 

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -4,7 +4,7 @@ import { CqrsModule } from '@nestjs/cqrs';
 
 import { ScenariosController } from './scenarios.controller';
 import { Scenario } from './scenario.api.entity';
-import { ScenariosService } from './scenarios.service';
+import { ScenariosCrudService } from './scenarios-crud.service';
 import { UsersModule } from '@marxan-api/modules/users/users.module';
 import { Project } from '@marxan-api/modules/projects/project.api.entity';
 import { ProtectedAreasModule } from '@marxan-api/modules/protected-areas/protected-areas.module';
@@ -14,6 +14,8 @@ import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
 import { WdpaAreaCalculationService } from './wdpa-area-calculation.service';
 import { AnalysisModule } from '../analysis/analysis.module';
 import { CostSurfaceModule } from './cost-surface/cost-surface.module';
+import { ScenarioService } from './scenario.service';
+import { ScenarioSerializer } from './dto/scenario.serializer';
 
 @Module({
   imports: [
@@ -27,8 +29,14 @@ import { CostSurfaceModule } from './cost-surface/cost-surface.module';
     CostSurfaceModule,
     HttpModule,
   ],
-  providers: [ScenariosService, ProxyService, WdpaAreaCalculationService],
+  providers: [
+    ScenarioService,
+    ScenariosCrudService,
+    ProxyService,
+    WdpaAreaCalculationService,
+    ScenarioSerializer,
+  ],
   controllers: [ScenariosController],
-  exports: [ScenariosService],
+  exports: [ScenariosCrudService, ScenarioService],
 })
 export class ScenariosModule {}

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -16,6 +16,7 @@ import { AnalysisModule } from '../analysis/analysis.module';
 import { CostSurfaceModule } from './cost-surface/cost-surface.module';
 import { ScenarioService } from './scenario.service';
 import { ScenarioSerializer } from './dto/scenario.serializer';
+import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { ScenarioSerializer } from './dto/scenario.serializer';
     ProxyService,
     WdpaAreaCalculationService,
     ScenarioSerializer,
+    ScenarioFeatureSerializer,
   ],
   controllers: [ScenariosController],
   exports: [ScenariosCrudService, ScenarioService],

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -14,7 +14,7 @@ import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
 import { WdpaAreaCalculationService } from './wdpa-area-calculation.service';
 import { AnalysisModule } from '../analysis/analysis.module';
 import { CostSurfaceModule } from './cost-surface/cost-surface.module';
-import { ScenarioService } from './scenario.service';
+import { ScenariosService } from './scenarios.service';
 import { ScenarioSerializer } from './dto/scenario.serializer';
 import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 
@@ -31,7 +31,7 @@ import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
     HttpModule,
   ],
   providers: [
-    ScenarioService,
+    ScenariosService,
     ScenariosCrudService,
     ProxyService,
     WdpaAreaCalculationService,
@@ -39,6 +39,6 @@ import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
     ScenarioFeatureSerializer,
   ],
   controllers: [ScenariosController],
-  exports: [ScenariosCrudService, ScenarioService],
+  exports: [ScenariosCrudService, ScenariosService],
 })
 export class ScenariosModule {}

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -16,7 +16,7 @@ import { UpdateScenarioDTO } from './dto/update.scenario.dto';
 import { UpdateScenarioPlanningUnitLockStatusDto } from './dto/update-scenario-planning-unit-lock-status.dto';
 
 @Injectable()
-export class ScenarioService {
+export class ScenariosService {
   private readonly geoprocessingUrl: string = AppConfig.get(
     'geoprocessing.url',
   ) as string;
@@ -29,7 +29,7 @@ export class ScenarioService {
     private readonly httpService: HttpService,
   ) {}
 
-  async findAll(fetchSpecification: FetchSpecification) {
+  async findAllPaginated(fetchSpecification: FetchSpecification) {
     return this.crudService.findAllPaginated(fetchSpecification);
   }
 


### PR DESCRIPTION
Similar to `projects`:
* move current service to `crud-service` and wrap existing functions,
* the ones that act on a given `scenarioId` received existing `guard` which verifies existence of given Scenario,
* move serializers to standalone classes
* leaves space for ACL stuff
* "fixed" spec for changing planning unit's inclusivity (by id / geo) - it was running without existing scenario id, added check prevents that