### PR TITLE
fix(marxan-run): in case of any error, handle it and use failed-reason

### DIFF
--- a/api/apps/api/src/modules/scenarios/marxan-run/events.handler.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/events.handler.ts
@@ -102,6 +102,9 @@ export class EventsHandler {
     await this.apiEvents.createIfNotExists({
       topic: job.data.scenarioId,
       kind,
+      data: {
+        reason: job.failedReason,
+      },
       externalId: eventId,
     });
   }

--- a/api/apps/api/src/modules/scenarios/marxan-run/run.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/run.service.spec.ts
@@ -142,6 +142,9 @@ test(`failed job`, async () => {
   await fixtures.ThenEventCreatedIfNotExisted(
     API_EVENT_KINDS.scenario__run__failed__v1__alpha1,
     `eventid1`,
+    {
+      reason: 'fail description',
+    },
   );
 });
 
@@ -261,8 +264,10 @@ async function getFixtures() {
   const fakeAssets = {
     forScenario: jest.fn(),
   };
+
   class FakeOutputRepository implements FieldsOf<OutputRepository> {
     db: ScenariosOutputResultsApiEntity[] = [];
+
     async saveOutput(job: {
       returnvalue: ExecutionResult | undefined;
       data: { scenarioId: string };
@@ -275,6 +280,7 @@ async function getFixtures() {
       });
     }
   }
+
   const testingModule = await Test.createTestingModule({
     providers: [
       RunHandler,
@@ -500,6 +506,7 @@ async function getFixtures() {
           data: {
             scenarioId: `scenario-1`,
           },
+          failedReason: `fail description`,
         };
       });
     },

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/marxan-sandbox-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/marxan-sandbox-runner.service.ts
@@ -79,7 +79,7 @@ export class MarxanSandboxRunnerService {
           marxanRun.stdError,
         );
         await workspace.cleanup();
-        reject(result);
+        reject(JSON.stringify(result));
       });
       marxanRun.on('finished', async () => {
         try {

--- a/api/apps/geoprocessing/src/modules/scenarios/run.worker.ts
+++ b/api/apps/geoprocessing/src/modules/scenarios/run.worker.ts
@@ -22,6 +22,7 @@ export const runWorkerQueueNameProvider: ValueProvider<string> = {
 export class RunWorker {
   private worker: Worker<JobData, ExecutionResult>;
   private queueEvents: QueueEvents;
+
   constructor(
     queueEventsBuilder: QueueEventsBuilder,
     workerBuilder: WorkerBuilder,
@@ -29,7 +30,13 @@ export class RunWorker {
     private readonly marxanRunner: MarxanSandboxRunnerService,
   ) {
     this.worker = workerBuilder.build<JobData, ExecutionResult>(queueName, {
-      process: (job) => this.run(job),
+      process: async (job) => {
+        try {
+          return await this.run(job);
+        } catch (error) {
+          throw new Error(JSON.stringify(error));
+        }
+      },
     });
     this.queueEvents = queueEventsBuilder.buildQueueEvents(queueName);
     this.queueEvents.on(`progress`, ({ data }: { data: ProgressData }) => {

--- a/api/apps/geoprocessing/test/integration/marxan-run/marxan-run.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/marxan-run/marxan-run.e2e-spec.ts
@@ -75,7 +75,7 @@ describe(`given input data is available`, () => {
         done(`Shouldn't finish Marxan run.`);
       })
       .catch((error) => {
-        expect(error.signal).toEqual('SIGTERM');
+        expect(JSON.parse(error).signal).toEqual('SIGTERM');
         done();
       });
 


### PR DESCRIPTION
Reason for using `string` within `new Error(...)` is that `bullmq` assumes such format so that the job data contains `failedReason` property derived from this very type (i.e. if processor finished throwing an error)

source: https://github.com/taskforcesh/bullmq/issues/537#issuecomment-836601738