### PR TITLE
fix(marxan-run): score/cost values should be persisted

### DIFF
--- a/api/apps/api/src/modules/scenarios/marxan-run/output.repository.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/output.repository.ts
@@ -25,6 +25,8 @@ export class OutputRepository {
     const entities: Omit<ScenariosOutputResultsApiEntity, 'id'>[] = output.map(
       (row) => ({
         ...row,
+        scoreValue: row.score,
+        costValue: row.cost,
         scenarioId: data.scenarioId,
       }),
     );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3466388/131307671-6e2b586d-87d0-417b-ab45-7421a1b3622d.png)

(bug for keeping old ones is in tracking system)