### PR TITLE
feat(scenario): validate marxan input

### DIFF
--- a/api/apps/api/src/modules/scenarios/dto/create.scenario.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/create.scenario.dto.ts
@@ -12,6 +12,8 @@ import {
 } from 'class-validator';
 import { IUCNCategory } from '@marxan-api/modules/protected-areas/protected-area.geo.entity';
 import { JobStatus, ScenarioType } from '../scenario.api.entity';
+import { MarxanParameters } from '@marxan/marxan-input/marxan-parameters';
+import { ScenarioMetadataDto } from './scenario-metadata.dto';
 
 export class CreateScenarioDTO {
   @ApiProperty()
@@ -62,7 +64,7 @@ export class CreateScenarioDTO {
 
   @ApiPropertyOptional()
   @IsOptional()
-  metadata?: Record<string, unknown>;
+  metadata?: ScenarioMetadataDto;
 
   @ApiProperty({ enum: JobStatus, enumName: 'JobStatus' })
   @IsOptional()

--- a/api/apps/api/src/modules/scenarios/dto/scenario-metadata.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-metadata.dto.ts
@@ -1,0 +1,63 @@
+import {
+  ClumpType,
+  HeuristicType,
+  IterativeImprovementType,
+  MarxanParameters,
+  RunMode,
+} from '@marxan/marxan-input';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class MarxanParametersDto extends MarxanParameters {
+  @ApiPropertyOptional()
+  BLM?: number;
+  @ApiPropertyOptional()
+  PROP?: number;
+  @ApiPropertyOptional()
+  RANDSEED?: number;
+  @ApiPropertyOptional()
+  BESTSCORE?: number;
+  @ApiPropertyOptional()
+  NUMREPS?: number;
+  @ApiPropertyOptional()
+  NUMITNS?: number;
+  @ApiPropertyOptional()
+  STARTTEMP?: number;
+  @ApiPropertyOptional()
+  COOLFAC?: number;
+  @ApiPropertyOptional()
+  NUMTEMP?: number;
+  @ApiPropertyOptional()
+  COSTTHRESH?: number;
+  @ApiPropertyOptional()
+  THRESHPEN1?: number;
+  @ApiPropertyOptional()
+  THRESHPEN2?: number;
+  @ApiPropertyOptional({
+    enum: RunMode,
+    example:
+      RunMode.SimulatedAnnealingFollowedByHeuristicAndIterativeImprovement,
+  })
+  RUNMODE?: RunMode;
+  @ApiPropertyOptional()
+  MISSLEVEL?: number;
+  @ApiPropertyOptional({
+    enum: IterativeImprovementType,
+    example: IterativeImprovementType.Swap,
+  })
+  ITIMPTYPE?: IterativeImprovementType;
+  @ApiPropertyOptional({
+    enum: HeuristicType,
+    example: HeuristicType.AverageRarity,
+  })
+  HEURTYPE?: HeuristicType;
+  @ApiPropertyOptional({
+    enum: ClumpType,
+    example: ClumpType.PartialCountAsHalf,
+  })
+  CLUMPTYPE?: ClumpType;
+}
+
+export class ScenarioMetadataDto {
+  @ApiPropertyOptional()
+  marxanInputParameterFile?: MarxanParametersDto;
+}

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module, HttpModule } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CqrsModule } from '@nestjs/cqrs';
 
+import { MarxanInput } from '@marxan/marxan-input/marxan-input';
 import { ScenariosController } from './scenarios.controller';
 import { Scenario } from './scenario.api.entity';
 import { ScenariosCrudService } from './scenarios-crud.service';
@@ -39,6 +40,7 @@ import { CostSurfaceTemplateModule } from './cost-surface-template';
     WdpaAreaCalculationService,
     ScenarioSerializer,
     ScenarioFeatureSerializer,
+    MarxanInput,
   ],
   controllers: [ScenariosController],
   exports: [ScenariosCrudService, ScenariosService],

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -1,6 +1,8 @@
-import { HttpService, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpService, Injectable } from '@nestjs/common';
 import { FetchSpecification } from 'nestjs-base-service';
+import { classToClass } from 'class-transformer';
 
+import { MarxanInput, MarxanParameters } from '@marxan/marxan-input';
 import { AppInfoDTO } from '@marxan-api/dto/info.dto';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { ScenarioFeaturesService } from '@marxan-api/modules/scenarios-features';
@@ -26,6 +28,7 @@ export class ScenariosService {
     private readonly updatePlanningUnits: AdjustPlanningUnits,
     private readonly costSurface: CostSurfaceFacade,
     private readonly httpService: HttpService,
+    private readonly marxanInputValidator: MarxanInput,
   ) {}
 
   async findAllPaginated(fetchSpecification: FetchSpecification) {
@@ -42,12 +45,14 @@ export class ScenariosService {
   }
 
   async create(input: CreateScenarioDTO, info: AppInfoDTO) {
-    return this.crudService.create(input, info);
+    const validatedMetadata = this.getPayloadWithValidatedMetadata(input);
+    return this.crudService.create(validatedMetadata, info);
   }
 
   async update(scenarioId: string, input: UpdateScenarioDTO) {
     await this.assertScenario(scenarioId);
-    return this.crudService.update(scenarioId, input);
+    const validatedMetadata = this.getPayloadWithValidatedMetadata(input);
+    return this.crudService.update(scenarioId, validatedMetadata);
   }
 
   async getFeatures(scenarioId: string) {
@@ -105,5 +110,31 @@ export class ScenariosService {
 
   private async assertScenario(scenarioId: string) {
     await this.crudService.getById(scenarioId);
+  }
+
+  /**
+   * Throws
+   * @param input
+   * @private
+   */
+  private getPayloadWithValidatedMetadata<
+    T extends CreateScenarioDTO | UpdateScenarioDTO
+  >(input: T): T {
+    let marxanInput: MarxanParameters | undefined;
+    if (input.metadata?.marxanInputParameterFile) {
+      try {
+        marxanInput = this.marxanInputValidator.from(
+          input.metadata.marxanInputParameterFile,
+        );
+      } catch (errors) {
+        // TODO debt: shouldn't throw HttpException
+        throw new BadRequestException(errors);
+      }
+    }
+    const withValidatedMetadata: T = classToClass<T>(input);
+    if (withValidatedMetadata.metadata) {
+      withValidatedMetadata.metadata.marxanInputParameterFile = marxanInput;
+    }
+    return withValidatedMetadata;
   }
 }

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -136,5 +136,28 @@ describe('ScenariosModule (e2e)', () => {
 
       expect(resources).toBeUndefined();
     });
+
+    it('should not allow to create scenario with invalid marxan properties', async () => {
+      await request(app.getHttpServer())
+        .post('/api/v1/scenarios')
+        .set('Authorization', `Bearer ${jwtToken}`)
+        .send({
+          ...E2E_CONFIG.scenarios.valid.minimal(),
+          metadata: {
+            marxanInputParameterFile: {
+              HEURTYPE: 99999999213231,
+            },
+          },
+        })
+        // .expect(400)
+        .then((response) => {
+          console.log(response.body);
+          console.log(response.text);
+          expect(
+            response.body.errors[0].meta.rawError.response.message[0]
+              .constraints.isEnum,
+          ).toMatchInlineSnapshot(`"HEURTYPE must be a valid enum value"`);
+        });
+    });
   });
 });

--- a/api/libs/marxan-input/src/index.ts
+++ b/api/libs/marxan-input/src/index.ts
@@ -1,1 +1,9 @@
 export { MarxanFileInput } from './marxan-file-input';
+export {
+  RunMode,
+  ClumpType,
+  HeuristicType,
+  IterativeImprovementType,
+  MarxanParameters,
+} from './marxan-parameters';
+export { MarxanInput } from './marxan-input';

--- a/api/libs/marxan-input/src/marxan-parameters.ts
+++ b/api/libs/marxan-input/src/marxan-parameters.ts
@@ -1,4 +1,4 @@
-import { Allow, IsEnum, IsNumber, IsOptional } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional } from 'class-validator';
 
 export enum RunMode {
   SimulatedAnnealingFollowedByHeuristic = 0,


### PR DESCRIPTION
Marxan Input parameters are separated on purpose from the dto itself:
* (future) difference in dto shape
* allow to validate regardless of the transport layer (and validation pipe flag in our case as well)

![image](https://user-images.githubusercontent.com/3466388/122167478-4fcbfd00-ce7b-11eb-89ae-1778d856e85f.png)
