### PR TITLE
fix(marxan-run): remove old summaries of a scenario run

### DIFF
--- a/api/apps/api/src/modules/scenarios/marxan-run/output.repository.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/output.repository.ts
@@ -30,6 +30,9 @@ export class OutputRepository {
         scenarioId: data.scenarioId,
       }),
     );
+    await this.outputs.delete({
+      scenarioId: data.scenarioId,
+    });
     await this.outputs.save(entities);
   }
 }


### PR DESCRIPTION
Ideally it should be done in transaction... in future