### PR TITLE
fix queries in scenario/pu linker to properly support custom planning areas

### DIFF
--- a/api/apps/api/src/modules/projects/project.api.entity.ts
+++ b/api/apps/api/src/modules/projects/project.api.entity.ts
@@ -27,7 +27,7 @@ export const projectResource: BaseServiceResource = {
 export enum PlanningUnitGridShape {
   square = 'square',
   hexagon = 'hexagon',
-  fromShapefile = 'from_shapefile',
+  fromShapefile = 'irregular',
 }
 
 @Entity('projects')

--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units-linker-service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units-linker-service.ts
@@ -113,7 +113,7 @@ export class ScenarioPlanningUnitsLinkerService {
     ) {
       return {
         planningUnitSelectionQueryPart: `type = '${PlanningUnitGridShape.fromShapefile}' and project_id = '${project.id}'`,
-        planningUnitIntersectionQueryPart: `(select the_geom from admin_regions ${this.getQueryPartForAdminAreaSelectionByLevel(
+        planningUnitIntersectionQueryPart: `(select the_geom from admin_regions where ${this.getQueryPartForAdminAreaSelectionByLevel(
           project,
         )})`,
       };
@@ -125,7 +125,7 @@ export class ScenarioPlanningUnitsLinkerService {
     ) {
       return {
         planningUnitSelectionQueryPart: `type = '${project.planningUnitGridShape}' and size = ${project.planningUnitAreakm2}`,
-        planningUnitIntersectionQueryPart: `(select the_geom from admin_regions ${this.getQueryPartForAdminAreaSelectionByLevel(
+        planningUnitIntersectionQueryPart: `(select the_geom from admin_regions where ${this.getQueryPartForAdminAreaSelectionByLevel(
           project,
         )})`,
       };
@@ -148,15 +148,15 @@ export class ScenarioPlanningUnitsLinkerService {
     const adminAreaLevel = AdminAreasService.levelFromId(adminAreaId);
 
     if (adminAreaLevel === 0) {
-      return `where gid_0 = '${adminAreaId}' and gid_1 is null and gid_2 is null`;
+      return `gid_0 = '${adminAreaId}' and gid_1 is null and gid_2 is null`;
     }
 
     if (adminAreaLevel === 1) {
-      return `where gid_1 = '${adminAreaId}' and gid_2 is null`;
+      return `gid_1 = '${adminAreaId}' and gid_2 is null`;
     }
 
     if (adminAreaLevel === 2) {
-      return `where gid_2 = '${adminAreaId}'`;
+      return `gid_2 = '${adminAreaId}'`;
     }
   }
 

--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units-linker-service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units-linker-service.ts
@@ -88,46 +88,46 @@ export class ScenarioPlanningUnitsLinkerService {
      * the planning area.
      */
     if (
-      this.isProjectUsingCustomPlanningArea(project) &&
-      this.isProjectUsingCustomPlanningUnitGrid(project)
+      this.isProjectUsingCustomPlanningUnitGrid(project) &&
+      this.isProjectUsingCustomPlanningArea(project)
     ) {
       return {
-        planningUnitIntersectionQueryPart: `type = '${PlanningUnitGridShape.fromShapefile}' and project_id = '${project.id}'`,
-        planningUnitSelectionQueryPart: `(select the_geom from planning_areas where project_id = ${project.id}`,
+        planningUnitSelectionQueryPart: `type = '${PlanningUnitGridShape.fromShapefile}' and project_id = '${project.id}'`,
+        planningUnitIntersectionQueryPart: `(select the_geom from planning_areas where project_id = '${project.id}')`,
       };
     }
 
     if (
-      this.isProjectUsingCustomPlanningArea(project) &&
-      this.isProjectUsingRegularPlanningUnitGrid(project)
+      this.isProjectUsingRegularPlanningUnitGrid(project) &&
+      this.isProjectUsingCustomPlanningArea(project)
     ) {
       return {
-        planningUnitIntersectionQueryPart: `type = '${PlanningUnitGridShape.fromShapefile}' and project_id = '${project.id}'`,
         planningUnitSelectionQueryPart: `type = '${project.planningUnitGridShape}' and size = ${project.planningUnitAreakm2}`,
+        planningUnitIntersectionQueryPart: `(select the_geom from planning_areas where project_id = '${project.id}')`,
       };
     }
 
     if (
-      this.isProjectUsingGadmPlanningArea(project) &&
-      this.isProjectUsingCustomPlanningUnitGrid(project)
+      this.isProjectUsingCustomPlanningUnitGrid(project) &&
+      this.isProjectUsingGadmPlanningArea(project)
     ) {
       return {
+        planningUnitSelectionQueryPart: `type = '${PlanningUnitGridShape.fromShapefile}' and project_id = '${project.id}'`,
         planningUnitIntersectionQueryPart: `(select the_geom from admin_regions ${this.getQueryPartForAdminAreaSelectionByLevel(
           project,
         )})`,
-        planningUnitSelectionQueryPart: `(select the_geom from planning_areas where project_id = ${project.id}`,
       };
     }
 
     if (
-      this.isProjectUsingGadmPlanningArea(project) &&
-      this.isProjectUsingRegularPlanningUnitGrid(project)
+      this.isProjectUsingRegularPlanningUnitGrid(project) &&
+      this.isProjectUsingGadmPlanningArea(project)
     ) {
       return {
+        planningUnitSelectionQueryPart: `type = '${project.planningUnitGridShape}' and size = ${project.planningUnitAreakm2}`,
         planningUnitIntersectionQueryPart: `(select the_geom from admin_regions ${this.getQueryPartForAdminAreaSelectionByLevel(
           project,
         )})`,
-        planningUnitSelectionQueryPart: `type = '${project.planningUnitGridShape}' and size = ${project.planningUnitAreakm2}`,
       };
     }
   }

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1628277500000-AddSupportForCustomPlanningUnitGrids.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1628277500000-AddSupportForCustomPlanningUnitGrids.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSupportForCustomPlanningUnitGrids1628277500000
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+alter table planning_units_geom add column project_id uuid null;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+alter table planning_units_geom drop column project_id;
+      `);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/planning-units/dto/create.regular.planning-units.dto.ts
+++ b/api/apps/geoprocessing/src/modules/planning-units/dto/create.regular.planning-units.dto.ts
@@ -12,7 +12,7 @@ import {
 export enum PlanningUnitGridShape {
   square = 'square',
   hexagon = 'hexagon',
-  fromShapefile = 'from_shapefile',
+  fromShapefile = 'irregular',
 }
 
 /**

--- a/api/libs/planning-unit-geometry/src/planning-units.geo.entity.ts
+++ b/api/libs/planning-unit-geometry/src/planning-units.geo.entity.ts
@@ -42,4 +42,15 @@ export class PlanningUnitsGeom {
     type: 'int',
   })
   size?: number | undefined | null;
+
+  /**
+   * For custom planning unit grids, this links back to the parent project
+   * where the custom grid is used.
+   */
+  @Column({
+    name: 'project_id',
+    nullable: true,
+    type: 'uuid'
+  })
+  projectId?: string | undefined | null;
 }


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-663

Totally mixing concerns, but while at this, I have added the new column to link back custom PU grid geometries to projects as discussed in https://vizzuality.atlassian.net/browse/MARXAN-279, just because the logic in this PR references that column (even if the corresponding code path can't yet be triggered in practice).

I have also updated `PlanningUnitGridShape.fromShapefile` to match what we have in the `shape_type` pg type (`irregular`) - this would not affect the current PR, but once we add support for irregular grids, linking them to scenarios would trigger a db error without this change. I checked if this could affect other parts of the code - I don't think it would, and it doesn't seem to break any tests, but 🤷🏼.

To test this, we need to first add support for regular grids *for custom planning areas* in `planning-units.job.ts` - @aagm I know you are taking care of this.

In the meanwhile, I successfully created and linked a regular PU grid to a scenario of a project with a custom planning area by issuing the PU creation query by hand:

```
INSERT INTO planning_units_geom (the_geom, type, size)
  select st_transform(geom, 4326) as the_geom,
  'hexagon' as type,
  <puGridSize> as size from (
    SELECT (ST_HexagonGrid(<sqrt(puGridSize) * 1000>,
      ST_Transform(a.the_geom, 3410))).*
      FROM planning_areas a
      WHERE project_id = '<project_id>'          
) grid
ON CONFLICT ON CONSTRAINT planning_units_geom_the_geom_type_key DO NOTHING;
```