### PR TITLE
feat(projects): find returns only projects created by user

### DIFF
--- a/api/apps/api/src/migrations/api/1629874400088-roles.ts
+++ b/api/apps/api/src/migrations/api/1629874400088-roles.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Roles1629874400088 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE
+                             FROM roles`);
+    await queryRunner.query(`
+      INSERT INTO roles (name)
+      values ('organization_owner'),
+             ('project_owner'),
+             ('organization_admin'),
+             ('project_admin'),
+             ('organization_user'),
+             ('project_user');
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE
+       FROM roles`,
+    );
+  }
+}

--- a/api/apps/api/src/modules/projects/control-level/users-projects.api.entity.ts
+++ b/api/apps/api/src/modules/projects/control-level/users-projects.api.entity.ts
@@ -1,0 +1,55 @@
+import { Role, Roles } from '@marxan-api/modules/users/role.api.entity';
+import { Check, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Project } from '@marxan-api/modules/projects/project.api.entity';
+import { User } from '@marxan-api/modules/users/user.api.entity';
+
+@Entity(`users_projects`)
+export class UsersProjectsApiEntity {
+  @PrimaryColumn({
+    type: `uuid`,
+    name: `user_id`,
+  })
+  userId!: string;
+
+  @PrimaryColumn({
+    type: `uuid`,
+    name: `project_id`,
+  })
+  projectId!: string;
+
+  @Check(`role_id`, `LIKE 'project_%'`)
+  @PrimaryColumn({
+    type: `varchar`,
+    name: `role_id`,
+  })
+  roleName!: Roles.project_user | Roles.project_admin | Roles.project_owner;
+
+  @ManyToOne(() => Project, {
+    onDelete: 'CASCADE',
+    primary: true,
+  })
+  @JoinColumn({
+    name: `project_id`,
+    referencedColumnName: `id`,
+  })
+  project?: Project;
+
+  @ManyToOne(() => User, {
+    onDelete: 'CASCADE',
+    primary: true,
+  })
+  @JoinColumn({
+    name: `user_id`,
+    referencedColumnName: `id`,
+  })
+  user?: User;
+
+  @ManyToOne(() => Role, {
+    primary: true,
+  })
+  @JoinColumn({
+    name: `role_id`,
+    referencedColumnName: `name`,
+  })
+  role?: Role;
+}

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -137,12 +137,14 @@ export class ProjectsController {
   @Get()
   async findAll(
     @ProcessFetchSpecification() fetchSpecification: FetchSpecification,
+    @Req() req: RequestWithAuthenticatedUser,
     @Query('q') namesSearch?: string,
   ): Promise<ProjectResultPlural> {
     const results = await this.projectsService.findAll(fetchSpecification, {
       params: {
         namesSearch,
       },
+      authenticatedUser: req.user,
     });
     return this.projectSerializer.serialize(results.data, results.metadata);
   }

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -19,6 +19,7 @@ import { JobStatusSerializer } from './dto/job-status.serializer';
 import { JobStatusService } from './job-status/job-status.service';
 import { ScenarioJobStatus } from './job-status/job-status.view.api.entity';
 import { PlanningAreasModule } from './planning-areas';
+import { UsersProjectsApiEntity } from './control-level/users-projects.api.entity';
 
 @Module({
   imports: [
@@ -27,7 +28,11 @@ import { PlanningAreasModule } from './planning-areas';
     PlanningAreasModule,
     GeoFeaturesModule,
     forwardRef(() => ScenariosModule),
-    TypeOrmModule.forFeature([Project, ScenarioJobStatus]),
+    TypeOrmModule.forFeature([
+      Project,
+      ScenarioJobStatus,
+      UsersProjectsApiEntity,
+    ]),
     UsersModule,
     PlanningUnitsModule,
     ProtectedAreasModule,

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -11,6 +11,7 @@ import { Project } from './project.api.entity';
 import { CreateProjectDTO } from './dto/create.project.dto';
 import { UpdateProjectDTO } from './dto/update.project.dto';
 import { PlanningAreasService } from './planning-areas';
+import { assertDefined } from '@marxan/utils';
 
 export { validationFailed } from './planning-areas';
 
@@ -44,8 +45,13 @@ export class ProjectsService {
 
   // TODO debt: shouldn't use API's DTO - avoid relating service to given access layer (Rest)
   async create(input: CreateProjectDTO, info: AppInfoDTO) {
-    // /ACL slot - can?/
-    return this.projectsCrud.create(input, info);
+    assertDefined(info.authenticatedUser);
+    const project = await this.projectsCrud.create(input, info);
+    await this.projectsCrud.assignCreatorRole(
+      project.id,
+      info.authenticatedUser.id,
+    );
+    return project;
   }
 
   async update(projectId: string, input: UpdateProjectDTO) {

--- a/api/apps/api/src/modules/users/role.api.entity.ts
+++ b/api/apps/api/src/modules/users/role.api.entity.ts
@@ -16,7 +16,7 @@ export enum Roles {
 
 @Entity('roles')
 export class Role {
-  @PrimaryColumn({ type: 'varchar' })
+  @PrimaryColumn({ type: 'varchar', enum: Roles })
   @IsEnum(Object.values(Roles))
-  name!: string;
+  name!: Roles;
 }

--- a/api/apps/api/test/fixtures/test-init-apidb.sql
+++ b/api/apps/api/test/fixtures/test-init-apidb.sql
@@ -5,15 +5,6 @@ VALUES
 ('bb@example.com', 'b', 'b', 'User B B', true, false, crypt('bbuserpassword', gen_salt('bf'))),
 ('cc@example.com', 'c', 'c', 'User C C', true, false, crypt('ccuserpassword', gen_salt('bf')));
 
-INSERT INTO roles
-VALUES
-('organization_owner'),
-('project_owner'),
-('organization_admin'),
-('project_admin'),
-('organization_user'),
-('project_user');
-
 INSERT INTO organizations (name, created_by)
 VALUES
 ('Example Org 1', (SELECT id FROM users WHERE email = 'aa@example.com')),

--- a/api/apps/api/test/project/project-get.e2e-spec.ts
+++ b/api/apps/api/test/project/project-get.e2e-spec.ts
@@ -19,45 +19,6 @@ beforeAll(async () => {
   }
 });
 
-describe(`When getting all projects`, () => {
-  it(`should return relevant data`, async () => {
-    const currentProjects = [
-      world.projectWithCountry,
-      world.projectWithGid1,
-      world.projectWithGid2,
-    ];
-    const response = await request(app.getHttpServer())
-      .get(`/api/v1/projects?disablePagination=true`)
-      .set('Authorization', `Bearer ${jwtToken}`)
-      .expect(200);
-
-    const testProjects = response.body.data.filter((project: any) =>
-      currentProjects.includes(project.id),
-    );
-
-    expect(
-      testProjects.map((project: any) =>
-        pick(project.attributes, ['planningAreaId', 'planningAreaName']),
-      ),
-    ).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "planningAreaId": "NAM",
-          "planningAreaName": "Namibia",
-        },
-        Object {
-          "planningAreaId": "NAM.13_1",
-          "planningAreaName": "Zambezi",
-        },
-        Object {
-          "planningAreaId": "NAM.13.5_1",
-          "planningAreaName": "Linyandi",
-        },
-      ]
-    `);
-  });
-});
-
 describe(`When getting a single project`, () => {
   it(`should return its details`, async () => {
     const response = await request(app.getHttpServer())

--- a/api/apps/api/test/project/user-projects.e2e-spec.ts
+++ b/api/apps/api/test/project/user-projects.e2e-spec.ts
@@ -1,0 +1,19 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getFixtures } from './user-projects.fixtures';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+afterEach(async () => {
+  await fixtures?.cleanup();
+});
+
+test(`getting own projects`, async () => {
+  const projectId = await fixtures.GivenUserCreatedAProject();
+  const someonesProjectId = await fixtures.GivenAnotherUserCreatedAProject();
+  const result = await fixtures.WhenGettingUserProjects();
+  fixtures.ThenOnlyUserCreatedArePresent(projectId, someonesProjectId, result);
+});

--- a/api/apps/api/test/project/user-projects.fixtures.ts
+++ b/api/apps/api/test/project/user-projects.fixtures.ts
@@ -1,0 +1,59 @@
+import { bootstrapApplication } from '../utils/api-application';
+import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
+import { OrganizationsTestUtils } from '../utils/organizations.test.utils';
+import { ProjectsTestUtils } from '../utils/projects.test.utils';
+import * as request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Project } from '@marxan-api/modules/projects/project.api.entity';
+import { Repository } from 'typeorm';
+
+export const getFixtures = async () => {
+  const app = await bootstrapApplication();
+  const token = await GivenUserIsLoggedIn(app);
+  const org = await OrganizationsTestUtils.createOrganization(app, token, {
+    name: `User Organization ${Date.now()}`,
+  });
+  const projectsRepo: Repository<Project> = app.get(
+    getRepositoryToken(Project),
+  );
+
+  const createProject = async (authToken = token) => {
+    const project = (
+      await ProjectsTestUtils.createProject(app, authToken, {
+        name: `User Project ${Date.now()}`,
+        organizationId: org.data.id,
+      })
+    ).data.id;
+    return project;
+  };
+
+  return {
+    cleanup: async () => {
+      await projectsRepo.delete({
+        organizationId: org.data.id,
+      });
+      await OrganizationsTestUtils.deleteOrganization(app, token, org.data.id);
+      await app.close();
+    },
+    WhenGettingUserProjects: async () =>
+      request(app.getHttpServer())
+        .get(`/api/v1/projects?disablePagination=true`)
+        .set('Authorization', `Bearer ${token}`),
+    GivenAnotherUserCreatedAProject: async () => {
+      const anotherUserToken = await GivenUserIsLoggedIn(app, `bb`);
+      return createProject(anotherUserToken);
+    },
+    GivenUserCreatedAProject: createProject,
+    ThenOnlyUserCreatedArePresent: (
+      owned: string,
+      someonesElse: string,
+      allProjects: request.Response,
+    ) => {
+      const userProjects: string[] = allProjects.body.data.map(
+        (p: any) => p.id,
+      );
+      expect(userProjects.includes(owned)).toBeTruthy();
+      expect(userProjects.includes(someonesElse)).toBeFalsy();
+    },
+  };
+};

--- a/api/apps/api/test/steps/given-user-is-logged-in.ts
+++ b/api/apps/api/test/steps/given-user-is-logged-in.ts
@@ -4,10 +4,11 @@ import { E2E_CONFIG } from '../e2e.config';
 
 export const GivenUserIsLoggedIn = async (
   app: INestApplication,
+  type: `aa` | `bb` = `aa`,
 ): Promise<string> =>
   (
     await request(app.getHttpServer()).post('/auth/sign-in').send({
-      username: E2E_CONFIG.users.basic.aa.username,
-      password: E2E_CONFIG.users.basic.aa.password,
+      username: E2E_CONFIG.users.basic[type].username,
+      password: E2E_CONFIG.users.basic[type].password,
     })
   ).body.accessToken;


### PR DESCRIPTION
MARXAN-582 restrict list of projects returned to user to their own projects only

migration (instead of seeds) will have a followup PR (please don't merge this one now)..


Implementation details:


Options were:
1. Add relations and cascade create
    1. pros: transactional
    2. cons: project itself knowing about roles/privileges; possible issues with adding further roles ([…roles, newRole])
2. Extracting roles/privileges into standalone (sub)module
    1. pros: clear separation
    2. cons: would require fine amount of changes to keep it in transaction; we don’t know the full shape of rbac/acl
3. Attaching to ~BaseService’s `actionAfterCreate`
    1. pros: pretty straightforward, easy to „remove”; failed non-transactional insert into user_projects may leave orphaned projects
    2. cons: overextending responsibilities; not transactional 
    3. Actually not possible as ~BaseService does not await on afterCreate (which I believe is intentional and fine…)
4. Adding additional logic within projects.service.ts

