### PR TITLE
tag happy-path scenario specs

### DIFF
--- a/e2e-product-testing/cypress/integration/AdjustPlanningUnits.feature
+++ b/e2e-product-testing/cypress/integration/AdjustPlanningUnits.feature
@@ -11,18 +11,21 @@ Feature: 'Exclude' planning units
         And the user has selected 'Upload shapefile'
         When the user uploads an incorrect shapefile
         Then the user gets an error on screen
+    @happypath
     Scenario: draw lock-out area over map
         Given the user is in the Analysis tab 
         And the user has selected 'Exclude areas'
         And the user has selected 'Draw a shape on map'
         When the user draws on the map
         Then the area is displayed on the map and as a removable modal
+    @happypath
     Scenario: select individual lock-out planning units on map
         Given the user is in the Analysis tab 
         And the user has selected 'Exclude areas'
         And the user has selected 'Select planning units'
         When the user selects planning units on the map
         Then the area is displayed on the map and as a removable modal
+    @happypath
     Scenario: remove lock-out selection
         Given the user is in the Analysis tab 
         And the user has selected 'Exclude areas'
@@ -43,18 +46,21 @@ Feature: 'Include' planning units
         And the user has selected 'Upload shapefile'
         When the user uploads an incorrect shapefile
         Then the user gets an error on screen
+    @happypath
     Scenario: draw lock-in area over map
         Given the user is in the Analysis tab 
         And the user has selected 'Include areas'
         And the user has selected 'Draw a shape on map'
         When the user draws on the map
         Then the area is displayed on the map and as a removable modal
+    @happypath
     Scenario: select individual lock-in planning units on map
         Given the user is in the Analysis tab 
         And the user has selected 'Include areas'
         And the user has selected 'Select planning units'
         When the user selects planning units on the map
         Then the area is displayed on the map and as a removable modal
+    @happypath
     Scenario: remove lock-in selection
         Given the user is in the Analysis tab 
         And the user has selected 'Include areas'

--- a/e2e-product-testing/cypress/integration/Features.feature
+++ b/e2e-product-testing/cypress/integration/Features.feature
@@ -1,8 +1,10 @@
 Feature: Add features modal
+    @happypath
     Scenario: Open features modal
         Given the user is on the Features tab 1/2
         When the user selects 'Add features +'
-        Then the modal to add fetures opens
+        Then the modal to add features opens
+    @happypath
     Scenario: Add features from inside platform
         Given the user is on Add features modal (Marxan 06b)
         When the user selects 'Add' on the features he/she wants to add and Saves
@@ -17,6 +19,7 @@ Feature: Add features modal
         And the user has a correct shapefile
         When the user uploads his/her shp via 'Upload your own features'
         Then the features are added to the Features tab 1/2
+    @happypath
     Scenario: Search features from inside platform with correct keywords
         Given the user is on Add features modal (Marxan 06b)
         When the user uses the search bar and types a keyword that matches a feature
@@ -27,6 +30,7 @@ Feature: Add features modal
         Then no features are shown
 
 Feature: Split
+    @happypath
     Scenario: Split output
         Given the user is in Features tab 1/2
         And the user has added at least one Split layer (bioregional type)
@@ -36,12 +40,14 @@ Feature: Split
         Then each sub-category appears as a new separate feature in Features tab 1/2
 
 Feature: Intersection
+    @happypath
     Scenario: Open intersection modal
         Given the user is in Features tab 1/2
         And the user has added at least one Intersection layer (species type)
         When The user clicks on 'Select features +'
         Then the Intersection modal opens
    
+   @happypath
    Scenario: Intersection species with bioregional layer
         Given the user is in the Intersection modal
         And the user has selected a bioregional layer
@@ -52,29 +58,34 @@ Feature: Intersection
         Then each intersection of species with sub-category appears as a new separate feature in Features tab 1/2
 
 Feature: Set targets
+    @happypath
     Scenario: Set individual target
         Given the user is in Features tab 2/2
         When the user changes the value of the target of one feature
         Then the new target is displayed for that feature
 
+    @happypath
     Scenario: Set block target
         Given the user is in Features tab 2/2
         When the user changes the value in the section 'ALL TARGETS'
         Then the target of all the features display the new value
     
 Feature: Set FPF
+    @happypath
     Scenario: Set individual FPF
         Given the user is in Features tab 2/2
         When the user changes the value of the FPF of one feature
         Then the new FPF is displayed for that feature
 
+    @happypath
     Scenario: Set block FPF
         Given the user is in Features tab 2/2
         When the user changes the value in the section 'ALL FPF'
         Then the FPF of all the features display the new value
 
 Feature: Feature processing
+    @happypath
     Scenario: Feature processing
         Given the user is in Feature tab 2/2
-        When the user cliks 'Continue'
+        When the user clicks 'Continue'
         Then the user is sent to the Project dashboard to view the status of the Scenario

--- a/e2e-product-testing/cypress/integration/GapAnalysis.feature
+++ b/e2e-product-testing/cypress/integration/GapAnalysis.feature
@@ -1,14 +1,17 @@
 Feature: View pre-run gap Analysis
+    @happypath
     Scenario: Open gap analysis (default view all features)
         Given the user is in Analysis tab
         When the user opens the 'View gap Analysis' modal
         Then the gap analysis displays all the features as a bar graph and on map
 
+    @happypath
     Scenario: Gap analysis view selected features
         Given the user has opened the gap analysis 
         When the user selects on the open eye icon on the features bar graph
         Then the eye is crossed out and the layer is hidden in the map
     
+    @happypath
     Scenario: Close gap analysis
         Given the user has opened the gap analysis
         When the user clicks on 'Close gap analysis'

--- a/e2e-product-testing/cypress/integration/LogIn.feature
+++ b/e2e-product-testing/cypress/integration/LogIn.feature
@@ -7,7 +7,7 @@ Feature: Sign up
         And the user has introduced his/her information
         But the user hasn't accepted the Terms of service
         When the user clicks 'Sign up'
-        Then the user gets a notifciation on screen
+        Then the user gets a notification on screen
     Scenario: Accepted terms and conditions
         Given the user is in 'Sign up' page
         And the user has introduced his/her information
@@ -18,9 +18,9 @@ Feature: Sign up
         Given the user is in 'Sign up' page
         And the user has introduced his/her information
         And the user has accepted the Terms of service
-        And the user is alredy registered
+        And the user is already registered
         When the user clicks 'Sign up'
-        Then the user gets a notifciation on screen to 'Sign In'
+        Then the user gets a notification on screen to 'Sign In'
 
 Feature: validate account
     Scenario: correct email introduced
@@ -29,6 +29,7 @@ Feature: validate account
         Then the user's account is validated
 
 Feature: Sign in
+    @happypath
     Scenario: correct email and password
         Given the user is in 'Sign in' page
         When the user introduces a correct email and password
@@ -36,7 +37,7 @@ Feature: Sign in
     Scenario: wrong email or password
         Given the user is in 'Sign in' page
         When the user introduces an incorrect email or password
-        Then the user gets a notifciation on screen
+        Then the user gets a notification on screen
     Scenario: recover password email
         Given the user is in 'Sign in' page
         And The user has forgotten his/her password
@@ -45,4 +46,4 @@ Feature: Sign in
     Scenario: not registered email
         Given the user is in 'Sign in' page
         When the user introduces an email that is not registered
-        Then the user gets a notifciation on screenF
+        Then the user gets a notification on screenF

--- a/e2e-product-testing/cypress/integration/Project.feature
+++ b/e2e-product-testing/cypress/integration/Project.feature
@@ -1,8 +1,10 @@
 Feature: Project dashboard actions
+    @happypath
     Scenario: See user's projects
-        Given the user has logged-in succesfuly
+        Given the user has logged-in successfully
         When the user is redirected to his/her project dashboard
         Then the user sees all his/her projects
+    @happypath
     Scenario: Search a project with correct keywords
         Given the user is in his/her project dashboard
         When the user uses the search bar and types a keyword that matches a project
@@ -11,10 +13,12 @@ Feature: Project dashboard actions
         Given the user is in his/her project dashboard
         When the user uses the search bar and types a keyword that does not match any project
         Then No projects are shown 
+    @happypath
     Scenario: Eliminate a project
         Given the user is in his/her project dashboard
         When the user deletes a project  
         Then The project is no longer in the users's dashboard
+    @happypath
     Scenario: Create new project
         Given the user is in his/her project dashboard
         When the user creates a new project
@@ -37,6 +41,7 @@ Feature: Project dashboard actions
         Then the user receives a message on screen where to find instructions  
 
 Feature: Share projects
+    @happypath
     Scenario: Share a project with contributors with Marxan profile
         Given the user is inside a Project (Marxan 03a_hover)
         And the user is in Add/Remove Members
@@ -47,17 +52,19 @@ Feature: Share projects
         And the user is in Add/Remove Members
         When the user adds an email for a contributor without a Marxan profile
         Then the contributor receives an email notification
+    @happypath
     Scenario: Search contributors
         Given the user is inside a Project (Marxan 03a_hover)
         And the user is in Add/Remove Members
-        When the user is searches for a contributor by keywords
+        When the user searches for a contributor by keywords
         Then only the contributors that match the keywords appear
         
 Feature: Add new planning region
+    @happypath
     Scenario: User without planning region shp
         Given the user is in the New Project Landing page
         And the user is DOES NOT have a planning region shapefile
-        When the user selectS a country and sub-region
+        When the user selects a country and sub-region
         Then the user see the contour area on the map
     Scenario: User with correct planning region shp
         Given the user is in the New Project Landing page
@@ -71,6 +78,7 @@ Feature: Add new planning region
         Then the user gets an error message
     
 Feature: Add new planning grid
+    @happypath
     Scenario: User without grid and correct shape/size combination
         Given the user is in the New Project Landing page
         And the user has added a planning region
@@ -97,8 +105,9 @@ Feature: Add new planning grid
         Then the user gets an error message
 
 Feature: Save project
+    @happypath
     Scenario: Completed all steps
-        Given the user is in the New Porject Landing page
+        Given the user is in the New Project Landing page
         And the user has added both a planning region and a grid
         When the user Saves the project
         Then the project shows in his/her Project dashboard

--- a/e2e-product-testing/cypress/integration/ProtectedAreas.feature
+++ b/e2e-product-testing/cypress/integration/ProtectedAreas.feature
@@ -1,7 +1,8 @@
 Feature: Select Protected Areas  
+    @happypath
     Scenario: Add WDPA from platform
         Given the user is on the Protected Areas tab 1/2
-        When the user selects and saves the protected areas he/her wants to add
+        When the user selects and saves the protected areas he/she wants to add
         Then the selected pas show on the map with no threshold applied
     Scenario: Add PAs from upload
         Given the user is on the Protected Areas tab 1/2
@@ -9,7 +10,8 @@ Feature: Select Protected Areas
         Then the selected pas show on the map with no threshold applied
 
 Feature: Set Protected Areas threshold
+    @happypath
     Scenario: Set threshold
     Given the user is on the Protected Areas tab 2/2
     When the users sets a threshold value and saves
-    Then the map shows the result of crossing PAs and PUs areas at the thresholod value
+    Then the map shows the result of crossing PAs and PUs areas at the threshold value

--- a/e2e-product-testing/cypress/integration/RunScenario.feature
+++ b/e2e-product-testing/cypress/integration/RunScenario.feature
@@ -1,4 +1,5 @@
 Feature: Boundary length modifier
+    @happypath
     Scenario: Modify boundary length modifier with correct value
         Given the user is in the Run Scenario modal
         When the user writes a value between the max and min allowed
@@ -9,6 +10,7 @@ Feature: Boundary length modifier
         Then the user gets a notification on screen
 
 Feature: Number of repetitions
+    @happypath
     Scenario: Modify number of repetitions with correct value
         Given the user is in the Run Scenario modal
         When the user writes a value between the max and min allowed
@@ -33,6 +35,7 @@ Feature: Advanced settings
         Then the user gets a notification on screen
 
 Feature: Run Marxan
+    @happypath
     Scenario: run marxan
         Given the user is in the Run Scenario modal
         When the user selects 'Run Scenario'

--- a/e2e-product-testing/cypress/integration/Scenario.feature
+++ b/e2e-product-testing/cypress/integration/Scenario.feature
@@ -1,4 +1,5 @@
 Feature: Create New Scenario
+    @happypath
     Scenario: create scenario inside platform
         Given the user is on the Project landing page (Marxan 03a)
         And the user selects 'Create Scenario +'

--- a/e2e-product-testing/cypress/integration/Solutions.feature
+++ b/e2e-product-testing/cypress/integration/Solutions.feature
@@ -37,10 +37,12 @@ Feature: Modify unmet targets
 
 @solutions_table
 Feature: View solutions table
+    @happypath
     Scenario: Open solutions modal
         Given the user is in the Solutions tab
         When the user clicks on 'View solutions table'
         Then the solution table modal opens on screen
+    @happypath
     Scenario: View all solutions
         Given the user is in the solutions table modal
         When the user does not select the 'View 5 most different solutions'
@@ -49,11 +51,13 @@ Feature: View solutions table
         Given the user is in the solutions table modal
         When the user selects the 'View 5 most different solutions'
         Then the user sees the 5 most different solutions ordered by run number
+    @happypath
     Scenario: View solutions on map
         Given the user is in the solutions table modal
         When the user marks a solution in the 'View on map' column
         Then the solution is shown on the map
 
+@happypath
 Feature: Order solutions table
     Scenario: Order solutions by run
         Given the user is in the solutions table modal
@@ -76,19 +80,23 @@ Feature: Order solutions table
         When the user selects 'Order by: Missing values'
         Then the solutions are ordered by missing values (lowest to highest)
 
+@happypath
 Feature: Download solutions table
-    @happypath
     Scenario: Download complete solutions table
         Given the user is in the solutions table modal
         When the user selects 'Download solutions'
         Then the user receives a bundle zip with all the result files in his/her local machine
 
-@run_gap_analysis
+@run_gap_analysis @happypath
 Feature: View post-run gap Analysis
-    Scenario: Open gap analysis (default view all features)
+    Scenario: Open gap analysis (default view all features, graph)
         Given the user is in Solutions tab
         When the user opens the 'View run gap analysis' modal
-        Then the gap analysis displays all the features as a bar graph and on map
+        Then the gap analysis displays all the features as a bar graph
+    Scenario: Open gap analysis (default view all features, map)
+        Given the user is in Solutions tab
+        When the user opens the 'View run gap analysis' modal
+        Then the gap analysis displays all the features on a map
     Scenario: Gap analysis view selected features
         Given the user has opened the gap analysis 
         When the user selects on the open eye icon on the features bar graph
@@ -104,9 +112,8 @@ Feature: Download gap analysis
         When the user clicks on 'Download'
         Then the user downloads a pdf with the gap analysis to his/her local machine
 
-@download_files
+@download_files @happypath
 Feature: Download files
-    @happypath
     Scenario: Download input files
         Given the user is in the Solutions tab
         When the user clicks on 'Download Input files'

--- a/e2e-product-testing/cypress/integration/Solutions.feature
+++ b/e2e-product-testing/cypress/integration/Solutions.feature
@@ -5,6 +5,7 @@ Feature: View unmet targets
         And there are features that don't meet their target
         When the user clicks 'Go to features'
         Then the user is taken to the Feature tab
+    @happypath
     Scenario: View features with unmet targets
         Given the user has run marxan
         And there are unmet targets
@@ -13,6 +14,7 @@ Feature: View unmet targets
         Then only the features that don't meet the target are shown on display
 
 Feature: Modify unmet targets
+    @happypath
     Scenario: Mark as met
         Given the user has run marxan
         And there are unmet targets
@@ -25,6 +27,7 @@ Feature: Modify unmet targets
         And the user is in the Feature tab
         When the user increases the FPF in the 'Change FPF in all not met features' box
         Then the new FPF set by the user appears in all the unmet features
+    @happypath
     Scenario: Increase FPF in one feature
         Given the user has run marxan
         And there are unmet targets
@@ -74,6 +77,7 @@ Feature: Order solutions table
         Then the solutions are ordered by missing values (lowest to highest)
 
 Feature: Download solutions table
+    @happypath
     Scenario: Download complete solutions table
         Given the user is in the solutions table modal
         When the user selects 'Download solutions'
@@ -102,6 +106,7 @@ Feature: Download gap analysis
 
 @download_files
 Feature: Download files
+    @happypath
     Scenario: Download input files
         Given the user is in the Solutions tab
         When the user clicks on 'Download Input files'
@@ -119,7 +124,7 @@ Feature: View map layers
         Then that layer is not visible on the map
 
 @re-run
-Feature: Re-reun scenario
+Feature: Re-run scenario
     Given the user is in the Solutions tab
     When the user clicks Re-Run scenario
     Then the user is taken to the 'Run Scenario' modal


### PR DESCRIPTION
Given that wiring up specs to actual testing behaviour will take a while, I have tried to focus on the happy-path scenarios which should be key for MVP (I did overdo a bit towards the end of the user journey, from feature selection onwards, I think, but we can trim further as we go).

The idea here is to start wiring up the `@happypath` scenarios, leaving the rest for later, while still keeping, in the meanwhile, all the specs as a useful documentation of what we expect users to be able to do on the platform, in a language which is both machine and human friendly (I know, I never hear anyone in daily life talking in Gherkin given-when-then style, but I would say it's at least understandable if not really friendly 😅 ).