### PR TITLE
feat(planning-units): lock-in areas protected by default

### DIFF
--- a/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/__mocks__/include-sample.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/__mocks__/include-sample.ts
@@ -228,6 +228,7 @@ export type AreaUnitSampleGeometryProps = {
   [k in ForCase]: {
     shouldBeExcluded: boolean;
     shouldBeIncluded: boolean;
+    protectedByDefault?: boolean;
   };
 };
 
@@ -495,6 +496,7 @@ export const areaUnitsSample = (forCase: string): AreaUnitSampleGeometry => ({
         singleFeature: {
           shouldBeExcluded: false,
           shouldBeIncluded: false,
+          protectedByDefault: true,
         },
         multipleFeatures: {
           shouldBeExcluded: false,

--- a/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
@@ -126,9 +126,20 @@ export class ScenarioPlanningUnitsInclusionProcessor
     await this.scenarioPlanningUnitsRepo.update(
       {
         scenarioId,
+        protectedByDefault: false,
       },
       {
         lockStatus: LockStatus.Unstated,
+      },
+    );
+
+    await this.scenarioPlanningUnitsRepo.update(
+      {
+        scenarioId,
+        protectedByDefault: true,
+      },
+      {
+        lockStatus: LockStatus.LockedIn,
       },
     );
 

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
@@ -65,13 +65,17 @@ export const createWorld = async (app: INestApplication) => {
       const toInclude = await insertPuGeometryFromGeoJson(
         puGeometryRepo,
         planningUnits.features.filter(
-          (f) => f.properties[forCase].shouldBeIncluded,
+          (f) =>
+            f.properties[forCase].shouldBeIncluded ||
+            f.properties[forCase].protectedByDefault,
         ),
       );
       const toExclude = await insertPuGeometryFromGeoJson(
         puGeometryRepo,
         planningUnits.features.filter(
-          (f) => f.properties[forCase].shouldBeExcluded,
+          (f) =>
+            f.properties[forCase].shouldBeExcluded &&
+            !f.properties[forCase].protectedByDefault,
         ),
       );
       const untouched = await insertPuGeometryFromGeoJson(
@@ -79,7 +83,8 @@ export const createWorld = async (app: INestApplication) => {
         planningUnits.features.filter(
           (f) =>
             !f.properties[forCase].shouldBeExcluded &&
-            !f.properties[forCase].shouldBeIncluded,
+            !f.properties[forCase].shouldBeIncluded &&
+            !f.properties[forCase].protectedByDefault,
         ),
       );
 
@@ -109,6 +114,7 @@ export const createWorld = async (app: INestApplication) => {
               puGeometryId: id,
               scenarioId,
               planningUnitMarxanId: index++,
+              protectedByDefault: true,
             }),
           ),
         )


### PR DESCRIPTION
It probably isn't most optimal solution (could make conditional update but honestly, it would be even slower).

Also all `to be included` features should have the flag turned on within specs but I haven't found easy way to implicite turn it only for one without turning the whole spec upside down.