### PR TITLE
front: add data on upload shapefile when create project [MARXAN-542]

### DIFF
--- a/app/layout/projects/new/form/planning-area-uploader/component.tsx
+++ b/app/layout/projects/new/form/planning-area-uploader/component.tsx
@@ -6,11 +6,12 @@ import { useDispatch } from 'react-redux';
 import { useUploadProjectPA } from 'hooks/projects';
 import { useToasts } from 'hooks/toast';
 
-import cx from 'classnames';
-import { motion } from 'framer-motion';
 import {
   setBbox, setUploadingPlanningArea, setMaxPuAreaSize, setMinPuAreaSize,
 } from 'store/slices/projects/new';
+
+import cx from 'classnames';
+import { motion } from 'framer-motion';
 
 import Icon from 'components/icon';
 import InfoButton from 'components/info-button';
@@ -63,15 +64,6 @@ export const PlanningAreUploader: React.FC<PlanningAreUploaderProps> = ({
 
     uploadProjectPAMutation.mutate({ data }, {
       onSuccess: ({ data: { data: g, id: PAid } }) => {
-        const mockMinPuAreaSize = 251;
-        const mockMaxPuAreaSize = 2311631;
-        const mockBbox = [
-          4.21875,
-          14.150390625,
-          2.8113711933311403,
-          12.811801316582619,
-        ];
-
         setLoading(false);
         setSuccessFile({ id: PAid, name: f.name });
         input.onChange(PAid);
@@ -86,9 +78,9 @@ export const PlanningAreUploader: React.FC<PlanningAreUploaderProps> = ({
         });
 
         dispatch(setUploadingPlanningArea(g));
-        dispatch(setBbox(mockBbox));
-        dispatch(setMinPuAreaSize(mockMinPuAreaSize));
-        dispatch(setMaxPuAreaSize(mockMaxPuAreaSize));
+        dispatch(setBbox(g.bbox));
+        dispatch(setMinPuAreaSize(g.marxanMetadata.minPuAreaSize));
+        dispatch(setMaxPuAreaSize(g.marxanMetadata.maxPuAreaSize));
 
         console.info('Shapefile uploaded', g);
       },


### PR DESCRIPTION
## Read bbox, minPuAreaSize, minPuAreaSize when upload shapefile on create project

### Feature relevant tickets
[MARXAN-542](https://vizzuality.atlassian.net/secure/RapidBoard.jspa?rapidView=38&projectKey=MARXAN&modal=detail&selectedIssue=MARXAN-542&quickFilter=71)