### PR TITLE
feat(custom-pu-grid): set project grid shape once geometries were set

### DIFF
--- a/api/apps/api/src/modules/projects/planning-unit-grid/planning-unit-grid-set.saga.ts
+++ b/api/apps/api/src/modules/projects/planning-unit-grid/planning-unit-grid-set.saga.ts
@@ -1,0 +1,19 @@
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { CustomPlanningUnitGridSet } from '../events/custom-planning-unit-grid-set.event';
+import { SetProjectGridFromShapefile } from './set-project-grid-from-shapefile.command';
+import { ProjectId } from './project.id';
+
+export class PlanningUnitGridSetSaga {
+  @Saga()
+  puGridSet = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(CustomPlanningUnitGridSet),
+      map(
+        (event) =>
+          new SetProjectGridFromShapefile(new ProjectId(event.projectId)),
+      ),
+    );
+}

--- a/api/apps/api/src/modules/projects/planning-unit-grid/planning-unit-grid.module.ts
+++ b/api/apps/api/src/modules/projects/planning-unit-grid/planning-unit-grid.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
 import { ApiEventsModule } from '@marxan-api/modules/api-events';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CqrsModule } from '@nestjs/cqrs';
+
+import { Project } from '@marxan-api/modules/projects/project.api.entity';
 
 import {
   setPlanningUnitGridEventsFactoryProvider,
@@ -10,15 +13,24 @@ import {
 } from './queue.providers';
 import { PlanningUnitGridEventsHandler } from './planning-unit-grid-events.handler';
 import { PlanningUnitGridService } from './planning-unit-grid.service';
+import { PlanningUnitGridSetSaga } from './planning-unit-grid-set.saga';
+import { SetProjectGridFromShapefileHandler } from './set-project-grid-from-shapefile.handler';
 
 @Module({
-  imports: [QueueApiEventsModule, ApiEventsModule, CqrsModule],
+  imports: [
+    QueueApiEventsModule,
+    ApiEventsModule,
+    CqrsModule,
+    TypeOrmModule.forFeature([Project]),
+  ],
   providers: [
     setPlanningUnitGridQueueProvider,
     setPlanningUnitGridQueueEventsProvider,
     setPlanningUnitGridEventsFactoryProvider,
     PlanningUnitGridEventsHandler,
     PlanningUnitGridService,
+    PlanningUnitGridSetSaga,
+    SetProjectGridFromShapefileHandler,
   ],
   exports: [PlanningUnitGridService],
 })

--- a/api/apps/api/src/modules/projects/planning-unit-grid/set-project-grid-from-shapefile.command.ts
+++ b/api/apps/api/src/modules/projects/planning-unit-grid/set-project-grid-from-shapefile.command.ts
@@ -1,0 +1,8 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+import { ProjectId } from './project.id';
+
+export class SetProjectGridFromShapefile extends Command<void> {
+  constructor(public readonly projectId: ProjectId) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/projects/planning-unit-grid/set-project-grid-from-shapefile.handler.ts
+++ b/api/apps/api/src/modules/projects/planning-unit-grid/set-project-grid-from-shapefile.handler.ts
@@ -1,0 +1,28 @@
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import {
+  PlanningUnitGridShape,
+  Project,
+} from '@marxan-api/modules/projects/project.api.entity';
+import { SetProjectGridFromShapefile } from './set-project-grid-from-shapefile.command';
+
+@CommandHandler(SetProjectGridFromShapefile)
+export class SetProjectGridFromShapefileHandler
+  implements IInferredCommandHandler<SetProjectGridFromShapefile> {
+  constructor(
+    @InjectRepository(Project) private readonly projects: Repository<Project>,
+  ) {}
+
+  async execute({ projectId }: SetProjectGridFromShapefile): Promise<void> {
+    await this.projects.update(
+      {
+        id: projectId.value,
+      },
+      {
+        planningUnitGridShape: PlanningUnitGridShape.fromShapefile,
+      },
+    );
+  }
+}

--- a/api/apps/api/src/modules/projects/project.api.entity.ts
+++ b/api/apps/api/src/modules/projects/project.api.entity.ts
@@ -27,7 +27,7 @@ export const projectResource: BaseServiceResource = {
 export enum PlanningUnitGridShape {
   square = 'square',
   hexagon = 'hexagon',
-  fromShapefile = 'irregular',
+  fromShapefile = 'from_shapefile',
 }
 
 @Entity('projects')


### PR DESCRIPTION
- unpacking shapefile and adding geometries - https://github.com/Vizzuality/marxan-cloud/pull/525
- exposing endpoint to submit & api events - https://github.com/Vizzuality/marxan-cloud/pull/527
- updating project `planning_unit_grid_shape` - https://github.com/Vizzuality/marxan-cloud/pull/529 (this)
- exposing endpoint to get the request status - https://github.com/Vizzuality/marxan-cloud/pull/528 