### PR TITLE
refactor: move scenario features data to shared lib

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-feature-set.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature-set.service.ts
@@ -15,7 +15,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Scenario } from '../scenarios/scenario.api.entity';
 import { EntityManager, Repository } from 'typeorm';
 import { GeoFeaturePropertySetService } from './geo-feature-property-sets.service';
-import { RemoteScenarioFeaturesData } from '../scenarios-features/entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { flattenDeep } from 'lodash';
 import { GeoprocessingOpSplitV1 } from './types/geo-feature.geoprocessing-operations.type';
 
@@ -87,7 +87,7 @@ export class GeoFeatureSetService {
   ): Promise<void> {
     await this.entityManager.transaction(async (transactionalEntityManager) => {
       const repository = transactionalEntityManager.getRepository(
-        RemoteScenarioFeaturesData,
+        ScenarioFeaturesData,
       );
       await repository.delete({ scenarioId });
       // First process features which can be used as they are (plain)
@@ -120,10 +120,10 @@ export class GeoFeatureSetService {
       featuresDataId: string;
       fpf: number;
       prop: number | undefined;
-    } & RemoteScenarioFeaturesData)[]
+    } & ScenarioFeaturesData)[]
   > {
     const repository = transactionalEntityManager.getRepository(
-      RemoteScenarioFeaturesData,
+      ScenarioFeaturesData,
     );
     return Promise.all(
       featureSpecification
@@ -163,7 +163,7 @@ export class GeoFeatureSetService {
     //   prop: number | undefined;
     // } & RemoteScenarioFeaturesData)[]
     const _repository = transactionalEntityManager.getRepository(
-      RemoteScenarioFeaturesData,
+      ScenarioFeaturesData,
     );
     return Promise.all(
       featureSpecification

--- a/api/apps/api/src/modules/geo-features/geo-feature.api.entity.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature.api.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 import { BaseServiceResource } from '@marxan-api/types/resource.interface';
+import { FeatureTags } from '@marxan/features';
 
 export const geoFeatureResource: BaseServiceResource = {
   className: 'GeoFeature',
@@ -10,11 +11,6 @@ export const geoFeatureResource: BaseServiceResource = {
   },
   moduleControllerPrefix: 'geo-features',
 };
-
-export enum FeatureTags {
-  bioregional = 'bioregional',
-  species = 'species',
-}
 
 export interface GeoFeatureProperty {
   key: string;

--- a/api/apps/api/src/modules/geo-features/geo-features.module.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.module.ts
@@ -17,13 +17,13 @@ import {
   EntityManagerToken,
   GeoFeatureSetService,
 } from './geo-feature-set.service';
-import { RemoteScenarioFeaturesData } from '../scenarios-features/entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { GeoFeaturePropertySetService } from './geo-feature-property-sets.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature(
-      [GeoFeatureGeometry, GeoFeaturePropertySet, RemoteScenarioFeaturesData],
+      [GeoFeatureGeometry, GeoFeaturePropertySet, ScenarioFeaturesData],
       apiConnections.geoprocessingDB.name,
     ),
     TypeOrmModule.forFeature([GeoFeature, Project, Scenario]),

--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -13,17 +13,14 @@ import {
   AppBaseService,
   JSONAPISerializerConfig,
 } from '@marxan-api/utils/app-base.service';
-import {
-  FeatureTags,
-  GeoFeature,
-  GeoFeatureProperty,
-} from './geo-feature.api.entity';
+import { GeoFeature, GeoFeatureProperty } from './geo-feature.api.entity';
 import { FetchSpecification } from 'nestjs-base-service';
 import { Project } from '@marxan-api/modules/projects/project.api.entity';
 import { apiConnections } from '@marxan-api/ormconfig';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { Scenario } from '../scenarios/scenario.api.entity';
 import { GeoFeaturePropertySetService } from './geo-feature-property-sets.service';
+import { FeatureTags } from '@marxan/features';
 
 const geoFeatureFilterKeyNames = [
   'featureClassName',

--- a/api/apps/api/src/modules/scenarios-features/__mocks__/scenario-features.view-data.ts
+++ b/api/apps/api/src/modules/scenarios-features/__mocks__/scenario-features.view-data.ts
@@ -1,9 +1,6 @@
 import { RemoteFeaturesData } from '../entities/remote-features-data.geo.entity';
-import { RemoteScenarioFeaturesData } from '../entities/remote-scenario-features-data.geo.entity';
-import {
-  FeatureTags,
-  GeoFeature,
-} from '../../geo-features/geo-feature.api.entity';
+import { FeatureTags, ScenarioFeaturesData } from '@marxan/features';
+import { GeoFeature } from '../../geo-features/geo-feature.api.entity';
 
 const featureIdMet = `feature-uuid-1-criteria-met`;
 const featureIdFailed = `feature-uuid-2-criteria-failed`;
@@ -12,7 +9,7 @@ const metaFeatureIdMet = `meta-feature-uuid-1-criteria-met`;
 const metaFeatureIdFailed = `meta-feature-uuid-1-criteria-failed`;
 
 type RawRemoteScenarioFeaturesData = Pick<
-  RemoteScenarioFeaturesData,
+  ScenarioFeaturesData,
   | 'id'
   | 'target'
   | 'scenarioId'

--- a/api/apps/api/src/modules/scenarios-features/entities/remote-connection-name.ts
+++ b/api/apps/api/src/modules/scenarios-features/entities/remote-connection-name.ts
@@ -1,3 +1,0 @@
-import { DbConnections } from '../../../ormconfig.connections';
-
-export const remoteConnectionName = DbConnections.geoprocessingDB;

--- a/api/apps/api/src/modules/scenarios-features/scenario-features.module.ts
+++ b/api/apps/api/src/modules/scenarios-features/scenario-features.module.ts
@@ -4,16 +4,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
 
-import { remoteConnectionName } from './entities/remote-connection-name';
-import { RemoteScenarioFeaturesData } from './entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { RemoteFeaturesData } from './entities/remote-features-data.geo.entity';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([GeoFeature]),
     TypeOrmModule.forFeature(
-      [RemoteScenarioFeaturesData, RemoteFeaturesData],
-      remoteConnectionName,
+      [ScenarioFeaturesData, RemoteFeaturesData],
+      DbConnections.geoprocessingDB,
     ),
   ],
   providers: [ScenarioFeaturesService],

--- a/api/apps/api/src/modules/scenarios-features/scenario-features.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios-features/scenario-features.service.spec.ts
@@ -1,9 +1,8 @@
 import { ScenarioFeaturesService } from './scenario-features.service';
 import { Repository } from 'typeorm';
-import { RemoteScenarioFeaturesData } from './entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { remoteConnectionName } from './entities/remote-connection-name';
 import { fakeQueryBuilder } from '../../utils/__mocks__/fake-query-builder';
 import { RemoteFeaturesData } from './entities/remote-features-data.geo.entity';
 import { GeoFeature } from '../geo-features/geo-feature.api.entity';
@@ -12,6 +11,7 @@ import {
   getValidNonGeoData,
   getValidRemoteFeatureData,
 } from './__mocks__/scenario-features.view-data';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
 
 let sut: ScenarioFeaturesService;
 let geoFeatureRepoMock: jest.Mocked<Repository<GeoFeature>>;
@@ -23,12 +23,12 @@ beforeAll(async () => {
   fakeResultResolver = jest.fn();
   const geoFeatureToken = getRepositoryToken(GeoFeature);
   const geoRemoteScenarioFeaturesRepoToken = getRepositoryToken(
-    RemoteScenarioFeaturesData,
-    remoteConnectionName,
+    ScenarioFeaturesData,
+    DbConnections.geoprocessingDB,
   );
   const geoRemoteFeaturesRepoToken = getRepositoryToken(
     RemoteFeaturesData,
-    remoteConnectionName,
+    DbConnections.geoprocessingDB,
   );
   const sandbox = await Test.createTestingModule({
     providers: [

--- a/api/apps/api/src/modules/scenarios-features/scenario-features.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/scenario-features.service.ts
@@ -7,16 +7,16 @@ import {
   JSONAPISerializerConfig,
 } from '../../utils/app-base.service';
 
-import { remoteConnectionName } from './entities/remote-connection-name';
 import { GeoFeature } from '../geo-features/geo-feature.api.entity';
-import { RemoteScenarioFeaturesData } from './entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { RemoteFeaturesData } from './entities/remote-features-data.geo.entity';
 import { UserSearchCriteria } from './search-criteria';
 import { AppConfig } from '../../utils/config.utils';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
 
 @Injectable()
 export class ScenarioFeaturesService extends AppBaseService<
-  RemoteScenarioFeaturesData,
+  ScenarioFeaturesData,
   never,
   never,
   UserSearchCriteria
@@ -24,10 +24,10 @@ export class ScenarioFeaturesService extends AppBaseService<
   constructor(
     @InjectRepository(GeoFeature)
     private readonly features: Repository<GeoFeature>,
-    @InjectRepository(RemoteFeaturesData, remoteConnectionName)
+    @InjectRepository(RemoteFeaturesData, DbConnections.geoprocessingDB)
     private readonly remoteFeature: Repository<RemoteFeaturesData>,
-    @InjectRepository(RemoteScenarioFeaturesData, remoteConnectionName)
-    private readonly remoteScenarioFeatures: Repository<RemoteScenarioFeaturesData>,
+    @InjectRepository(ScenarioFeaturesData, DbConnections.geoprocessingDB)
+    private readonly remoteScenarioFeatures: Repository<ScenarioFeaturesData>,
   ) {
     super(remoteScenarioFeatures, 'scenario_features', 'scenario_feature', {
       logging: { muteAll: AppConfig.get<boolean>('logging.muteAll', false) },
@@ -35,10 +35,10 @@ export class ScenarioFeaturesService extends AppBaseService<
   }
 
   setFilters(
-    query: SelectQueryBuilder<RemoteScenarioFeaturesData>,
+    query: SelectQueryBuilder<ScenarioFeaturesData>,
     filters?: FiltersSpecification['filter'],
     info?: UserSearchCriteria,
-  ): SelectQueryBuilder<RemoteScenarioFeaturesData> {
+  ): SelectQueryBuilder<ScenarioFeaturesData> {
     const scenarioId = info?.params?.scenarioId;
     if (scenarioId) {
       return query.andWhere(`${this.alias}.scenario_id = :scenarioId`, {
@@ -51,7 +51,7 @@ export class ScenarioFeaturesService extends AppBaseService<
   async extendFindAllResults(
     entitiesAndCount: [any[], number],
   ): Promise<[any[], number]> {
-    const scenarioFeaturesData = entitiesAndCount[0] as RemoteScenarioFeaturesData[];
+    const scenarioFeaturesData = entitiesAndCount[0] as ScenarioFeaturesData[];
     const featuresDataIds = scenarioFeaturesData.map(
       (rsfd) => rsfd.featuresDataId,
     );
@@ -98,7 +98,7 @@ export class ScenarioFeaturesService extends AppBaseService<
     ];
   }
 
-  get serializerConfig(): JSONAPISerializerConfig<RemoteScenarioFeaturesData> {
+  get serializerConfig(): JSONAPISerializerConfig<ScenarioFeaturesData> {
     return {
       attributes: [
         'description',
@@ -116,9 +116,9 @@ export class ScenarioFeaturesService extends AppBaseService<
   }
 
   #injectAndCompute = (
-    base: RemoteScenarioFeaturesData,
+    base: ScenarioFeaturesData,
     assign: GeoFeature,
-  ): RemoteScenarioFeaturesData => {
+  ): ScenarioFeaturesData => {
     const metArea = base?.currentArea ?? 0;
     const totalArea = base?.totalArea ?? 0;
     const targetPct = (base?.target ?? 0) / 100;

--- a/api/apps/api/src/modules/scenarios/input-files/input-files.module.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/input-files.module.ts
@@ -4,7 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { PlanningUnitsGeom } from '@marxan-jobs/planning-unit-geometry';
 import { ScenarioPuvsprGeoEntity } from '@marxan/scenario-puvspr';
-import { RemoteScenarioFeaturesData } from '@marxan-api/modules/scenarios-features/entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import {
   ScenariosPlanningUnitGeoEntity,
   ScenariosPuCostDataGeo,
@@ -27,7 +27,7 @@ import { InputFilesArchiverService } from './input-files-archiver.service';
       [
         PlanningUnitsGeom,
         ScenarioPuvsprGeoEntity,
-        RemoteScenarioFeaturesData,
+        ScenarioFeaturesData,
         ScenariosPlanningUnitGeoEntity,
         ScenariosPuCostDataGeo,
       ],

--- a/api/apps/api/src/modules/scenarios/input-files/spec.dat.service.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/spec.dat.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { RemoteScenarioFeaturesData } from '@marxan-api/modules/scenarios-features/entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { Repository } from 'typeorm';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 
 @Injectable()
 export class SpecDatService {
   constructor(
-    @InjectRepository(RemoteScenarioFeaturesData, DbConnections.geoprocessingDB)
-    private readonly scenarioFeaturesData: Repository<RemoteScenarioFeaturesData>,
+    @InjectRepository(ScenarioFeaturesData, DbConnections.geoprocessingDB)
+    private readonly scenarioFeaturesData: Repository<ScenarioFeaturesData>,
   ) {}
 
   async getSpecDatContent(scenarioId: string): Promise<string> {

--- a/api/apps/api/src/modules/scenarios/input-files/spec.data.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/spec.data.service.spec.ts
@@ -1,4 +1,4 @@
-import { RemoteScenarioFeaturesData } from '@marxan-api/modules/scenarios-features/entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { Repository } from 'typeorm';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -7,11 +7,11 @@ import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { SpecDatService } from './spec.dat.service';
 
 let sut: SpecDatService;
-let dataRepo: jest.Mocked<Repository<RemoteScenarioFeaturesData>>;
+let dataRepo: jest.Mocked<Repository<ScenarioFeaturesData>>;
 
 beforeEach(async () => {
   const token = getRepositoryToken(
-    RemoteScenarioFeaturesData,
+    ScenarioFeaturesData,
     DbConnections.geoprocessingDB,
   );
   const sandbox = await Test.createTestingModule({
@@ -50,7 +50,7 @@ describe(`when there is data available`, () => {
         fpf: 0.33,
         featuresDataId: '...',
         prop: 0.25,
-      } as RemoteScenarioFeaturesData,
+      } as ScenarioFeaturesData,
       {
         scenarioId: 'id',
         featureId: 1,
@@ -64,7 +64,7 @@ describe(`when there is data available`, () => {
         metadata: {
           sepdistance: 4000,
         },
-      } as RemoteScenarioFeaturesData,
+      } as ScenarioFeaturesData,
     ]);
   });
 

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -50,7 +50,7 @@ import {
 import { CreateScenarioDTO } from './dto/create.scenario.dto';
 import { UpdateScenarioDTO } from './dto/update.scenario.dto';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
-import { RemoteScenarioFeaturesData } from '../scenarios-features/entities/remote-scenario-features-data.geo.entity';
+import { ScenarioFeaturesData } from '@marxan/features';
 import { UpdateScenarioPlanningUnitLockStatusDto } from './dto/update-scenario-planning-unit-lock-status.dto';
 import { uploadOptions } from '@marxan-api/utils/file-uploads.utils';
 import { ShapefileGeoJSONResponseDTO } from './dto/shapefile.geojson.response.dto';
@@ -284,12 +284,12 @@ export class ScenariosController {
 
   @ApiOperation({ description: `Resolve scenario's features pre-gap data.` })
   @ApiOkResponse({
-    type: RemoteScenarioFeaturesData,
+    type: ScenarioFeaturesData,
   })
   @Get(':id/features')
   async getScenarioFeatures(
     @Param('id', ParseUUIDPipe) id: string,
-  ): Promise<Partial<RemoteScenarioFeaturesData>[]> {
+  ): Promise<Partial<ScenarioFeaturesData>[]> {
     return this.scenarioFeatureSerializer.serialize(
       await this.service.getFeatures(id),
     );

--- a/api/apps/api/test/jest-e2e.json
+++ b/api/apps/api/test/jest-e2e.json
@@ -1,6 +1,13 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "moduleDirectories": ["node_modules", "src"],
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "ts"
+  ],
+  "moduleDirectories": [
+    "node_modules",
+    "src"
+  ],
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
@@ -9,16 +16,36 @@
   },
   "moduleNameMapper": {
     "@marxan-api/(.*)": "<rootDir>/../src/$1",
-    "^@marxan/utils": ["<rootDir>/../../../libs/utils/src"],
-    "^@marxan/utils/(.*)$": ["<rootDir>/../../..//libs/utils/src/$1"],
-    "^@marxan/scenarios-planning-unit": ["<rootDir>/../../../libs/scenarios-planning-unit/src"],
-    "^@marxan/scenarios-planning-unit/(.*)$": ["<rootDir>/../../../libs/scenarios-planning-unit/src/$1"],
-    "^@marxan/admin-regions": ["<rootDir>/../../../libs/admin-regions/src"],
-    "^@marxan/admin-regions/(.*)$": ["<rootDir>/../../../libs/admin-regions/src/$1"],
-    "^@marxan/api-events": ["<rootDir>/../../../libs/api-events/src"],
-    "^@marxan/api-events/(.*)$": ["<rootDir>/../../../libs/api-events/src/$1"],
-    "^@marxan-jobs/planning-unit-geometry": ["<rootDir>/../../../libs/planning-unit-geometry/src"],
-    "^@marxan-jobs/planning-unit-geometry/(.*)$": ["<rootDir>/../../../libs/planning-unit-geometry/src/$1"],
+    "^@marxan/utils": [
+      "<rootDir>/../../../libs/utils/src"
+    ],
+    "^@marxan/utils/(.*)$": [
+      "<rootDir>/../../..//libs/utils/src/$1"
+    ],
+    "^@marxan/scenarios-planning-unit": [
+      "<rootDir>/../../../libs/scenarios-planning-unit/src"
+    ],
+    "^@marxan/scenarios-planning-unit/(.*)$": [
+      "<rootDir>/../../../libs/scenarios-planning-unit/src/$1"
+    ],
+    "^@marxan/admin-regions": [
+      "<rootDir>/../../../libs/admin-regions/src"
+    ],
+    "^@marxan/admin-regions/(.*)$": [
+      "<rootDir>/../../../libs/admin-regions/src/$1"
+    ],
+    "^@marxan/api-events": [
+      "<rootDir>/../../../libs/api-events/src"
+    ],
+    "^@marxan/api-events/(.*)$": [
+      "<rootDir>/../../../libs/api-events/src/$1"
+    ],
+    "^@marxan-jobs/planning-unit-geometry": [
+      "<rootDir>/../../../libs/planning-unit-geometry/src"
+    ],
+    "^@marxan-jobs/planning-unit-geometry/(.*)$": [
+      "<rootDir>/../../../libs/planning-unit-geometry/src/$1"
+    ],
     "@marxan/scenario-cost-surface/(.*)": "<rootDir>/../../../libs/scenario-cost-surface/src/$1",
     "@marxan/scenario-cost-surface": "<rootDir>/../../../libs/scenario-cost-surface/src",
     "@marxan/marxan-input/(.*)": "<rootDir>/../../../libs/marxan-input/src/$1",
@@ -29,6 +56,8 @@
     "@marxan/scenario-puvspr/(.*)": "<rootDir>/../../../libs/scenario-puvspr/src/$1",
     "@marxan/scenario-puvspr": "<rootDir>/../../../libs/scenario-puvspr/src",
     "@marxan/scenario-run-queue/(.*)": "<rootDir>/../../../libs/scenario-run-queue/src/$1",
-    "@marxan/scenario-run-queue": "<rootDir>/../../../libs/scenario-run-queue/src"
+    "@marxan/scenario-run-queue": "<rootDir>/../../../libs/scenario-run-queue/src",
+    "@marxan/features/(.*)": "<rootDir>/../../../libs/features/src/$1",
+    "@marxan/features": "<rootDir>/../../../libs/features/src"
   }
 }

--- a/api/apps/api/test/scenario-features/steps/when-scenario-has-pre-gap-data.ts
+++ b/api/apps/api/test/scenario-features/steps/when-scenario-has-pre-gap-data.ts
@@ -2,17 +2,17 @@ import { INestApplication } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { RemoteScenarioFeaturesData } from '../../../src/modules/scenarios-features/entities/remote-scenario-features-data.geo.entity';
-import { remoteConnectionName } from '../../../src/modules/scenarios-features/entities/remote-connection-name';
+import { ScenarioFeaturesData } from '@marxan/features';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
 
 export const WhenScenarioHasPreGapData = async (
   app: INestApplication,
 ): Promise<{
-  featuresData: RemoteScenarioFeaturesData[];
+  featuresData: ScenarioFeaturesData[];
   scenarioId: string;
 }> => {
-  const repo: Repository<RemoteScenarioFeaturesData> = await app.get(
-    getRepositoryToken(RemoteScenarioFeaturesData, remoteConnectionName),
+  const repo: Repository<ScenarioFeaturesData> = await app.get(
+    getRepositoryToken(ScenarioFeaturesData, DbConnections.geoprocessingDB),
   );
   const rows = await repo.find();
   if (rows.length === 0) {

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/geo-output.module.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/geo-output.module.ts
@@ -8,8 +8,10 @@ import { MarxanDirectory } from '../../marxan-directory.service';
 import { FileReader } from '../../file-reader';
 import { SolutionsReaderService } from './solutions/output-file-parsing/solutions-reader.service';
 import { PlanningUnitSelectionCalculatorService } from './solutions/solution-aggregation/planning-unit-selection-calculator.service';
+import { ScenarioFeaturesDataService } from './scenario-features/scenario-features-data.service';
 import { OutputScenariosPuDataGeoEntity } from '@marxan/marxan-output';
 import { ScenariosPlanningUnitGeoEntity } from '@marxan/scenarios-planning-unit';
+import { ScenarioFeaturesData } from '@marxan/features';
 
 @Module({
   imports: [
@@ -17,6 +19,7 @@ import { ScenariosPlanningUnitGeoEntity } from '@marxan/scenarios-planning-unit'
       MarxanExecutionMetadataGeoEntity,
       OutputScenariosPuDataGeoEntity,
       ScenariosPlanningUnitGeoEntity,
+      ScenarioFeaturesData,
     ]),
   ],
   providers: [
@@ -25,6 +28,7 @@ import { ScenariosPlanningUnitGeoEntity } from '@marxan/scenarios-planning-unit'
     MarxanDirectory,
     FileReader,
     SolutionsReaderService,
+    ScenarioFeaturesDataService,
     PlanningUnitSelectionCalculatorService,
   ],
   exports: [GeoOutputRepository],

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/geo-output.repository.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/geo-output.repository.ts
@@ -13,12 +13,14 @@ import {
   OutputScenariosPuDataGeoEntity,
 } from '@marxan/marxan-output';
 import { readFileSync } from 'fs';
+import { ScenarioFeaturesDataService } from './scenario-features/scenario-features-data.service';
 
 @Injectable()
 export class GeoOutputRepository {
   constructor(
     private readonly metadataArchiver: MetadataArchiver,
     private readonly solutionsReader: SolutionsReaderService,
+    private readonly scenarioFeaturesDataReader: ScenarioFeaturesDataService,
     private readonly planningUnitsStateCalculator: PlanningUnitSelectionCalculatorService,
     @InjectEntityManager(geoprocessingConnections.default)
     private readonly entityManager: EntityManager,
@@ -46,10 +48,20 @@ export class GeoOutputRepository {
     const planningUnitsState: PlanningUnitsSelectionState = await this.planningUnitsStateCalculator.consume(
       solutionsStream,
     );
+
+    // TODO grab data from ScenarioFeaturesDataService
+    const _sfds = await this.scenarioFeaturesDataReader.from(
+      workspace.workingDirectory,
+      scenarioId,
+    );
+
     return this.entityManager.transaction(async (transaction) => {
       await transaction.delete(OutputScenariosPuDataGeoEntity, {
         scenarioPuId: In(Object.keys(planningUnitsState)),
       });
+
+      // TODO clean ScenarioFeaturesData
+      // TODO add ScenarioFeaturesData new data
 
       await Promise.all(
         Object.entries(planningUnitsState).map(([scenarioPuId, data]) =>

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/__mocks__/sample-content.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/__mocks__/sample-content.ts
@@ -1,0 +1,12 @@
+/**
+ * output_mv00100.csv
+ */
+export const sampleContent = `"Conservation Feature","Feature Name","Target","Amount Held","Occurrence Target ","Occurrences Held","Separation Target ","Separation Achieved","Target Met","MPM"
+7,VALUE_7,0.000000,0.000000,0,0,0,3306597,,1.000000
+6,VALUE_6,0.000000,0.000000,0,0,0,3306597,,1.000000
+5,VALUE_5,0.500000,0.000000,0,0,0,3306597,no,0.000000
+4,VALUE_4,0.500000,30000.000000,0,1,0,3306597,yes,1.000000
+3,VALUE_3,0.500000,380000.000000,0,1,0,3306597,yes,1.000000
+2,VALUE_2,0.500000,880000.000000,0,1,0,3306597,yes,1.000000
+1,VALUE_1,0.500000,100000.000000,0,1,0,3306597,yes,1.000000
+`;

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/feature-id-to-scenario-feature-data.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/feature-id-to-scenario-feature-data.ts
@@ -1,0 +1,1 @@
+export type FeatureIdToScenarioFeatureData = Record<number, string>;

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/scenario-feature-data.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/scenario-feature-data.ts
@@ -1,0 +1,6 @@
+import { OutputScenariosFeaturesDataGeoEntity } from '@marxan/marxan-output';
+
+export type ScenarioFeatureData = Omit<
+  OutputScenariosFeaturesDataGeoEntity,
+  `id`
+>;

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/scenario-features-data.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/scenario-features-data.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { ScenarioFeatureData } from './scenario-feature-data';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ScenarioFeaturesData } from '@marxan/features';
+import { FeatureIdToScenarioFeatureData } from '@marxan-geoprocessing/marxan-sandboxed-runner/adapters/solutions-output/geo-output/scenario-features/feature-id-to-scenario-feature-data';
+
+@Injectable()
+export class ScenarioFeaturesDataService {
+  // iterate over all mv* files
+  // stream their content to transformer
+
+  constructor(
+    @InjectRepository(ScenarioFeaturesData)
+    private readonly scenarioFeatureData: Repository<ScenarioFeaturesData>,
+  ) {}
+
+  async from(
+    outputDirectory: string,
+    scenarioId: string,
+  ): Promise<ScenarioFeatureData[]> {
+    const planningUnits = await this.scenarioFeatureData.findAndCount({
+      where: {
+        scenarioId,
+      },
+      select: ['id', 'featureId'],
+    });
+    const _mapping = planningUnits[0].reduce<FeatureIdToScenarioFeatureData>(
+      (previousValue, sfd) => {
+        previousValue[sfd.featureId] = sfd.id;
+        return previousValue;
+      },
+      {},
+    );
+    console.log(`--- scenario features data mapping`, _mapping);
+    return [];
+  }
+}

--- a/api/apps/geoprocessing/test/jest-e2e.json
+++ b/api/apps/geoprocessing/test/jest-e2e.json
@@ -29,6 +29,8 @@
     "@marxan/planning-area-repository/(.*)": "<rootDir>/../../libs/planning-area-repository/src/$1",
     "@marxan/planning-area-repository": "<rootDir>/../../libs/planning-area-repository/src",
     "@marxan/scenario-run-queue/(.*)": "<rootDir>/../../libs/scenario-run-queue/src/$1",
-    "@marxan/scenario-run-queue": "<rootDir>/../../libs/scenario-run-queue/src"
+    "@marxan/scenario-run-queue": "<rootDir>/../../libs/scenario-run-queue/src",
+    "@marxan/features/(.*)": "<rootDir>/../../libs/features/src/$1",
+    "@marxan/features": "<rootDir>/../../libs/features/src"
   }
 }

--- a/api/libs/features/src/feature-tags.ts
+++ b/api/libs/features/src/feature-tags.ts
@@ -1,0 +1,4 @@
+export enum FeatureTags {
+  bioregional = 'bioregional',
+  species = 'species',
+}

--- a/api/libs/features/src/index.ts
+++ b/api/libs/features/src/index.ts
@@ -1,0 +1,2 @@
+export { FeatureTags } from './feature-tags';
+export { ScenarioFeaturesData } from './scenario-features-data.geo.entity';

--- a/api/libs/features/src/scenario-features-data.geo.entity.ts
+++ b/api/libs/features/src/scenario-features-data.geo.entity.ts
@@ -1,11 +1,9 @@
+import { FeatureTags } from '@marxan/features';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-import { FeatureTags } from '../../geo-features/geo-feature.api.entity';
 
-export const remoteScenarioFeaturesDataName = 'scenario_features_data';
-
-@Entity(remoteScenarioFeaturesDataName)
-export class RemoteScenarioFeaturesData {
+@Entity(`scenario_features_data`)
+export class ScenarioFeaturesData {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 

--- a/api/libs/features/tsconfig.lib.json
+++ b/api/libs/features/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/features"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/api/libs/marxan-output/src/index.ts
+++ b/api/libs/marxan-output/src/index.ts
@@ -1,3 +1,4 @@
 export { MarxanExecutionMetadataGeoEntity } from './marxan-execution-metadata.geo.entity';
 export { OutputScenariosPuDataGeoEntity } from './output-scenarios-pu-data.geo.entity';
+export { OutputScenariosFeaturesDataGeoEntity } from './output-scenarios-features-data.geo.entity';
 export { ResultRow, ExecutionResult } from './execution-result';

--- a/api/libs/marxan-output/src/output-scenarios-features-data.geo.entity.ts
+++ b/api/libs/marxan-output/src/output-scenarios-features-data.geo.entity.ts
@@ -1,0 +1,49 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity(`output_scenarios_features_data`)
+export class OutputScenariosFeaturesDataGeoEntity {
+  @PrimaryGeneratedColumn(`uuid`)
+  id!: string;
+
+  @Column({
+    type: `uuid`,
+    name: `feature_scenario_id`,
+  })
+  featureScenarioId!: string;
+
+  @Column({
+    type: `int`,
+    name: `run_id`,
+  })
+  runId!: number;
+
+  @Column({
+    type: `float8`,
+    name: `amount`,
+  })
+  amount?: number;
+
+  @Column({
+    type: `float8`,
+    name: `occurrences`,
+  })
+  occurrences?: number;
+
+  @Column({
+    type: `float8`,
+    name: `separation`,
+  })
+  separation?: number;
+
+  @Column({
+    type: `boolean`,
+    name: `target`,
+  })
+  target?: boolean;
+
+  @Column({
+    type: `float8`,
+    name: `mpm`,
+  })
+  mpm?: number;
+}

--- a/api/nest-cli.json
+++ b/api/nest-cli.json
@@ -124,6 +124,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/scenario-run-queue/tsconfig.lib.json"
       }
+    },
+    "features": {
+      "type": "library",
+      "root": "libs/features",
+      "entryFile": "index",
+      "sourceRoot": "libs/features/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/features/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -183,7 +183,9 @@
       "@marxan/scenario-puvspr/(.*)": "<rootDir>/libs/scenario-puvspr/src/$1",
       "@marxan/scenario-puvspr": "<rootDir>/libs/scenario-puvspr/src",
       "@marxan/scenario-run-queue/(.*)": "<rootDir>/libs/scenario-run-queue/src/$1",
-      "@marxan/scenario-run-queue": "<rootDir>/libs/scenario-run-queue/src"
+      "@marxan/scenario-run-queue": "<rootDir>/libs/scenario-run-queue/src",
+      "@marxan/features/(.*)": "<rootDir>/libs/features/src/$1",
+      "@marxan/features": "<rootDir>/libs/features/src"
     }
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -84,6 +84,12 @@
       ],
       "@marxan/scenario-run-queue/*": [
         "libs/scenario-run-queue/src/*"
+      ],
+      "@marxan/features": [
+        "libs/features/src"
+      ],
+      "@marxan/features/*": [
+        "libs/features/src/*"
       ]
     }
   },


### PR DESCRIPTION
Figured out that adding more would be hard to read the diff, thus adding standalone PR for moving things around and setting really dummy shell/plan for putting the data to the db.