### PR TITLE
feat(api): allow to get scenarios solutions results

### DIFF
--- a/api/apps/api/src/modules/scenarios/dto/scenario-solution-result.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-solution-result.dto.ts
@@ -1,0 +1,46 @@
+import {
+  ApiExtraModels,
+  ApiProperty,
+  getSchemaPath,
+  refs,
+} from '@nestjs/swagger';
+import { ScenariosOutputResultsGeoEntity } from '@marxan/scenarios-planning-unit';
+import { oneOf } from 'purify-ts';
+
+class ScenarioSolutionsDataDto {
+  @ApiProperty()
+  type: 'solutions' = 'solutions';
+
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({
+    isArray: true,
+    type: () => ScenariosOutputResultsGeoEntity,
+  })
+  attributes!: ScenariosOutputResultsGeoEntity[];
+}
+
+class ScenarioSolutionDataDto {
+  @ApiProperty()
+  type: 'solution' = 'solution';
+
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({
+    type: () => ScenariosOutputResultsGeoEntity,
+  })
+  attributes!: ScenariosOutputResultsGeoEntity;
+}
+
+@ApiExtraModels(ScenarioSolutionsDataDto, ScenarioSolutionDataDto)
+export class ScenarioSolutionResultDto {
+  @ApiProperty({
+    oneOf: [
+      { $ref: getSchemaPath(ScenarioSolutionsDataDto) },
+      { $ref: getSchemaPath(ScenarioSolutionDataDto) },
+    ],
+  })
+  data!: ScenarioSolutionsDataDto | ScenarioSolutionDataDto;
+}

--- a/api/apps/api/src/modules/scenarios/dto/scenario-solution-result.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-solution-result.dto.ts
@@ -1,11 +1,5 @@
-import {
-  ApiExtraModels,
-  ApiProperty,
-  getSchemaPath,
-  refs,
-} from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import { ScenariosOutputResultsGeoEntity } from '@marxan/scenarios-planning-unit';
-import { oneOf } from 'purify-ts';
 
 class ScenarioSolutionsDataDto {
   @ApiProperty()

--- a/api/apps/api/src/modules/scenarios/dto/scenario-solution.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-solution.serializer.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { PaginationMeta } from '@marxan-api/utils/app-base.service';
+import { ScenariosOutputResultsGeoEntity } from '@marxan/scenarios-planning-unit';
+import { SolutionResultCrudService } from '../solutions-result/solution-result-crud.service';
+
+@Injectable()
+export class ScenarioSolutionSerializer {
+  constructor(
+    private readonly scenariosSolutionsCrudService: SolutionResultCrudService,
+  ) {}
+
+  async serialize(
+    entities:
+      | Partial<ScenariosOutputResultsGeoEntity>
+      | (Partial<ScenariosOutputResultsGeoEntity> | undefined)[],
+    paginationMeta?: PaginationMeta,
+  ): Promise<any> {
+    return this.scenariosSolutionsCrudService.serialize(
+      entities,
+      paginationMeta,
+    );
+  }
+}

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -28,6 +28,7 @@ import {
   ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { apiGlobalPrefixes } from '@marxan-api/api.config';
@@ -51,7 +52,6 @@ import { ScenarioSerializer } from './dto/scenario.serializer';
 import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 import { ScenarioFeatureResultDto } from './dto/scenario-feature-result.dto';
 import { ScenarioSolutionResultDto } from './dto/scenario-solution-result.dto';
-import { ApiImplicitQuery } from '@nestjs/swagger/dist/decorators/api-implicit-query.decorator';
 import { ScenarioSolutionSerializer } from './dto/scenario-solution.serializer';
 
 @UseGuards(JwtAuthGuard)
@@ -181,12 +181,12 @@ export class ScenariosController {
   @ApiOkResponse({
     type: ScenarioSolutionResultDto,
   })
-  @ApiImplicitQuery({
+  @ApiQuery({
     name: 'best',
     required: false,
     type: Boolean,
   })
-  @ApiImplicitQuery({
+  @ApiQuery({
     name: 'most-different',
     required: false,
     type: Boolean,

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -18,6 +18,10 @@ import { ScenariosService } from './scenarios.service';
 import { ScenarioSerializer } from './dto/scenario.serializer';
 import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 import { CostSurfaceTemplateModule } from './cost-surface-template';
+import { SolutionResultCrudService } from './solutions-result/solution-result-crud.service';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { ScenariosOutputResultsGeoEntity } from '@marxan/scenarios-planning-unit';
+import { ScenarioSolutionSerializer } from './dto/scenario-solution.serializer';
 
 @Module({
   imports: [
@@ -25,6 +29,10 @@ import { CostSurfaceTemplateModule } from './cost-surface-template';
     ProtectedAreasModule,
     forwardRef(() => ProjectsModule),
     TypeOrmModule.forFeature([Project, Scenario]),
+    TypeOrmModule.forFeature(
+      [ScenariosOutputResultsGeoEntity],
+      DbConnections.geoprocessingDB,
+    ),
     UsersModule,
     ScenarioFeaturesModule,
     AnalysisModule,
@@ -39,6 +47,8 @@ import { CostSurfaceTemplateModule } from './cost-surface-template';
     WdpaAreaCalculationService,
     ScenarioSerializer,
     ScenarioFeatureSerializer,
+    SolutionResultCrudService,
+    ScenarioSolutionSerializer,
   ],
   controllers: [ScenariosController],
   exports: [ScenariosCrudService, ScenariosService],

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -13,6 +13,7 @@ import { ScenariosCrudService } from './scenarios-crud.service';
 import { CreateScenarioDTO } from './dto/create.scenario.dto';
 import { UpdateScenarioDTO } from './dto/update.scenario.dto';
 import { UpdateScenarioPlanningUnitLockStatusDto } from './dto/update-scenario-planning-unit-lock-status.dto';
+import { SolutionResultCrudService } from './solutions-result/solution-result-crud.service';
 
 @Injectable()
 export class ScenariosService {
@@ -26,6 +27,7 @@ export class ScenariosService {
     private readonly updatePlanningUnits: AdjustPlanningUnits,
     private readonly costSurface: CostSurfaceFacade,
     private readonly httpService: HttpService,
+    private readonly solutionsCrudService: SolutionResultCrudService,
   ) {}
 
   async findAllPaginated(fetchSpecification: FetchSpecification) {
@@ -103,7 +105,42 @@ export class ScenariosService {
     return geoJson;
   }
 
+  async findScenarioResults(
+    scenarioId: string,
+    runId: string,
+    fetchSpecification: FetchSpecification,
+  ) {
+    await this.assertScenario(scenarioId);
+    return this.solutionsCrudService.findAll(fetchSpecification);
+  }
+
   private async assertScenario(scenarioId: string) {
     await this.crudService.getById(scenarioId);
+  }
+
+  async getBestSolution(scenarioId: string, runId: string) {
+    await this.assertScenario(scenarioId);
+    // TODO correct implementation
+    return this.solutionsCrudService.getById(runId);
+  }
+
+  async getMostDifferentSolutions(
+    scenarioId: string,
+    runId: string,
+    fetchSpecification: FetchSpecification,
+  ) {
+    await this.assertScenario(scenarioId);
+    // TODO correct implementation
+    return this.solutionsCrudService.findAllPaginated(fetchSpecification);
+  }
+
+  async findAllSolutionsPaginated(
+    scenarioId: string,
+    runId: string,
+    fetchSpecification: FetchSpecification,
+  ) {
+    await this.assertScenario(scenarioId);
+    // TODO correct implementation
+    return this.solutionsCrudService.findAllPaginated(fetchSpecification);
   }
 }

--- a/api/apps/api/src/modules/scenarios/solutions-result/solution-result-crud.service.ts
+++ b/api/apps/api/src/modules/scenarios/solutions-result/solution-result-crud.service.ts
@@ -1,0 +1,72 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  AppBaseService,
+  JSONAPISerializerConfig,
+} from '@marxan-api/utils/app-base.service';
+
+import { AppInfoDTO } from '@marxan-api/dto/info.dto';
+import { AppConfig } from '@marxan-api/utils/config.utils';
+import { FetchSpecification } from 'nestjs-base-service';
+import { ScenariosOutputResultsGeoEntity } from '@marxan/scenarios-planning-unit';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+
+@Injectable()
+export class SolutionResultCrudService extends AppBaseService<
+  ScenariosOutputResultsGeoEntity,
+  never,
+  never,
+  AppInfoDTO
+> {
+  constructor(
+    @InjectRepository(
+      ScenariosOutputResultsGeoEntity,
+      DbConnections.geoprocessingDB,
+    )
+    protected readonly repository: Repository<ScenariosOutputResultsGeoEntity>,
+  ) {
+    super(repository, 'solution', 'solutions', {
+      logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
+    });
+  }
+
+  get serializerConfig(): JSONAPISerializerConfig<ScenariosOutputResultsGeoEntity> {
+    return {
+      attributes: [
+        'id',
+        'planningUnits',
+        'missingValues',
+        'cost',
+        'score',
+        'run',
+      ],
+      keyForAttribute: 'camelCase',
+    };
+  }
+
+  async extendFindAllResults(
+    entitiesAndCount: [ScenariosOutputResultsGeoEntity[], number],
+    _fetchSpecification?: FetchSpecification,
+    _info?: AppInfoDTO,
+  ): Promise<[ScenariosOutputResultsGeoEntity[], number]> {
+    const extendedEntities: Promise<ScenariosOutputResultsGeoEntity>[] = entitiesAndCount[0].map(
+      (entity) => this.extendGetByIdResult(entity),
+    );
+    return [await Promise.all(extendedEntities), entitiesAndCount[1]];
+  }
+
+  async extendGetByIdResult(
+    entity: ScenariosOutputResultsGeoEntity,
+    _fetchSpecification?: FetchSpecification,
+    _info?: AppInfoDTO,
+  ): Promise<ScenariosOutputResultsGeoEntity> {
+    // TODO implement
+    entity.planningUnits = 17;
+    entity.missingValues = 13;
+    entity.cost = 400;
+    entity.score = 999;
+    entity.run = 1;
+    return entity;
+  }
+}

--- a/api/apps/api/test/scenario-solutions/get-all-solutions.e2e-spec.ts
+++ b/api/apps/api/test/scenario-solutions/get-all-solutions.e2e-spec.ts
@@ -1,0 +1,47 @@
+import { PromiseType } from 'utility-types';
+import { createWorld } from './world';
+
+let world: PromiseType<ReturnType<typeof createWorld>>;
+
+beforeAll(async () => {
+  world = await createWorld();
+});
+
+describe(`When getting scenario solution results`, () => {
+  beforeAll(async () => {
+    await world.GivenScenarioHasSolutionsReady();
+  });
+
+  it(`should resolve solutions`, async () => {
+    const response = await world.WhenGettingSolutions();
+    expect(response.body.meta).toMatchInlineSnapshot(`
+      Object {
+        "page": 1,
+        "size": 25,
+        "totalItems": 1,
+        "totalPages": 1,
+      }
+    `);
+
+    expect(response.body.data.length).toEqual(1);
+    expect(response.body.data[0].attributes).toMatchInlineSnapshot(
+      {
+        id: expect.any(String),
+      },
+      `
+      Object {
+        "cost": 400,
+        "id": Any<String>,
+        "missingValues": 13,
+        "planningUnits": 17,
+        "run": 1,
+        "score": 999,
+      }
+    `,
+    );
+  });
+});
+
+afterAll(async () => {
+  await world?.cleanup();
+});

--- a/api/apps/api/test/scenario-solutions/world.ts
+++ b/api/apps/api/test/scenario-solutions/world.ts
@@ -1,0 +1,58 @@
+import { bootstrapApplication } from '../utils/api-application';
+import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
+import * as request from 'supertest';
+import { ScenariosTestUtils } from '../utils/scenarios.test.utils';
+import { GivenProjectExists } from '../steps/given-project';
+import { E2E_CONFIG } from '../e2e.config';
+import { v4 } from 'uuid';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ScenariosOutputResultsGeoEntity } from '@marxan/scenarios-planning-unit';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { Repository } from 'typeorm';
+
+export const createWorld = async () => {
+  const app = await bootstrapApplication();
+  const jwt = await GivenUserIsLoggedIn(app);
+  const { projectId, cleanup: cleanupProject } = await GivenProjectExists(
+    app,
+    jwt,
+  );
+  const scenario = await ScenariosTestUtils.createScenario(app, jwt, {
+    ...E2E_CONFIG.scenarios.valid.minimal(),
+    projectId,
+  });
+
+  const marxanOutputRepo: Repository<ScenariosOutputResultsGeoEntity> = app.get(
+    getRepositoryToken(
+      ScenariosOutputResultsGeoEntity,
+      DbConnections.geoprocessingDB,
+    ),
+  );
+
+  return {
+    GivenScenarioHasSolutionsReady: async () => {
+      // TODO implement again once all stuff is in place
+      await marxanOutputRepo.save(
+        marxanOutputRepo.create({
+          scenarioId: scenario.data.id,
+          runId: null,
+          scoreValue: 4000,
+        }),
+      );
+    },
+    WhenGettingSolutions: async () =>
+      request(app.getHttpServer())
+        .get(
+          `/api/v1/scenarios/${scenario.data.id}/marxan/run/${v4()}/solutions`,
+        )
+        .set('Authorization', `Bearer ${jwt}`),
+    cleanup: async () => {
+      await marxanOutputRepo.delete({
+        scenarioId: scenario.data.id,
+      });
+      await ScenariosTestUtils.deleteScenario(app, jwt, scenario.data.id);
+      await cleanupProject();
+      await app.close();
+    },
+  };
+};

--- a/api/libs/scenarios-planning-unit/src/index.ts
+++ b/api/libs/scenarios-planning-unit/src/index.ts
@@ -1,3 +1,4 @@
 export { LockStatus } from './lock-status.enum';
 export { ScenariosPlanningUnitGeoEntity } from './scenarios-planning-unit.geo.entity';
+export { ScenariosOutputResultsGeoEntity } from './scenarios-output-results.geo.entity';
 export * from './domain';

--- a/api/libs/scenarios-planning-unit/src/scenarios-output-results.geo.entity.ts
+++ b/api/libs/scenarios-planning-unit/src/scenarios-output-results.geo.entity.ts
@@ -1,0 +1,90 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+const tableName = `output_results_data`;
+
+@Entity(tableName)
+export class ScenariosOutputResultsGeoEntity {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /**
+   * references ScenariosPlanningUnitGeoEntity.planningUnitMarxanId
+   */
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: `puid`,
+  })
+  scenariosPuDataPlanningUnitMarxanId?: number | null;
+
+  @Column({
+    type: `uuid`,
+    nullable: true,
+    name: `scenario_id`,
+  })
+  scenarioId?: string | null;
+
+  /**
+   * TODO describe/change
+   */
+  @Column({
+    type: `uuid`,
+    nullable: true,
+    name: `run_id`,
+  })
+  runId?: string | null;
+
+  /**
+   * Score of the run
+   */
+  @Column({
+    type: `float8`,
+    nullable: true,
+    name: `value`,
+  })
+  scoreValue?: number | null;
+
+  /**
+   * TODO describe/change
+   */
+  @Column({
+    type: `jsonb`,
+    nullable: true,
+    name: `missing_values`,
+  })
+  missingValuesJsonb?: unknown | null;
+
+  /**
+   * API fields
+   * --------------------
+   */
+
+  @ApiProperty({
+    description: `The number of planning units contained in the solution for that run.`,
+  })
+  planningUnits!: number;
+
+  @ApiProperty({
+    description: `The number of planning units omitted in the solution for that run.`,
+  })
+  missingValues!: number;
+
+  // TODO describe
+  @ApiProperty({
+    description: `TODO`,
+  })
+  cost!: number;
+
+  @ApiProperty({
+    description: `Score value of the solution - the higher, the better.`,
+  })
+  score!: number;
+
+  // TODO describe
+  @ApiProperty({
+    description: ``,
+  })
+  run!: number;
+}


### PR DESCRIPTION
This PR mainly touches base implementation of an API layer and leaves space for actual implementation; includes:
* entity 
* dtos
* crud-service based on AppBaseService

It may happen that some `runId` or other fields aren't correct (according to discussion on slack) but I would opt in for leaving it for future PR once it is well settled.

![image](https://user-images.githubusercontent.com/3466388/122000187-b59e8300-cdae-11eb-8c78-eb92ceb8dd38.png)

![image](https://user-images.githubusercontent.com/3466388/122000801-aff56d00-cdaf-11eb-93df-9009722d9b7d.png)

![image](https://user-images.githubusercontent.com/3466388/122002144-a8cf5e80-cdb1-11eb-9036-6c550ea8ba24.png)
