### PR TITLE
feat(api): include async job status in all relevant endpoints

### DIFF
--- a/api/apps/api/src/dto/async-job-tag.ts
+++ b/api/apps/api/src/dto/async-job-tag.ts
@@ -1,0 +1,1 @@
+export const asyncJobTag = 'Async job';

--- a/api/apps/api/src/dto/async-job-type.ts
+++ b/api/apps/api/src/dto/async-job-type.ts
@@ -1,0 +1,4 @@
+export enum AsyncJobType {
+  Project = 'project',
+  Scenario = 'scenario',
+}

--- a/api/apps/api/src/dto/async-job.dto.ts
+++ b/api/apps/api/src/dto/async-job.dto.ts
@@ -1,0 +1,61 @@
+import {
+  ApiHideProperty,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
+import { Exclude, plainToClass } from 'class-transformer';
+import { AsyncJobType } from './async-job-type';
+
+export class AsyncJobDto {
+  @ApiProperty({
+    enum: AsyncJobType,
+  })
+  type!: AsyncJobType;
+
+  @ApiPropertyOptional({
+    isArray: true,
+    type: String,
+  })
+  ids?: string[];
+
+  @ApiProperty()
+  started!: boolean;
+
+  @ApiProperty()
+  isoDate!: string;
+
+  static forScenario(): AsyncJobDto {
+    return plainToClass(AsyncJobDto, {
+      type: AsyncJobType.Scenario,
+      isoDate: new Date().toISOString(),
+      started: true,
+    });
+  }
+
+  static forProject(ids?: string[]): AsyncJobDto {
+    return plainToClass(AsyncJobDto, {
+      type: AsyncJobType.Project,
+      started: true,
+      isoDate: new Date().toISOString(),
+      ids,
+    });
+  }
+
+  asJsonApiMetadata(): JsonApiAsyncJobMeta {
+    return plainToClass(JsonApiAsyncJobMeta, {
+      meta: plainToClass(AsyncJobDto, {
+        started: this.started,
+        ids: this.ids,
+        isoDate: this.isoDate,
+        type: this.type,
+      }),
+    });
+  }
+}
+
+export class JsonApiAsyncJobMeta {
+  @ApiProperty({
+    type: AsyncJobDto,
+  })
+  meta!: AsyncJobDto;
+}

--- a/api/apps/api/src/dto/inline-job-tag.ts
+++ b/api/apps/api/src/dto/inline-job-tag.ts
@@ -1,0 +1,1 @@
+export const inlineJobTag = 'Inline job';

--- a/api/apps/api/src/modules/geo-features/geo-feature-set.api.entity.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature-set.api.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { BaseServiceResource } from '@marxan-api/types/resource.interface';
 import { GeoFeatureSetSpecification } from './dto/geo-feature-set-specification.dto';
+import { JsonApiAsyncJobMeta } from '@marxan-api/dto/async-job.dto';
 
 export const geoFeatureResource: BaseServiceResource = {
   className: 'GeoFeature',
@@ -31,7 +32,7 @@ export class JSONAPIGeoFeatureSetsData {
   attributes!: GeoFeatureSetSpecification;
 }
 
-export class GeoFeatureSetResult {
+export class GeoFeatureSetResult extends JsonApiAsyncJobMeta {
   @ApiProperty()
   data!: JSONAPIGeoFeatureSetsData;
 }

--- a/api/apps/api/src/modules/geo-features/geo-feature-set.serializer.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature-set.serializer.ts
@@ -3,6 +3,9 @@ import { PaginationMeta } from '@marxan-api/utils/app-base.service';
 import { GeoFeatureSetService } from './geo-feature-set.service';
 import { GeoFeatureSetSpecification } from './dto/geo-feature-set-specification.dto';
 import { SimpleJobStatus } from '../scenarios/scenario.api.entity';
+import { GeoFeatureSetResult } from '@marxan-api/modules/geo-features/geo-feature-set.api.entity';
+import { plainToClass } from 'class-transformer';
+import { AsyncJobDto } from '@marxan-api/dto/async-job.dto';
 
 @Injectable()
 export class GeoFeatureSetSerializer {
@@ -14,10 +17,17 @@ export class GeoFeatureSetSerializer {
       | undefined
       | (Partial<GeoFeatureSetSpecification> | undefined)[],
     paginationMeta?: PaginationMeta,
-  ): Promise<any> {
-    return this.geoFeatureSetsService.serialize(entities, paginationMeta);
+    asyncJobTriggered?: boolean,
+  ): Promise<GeoFeatureSetResult> {
+    return plainToClass(GeoFeatureSetResult, {
+      ...(await this.geoFeatureSetsService.serialize(entities, paginationMeta)),
+      meta: asyncJobTriggered ? AsyncJobDto.forScenario() : undefined,
+    });
   }
 
+  /**
+   * @deprecated
+   */
   emptySpecification() {
     return this.geoFeatureSetsService.serialize({
       status: SimpleJobStatus.draft,

--- a/api/apps/api/src/modules/projects/dto/project-grid-request.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/project-grid-request.dto.ts
@@ -1,8 +1,0 @@
-import { IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
-
-export class ProjectGridRequestDto {
-  @ApiProperty()
-  @IsString()
-  id!: string;
-}

--- a/api/apps/api/src/modules/projects/project.api.entity.ts
+++ b/api/apps/api/src/modules/projects/project.api.entity.ts
@@ -15,6 +15,7 @@ import { TimeUserEntityMetadata } from '../../types/time-user-entity-metadata';
 import { BaseServiceResource } from '../../types/resource.interface';
 import { BBox } from 'geojson';
 import { ProtectedAreaDto } from '@marxan-api/modules/projects/dto/protected-area.dto';
+import { JsonApiAsyncJobMeta } from '@marxan-api/dto/async-job.dto';
 
 export const projectResource: BaseServiceResource = {
   className: 'Project',
@@ -199,7 +200,7 @@ export class ProjectResultPlural {
   data!: JSONAPIProjectData[];
 }
 
-export class ProjectResultSingular {
+export class ProjectResultSingular extends JsonApiAsyncJobMeta {
   @ApiProperty()
   data!: JSONAPIProjectData;
 }

--- a/api/apps/api/src/modules/projects/projects-listing.controller.ts
+++ b/api/apps/api/src/modules/projects/projects-listing.controller.ts
@@ -50,7 +50,7 @@ export class ProjectsListingController {
       },
       authenticatedUser: req.user,
     });
-    return this.projectSerializer.serialize(results.data, results.metadata);
+    return this.projectSerializer.serializeAll(results.data, results.metadata);
   }
 
   @ProjectsListing()
@@ -64,7 +64,7 @@ export class ProjectsListingController {
         namesSearch,
       },
     });
-    return this.projectSerializer.serialize(results.data, results.metadata);
+    return this.projectSerializer.serializeAll(results.data, results.metadata);
   }
 }
 

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -62,6 +62,8 @@ import {
   AsyncJobDto,
   JsonApiAsyncJobMeta,
 } from '@marxan-api/dto/async-job.dto';
+import { asyncJobTag } from '@marxan-api/dto/async-job-tag';
+import { inlineJobTag } from '@marxan-api/dto/inline-job-tag';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -124,6 +126,7 @@ export class ProjectsController {
 
   @ApiOperation({ description: 'Create project' })
   @ApiOkResponse({ type: ProjectResultSingular })
+  @ApiTags(asyncJobTag)
   @Post()
   async create(
     @Body() dto: CreateProjectDTO,
@@ -138,6 +141,7 @@ export class ProjectsController {
 
   @ApiOperation({ description: 'Update project' })
   @ApiOkResponse({ type: ProjectResultSingular })
+  @ApiTags(asyncJobTag)
   @Patch(':id')
   async update(
     @Param('id') id: string,
@@ -163,6 +167,7 @@ export class ProjectsController {
   })
   @UseInterceptors(FileInterceptor('file', uploadOptions))
   @ApiCreatedResponse({ type: JsonApiAsyncJobMeta })
+  @ApiTags(asyncJobTag)
   @Post(`:id/grid`)
   async setProjectGrid(
     @Param('id') projectId: string,
@@ -201,7 +206,7 @@ export class ProjectsController {
     description: 'Upload shapefile for project-specific protected areas',
   })
   @UseInterceptors(FileInterceptor('file', uploadOptions))
-  @ApiNoContentResponse()
+  @ApiTags(asyncJobTag)
   @Post(':id/protected-areas/shapefile')
   async shapefileForProtectedArea(
     @Param('id') projectId: string,
@@ -223,6 +228,7 @@ export class ProjectsController {
     description: 'Upload shapefile with project planning-area',
   })
   @UseInterceptors(FileInterceptor('file', uploadOptions))
+  @ApiTags(inlineJobTag)
   @Post('planning-area/shapefile')
   async shapefileWithProjectPlanningArea(
     @UploadedFile() file: Express.Multer.File,
@@ -248,6 +254,7 @@ export class ProjectsController {
     description: `Upload shapefiles of species or bioregional features.`,
   })
   @ApiOkResponse({ type: ShapefileUploadResponse })
+  @ApiTags(inlineJobTag)
   @Post(`:id/features/shapefile`)
   @UseInterceptors(
     FileInterceptor('file', {

--- a/api/apps/api/src/modules/scenarios/dto/scenario.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario.serializer.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { PaginationMeta } from '@marxan-api/utils/app-base.service';
-import { Scenario } from '../scenario.api.entity';
+import { Scenario, ScenarioResult } from '../scenario.api.entity';
 import { ScenariosCrudService } from '../scenarios-crud.service';
+import { plainToClass } from 'class-transformer';
+import { AsyncJobDto } from '@marxan-api/dto/async-job.dto';
 
 @Injectable()
 export class ScenarioSerializer {
@@ -10,7 +12,11 @@ export class ScenarioSerializer {
   async serialize(
     entities: Partial<Scenario> | (Partial<Scenario> | undefined)[],
     paginationMeta?: PaginationMeta,
-  ): Promise<any> {
-    return this.scenariosCrudService.serialize(entities, paginationMeta);
+    asyncJobTriggered?: boolean,
+  ): Promise<ScenarioResult> {
+    return plainToClass(ScenarioResult, {
+      ...(await this.scenariosCrudService.serialize(entities, paginationMeta)),
+      meta: asyncJobTriggered ? AsyncJobDto.forScenario() : undefined,
+    });
   }
 }

--- a/api/apps/api/src/modules/scenarios/scenario.api.entity.ts
+++ b/api/apps/api/src/modules/scenarios/scenario.api.entity.ts
@@ -15,6 +15,7 @@ import { IsArray, IsOptional } from 'class-validator';
 import { TimeUserEntityMetadata } from '../../types/time-user-entity-metadata';
 import { BaseServiceResource } from '../../types/resource.interface';
 import { GeoFeatureSetSpecification } from '../geo-features/dto/geo-feature-set-specification.dto';
+import { JsonApiAsyncJobMeta } from '@marxan-api/dto/async-job.dto';
 
 export const scenarioResource: BaseServiceResource = {
   className: 'Scenario',
@@ -215,7 +216,7 @@ export class JSONAPIScenarioData {
   attributes!: Scenario;
 }
 
-export class ScenarioResult {
+export class ScenarioResult extends JsonApiAsyncJobMeta {
   @ApiProperty()
   data!: JSONAPIScenarioData;
 }

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -85,6 +85,8 @@ import {
   AsyncJobDto,
   JsonApiAsyncJobMeta,
 } from '@marxan-api/dto/async-job.dto';
+import { asyncJobTag } from '@marxan-api/dto/async-job-tag';
+import { inlineJobTag } from '@marxan-api/dto/inline-job-tag';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -217,6 +219,7 @@ export class ScenariosController {
 
   @ApiOperation({ description: 'Create scenario' })
   @ApiCreatedResponse({ type: ScenarioResult })
+  @ApiTags(asyncJobTag)
   @Post()
   async create(
     @Body(new ValidationPipe()) dto: CreateScenarioDTO,
@@ -230,6 +233,7 @@ export class ScenariosController {
   }
 
   @ApiOperation({ description: 'Create feature set for scenario' })
+  @ApiTags(asyncJobTag)
   @Post(':id/features/specification/v2')
   async createSpecification(
     @Body(new ValidationPipe()) dto: CreateGeoFeatureSetDTO,
@@ -289,7 +293,7 @@ export class ScenariosController {
 
   @ApiConsumesShapefile({ withGeoJsonResponse: false })
   @UseInterceptors(FileInterceptor('file', uploadOptions))
-  @ApiNoContentResponse()
+  @ApiTags(asyncJobTag)
   @Post(`:id/cost-surface/shapefile`)
   async processCostSurfaceShapefile(
     @Param('id') scenarioId: string,
@@ -307,6 +311,7 @@ export class ScenariosController {
   }
 
   @ApiConsumesShapefile()
+  @ApiTags(inlineJobTag)
   @Post(':id/planning-unit-shapefile')
   @UseInterceptors(FileInterceptor('file', uploadOptions))
   async uploadLockInShapeFile(
@@ -318,6 +323,7 @@ export class ScenariosController {
 
   @ApiOperation({ description: 'Update scenario' })
   @ApiOkResponse({ type: ScenarioResult })
+  @ApiTags(asyncJobTag)
   @Patch(':id')
   async update(
     @Param('id') id: string,
@@ -337,8 +343,9 @@ export class ScenariosController {
     return await this.service.remove(id);
   }
 
-  @Patch(':id/planning-units')
+  @ApiTags(asyncJobTag)
   @ApiOkResponse()
+  @Patch(':id/planning-units')
   async changePlanningUnits(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() input: UpdateScenarioPlanningUnitLockStatusDto,
@@ -515,7 +522,7 @@ export class ScenariosController {
     description: `Request start of the Marxan execution.`,
     summary: `Request start of the Marxan execution.`,
   })
-  @ApiTags(marxanRunTag)
+  @ApiTags(marxanRunTag, asyncJobTag)
   @ApiQuery({
     name: `blm`,
     required: false,

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -4,19 +4,19 @@ import {
   Delete,
   Get,
   Header,
+  InternalServerErrorException,
   Param,
   ParseUUIDPipe,
   Patch,
   Post,
-  Query,
   Put,
+  Query,
   Req,
   Res,
   UploadedFile,
   UseGuards,
   UseInterceptors,
   ValidationPipe,
-  InternalServerErrorException,
 } from '@nestjs/common';
 import { scenarioResource, ScenarioResult } from './scenario.api.entity';
 import { Request, Response } from 'express';
@@ -81,6 +81,10 @@ import { ScenarioFeaturesGapDataSerializer } from './dto/scenario-feature-gap-da
 import { ScenarioFeaturesOutputGapDataService } from '../scenarios-features/scenario-features-output-gap-data.service';
 import { ScenarioFeaturesOutputGapDataSerializer } from './dto/scenario-feature-output-gap-data.serializer';
 import { CostRangeDto } from './dto/cost-range.dto';
+import {
+  AsyncJobDto,
+  JsonApiAsyncJobMeta,
+} from '@marxan-api/dto/async-job.dto';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -220,6 +224,8 @@ export class ScenariosController {
   ): Promise<ScenarioResult> {
     return await this.scenarioSerializer.serialize(
       await this.service.create(dto, { authenticatedUser: req.user }),
+      undefined,
+      true,
     );
   }
 
@@ -233,7 +239,11 @@ export class ScenariosController {
     if (isLeft(result)) {
       throw new InternalServerErrorException(result.left.description);
     }
-    return await this.geoFeatureSetSerializer.serialize(result.right);
+    return await this.geoFeatureSetSerializer.serialize(
+      result.right,
+      undefined,
+      true,
+    );
   }
 
   @ApiOperation({ description: 'Create feature set for scenario' })
@@ -284,8 +294,9 @@ export class ScenariosController {
   async processCostSurfaceShapefile(
     @Param('id') scenarioId: string,
     @UploadedFile() file: Express.Multer.File,
-  ): Promise<void> {
+  ): Promise<JsonApiAsyncJobMeta> {
     this.service.processCostSurfaceShapefile(scenarioId, file);
+    return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
 
   @Get(`:id/cost-surface`)
@@ -314,6 +325,8 @@ export class ScenariosController {
   ): Promise<ScenarioResult> {
     return await this.scenarioSerializer.serialize(
       await this.service.update(id, dto),
+      undefined,
+      true,
     );
   }
 
@@ -329,9 +342,9 @@ export class ScenariosController {
   async changePlanningUnits(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() input: UpdateScenarioPlanningUnitLockStatusDto,
-  ): Promise<void> {
+  ): Promise<JsonApiAsyncJobMeta> {
     await this.service.changeLockStatus(id, input);
-    return;
+    return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
 
   @Delete(`:id/planning-units`)
@@ -509,14 +522,15 @@ export class ScenariosController {
     type: Number,
   })
   @ApiAcceptedResponse({
-    description: `No content.`,
+    type: JsonApiAsyncJobMeta,
   })
   @Post(`:id/marxan`)
   async executeMarxanRun(
     @Param(`id`, ParseUUIDPipe) id: string,
     @Query(`blm`) blm?: number,
-  ) {
+  ): Promise<JsonApiAsyncJobMeta> {
     await this.service.run(id, blm);
+    return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
 
   @ApiOperation({

--- a/api/apps/api/test/project-grid/project-grid.fixtures.ts
+++ b/api/apps/api/test/project-grid/project-grid.fixtures.ts
@@ -31,10 +31,17 @@ export const getFixtures = async () => {
         .set('Authorization', `Bearer ${token}`)
         .attach(`file`, __dirname + '/grid-nam-shapefile.zip'),
     ThenShapefileIsSubmittedToProcessing: async (body: any) => {
-      expect(body.id).toBeDefined();
+      expect(body.meta).toEqual({
+        started: true,
+        ids: expect.any(Array),
+        isoDate: expect.any(String),
+        type: `project`,
+      });
       await waitForExpect(async () => {
         // using implementation details...
-        const job = Object.values(queue.jobs).find((j) => j.id === body.id);
+        const job = Object.values(queue.jobs).find(
+          (j) => j.id === body.meta.ids[0],
+        );
         expect(job).toBeDefined();
         expect(job!.data?.projectId).toBeDefined();
         expect(job!.data?.shapefile.filename).toMatch(/grid-nam-shapefile.zip/);

--- a/api/apps/api/test/project-protected-areas/project-protected-areas-upload-shapefile.e2e-spec.ts
+++ b/api/apps/api/test/project-protected-areas/project-protected-areas-upload-shapefile.e2e-spec.ts
@@ -26,9 +26,10 @@ describe(`when project is not available`, () => {
 
 describe(`when project is available`, () => {
   it(`submits shapefile to the system`, async () => {
-    expect(
-      (await world.WhenSubmittingShapefileFor(world.projectId)).status,
-    ).toEqual(201);
+    const result = await world.WhenSubmittingShapefileFor(world.projectId);
+
+    expect(result.status).toEqual(201);
+    expect(result.body.meta.started).toBeTruthy();
     const job = world.GetSubmittedJobs()[0];
     expect(job).toMatchObject({
       name: `protected-areas-for-${world.projectId}`,

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -94,6 +94,7 @@ export const getFixtures = async () => {
           id: publicProjectId,
           type: 'projects',
         },
+        meta: {},
       });
     },
     WhenGettingProject: async (projectId: string) =>

--- a/api/apps/api/test/projects.e2e-spec.ts
+++ b/api/apps/api/test/projects.e2e-spec.ts
@@ -96,6 +96,7 @@ describe('ProjectsModule (e2e)', () => {
       const jsonAPIResponse: ProjectResultSingular = response.body;
       completeProject = await Deserializer.deserialize(response.body);
       expect(jsonAPIResponse.data.type).toBe('projects');
+      expect(jsonAPIResponse.meta.started).toBeTruthy();
 
       const createScenarioDTO: Partial<CreateScenarioDTO> = {
         ...E2E_CONFIG.scenarios.valid.minimal(),

--- a/api/apps/api/test/scenario-pu-change/scenario-put-change.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-put-change.e2e-spec.ts
@@ -41,8 +41,9 @@ describe(`when requesting to change inclusive options`, () => {
 
   describe(`when desired PU ids are available`, () => {
     it(`triggers the job`, async () => {
-      await world.WhenChangingPlanningUnitInclusivityWithExistingPu();
+      const result = await world.WhenChangingPlanningUnitInclusivityWithExistingPu();
       const job = Object.values(queue.jobs)[0];
+      expect(result.meta.started).toBeTruthy();
       HasExpectedJobDetails(job);
       HasRelevantJobName(job, world.scenarioId);
     });


### PR DESCRIPTION
We should be carefully when serializing stuff.

1. "meta" is already included when pagination is defined
2. neither "meta" nor "pagination" is defined within swagger / classes, thus using `plainToClass` removes it
3. I haven't refactored "mixing" them, nor the OpenApi docs.

We should consider redesign of creating OpenApi definitions, meta inclusion/mixing, responsibilities and serialization itself.



# PROJECTS

## Async jobs
-  Project create / upload - MAY create an actions
-  projects/:id/protected-areas/shapefile
-  projects/:id/grid

## Non-async jobs
- projects/:id/features/shapefile (API-side)
- projects/:id/planning-area/shapefile („inline” proxy go Geoprocessing)

# SCENARIOS

## Async jobs  
- Create / update scenario (CalculatePlanningUnitsProtectionLevel)
- scenarios/:id/marxan
- scenarios/:id/planning-units
- scenarios/:id/cost-surface/shapefile
- scenarios/:id/features/specification/v2

## Non-async jobs
- scenarios/:id/planning-unit-shapefile („inline” proxy to Geoprocessing)
- scenarios/:id/features/specification - deprecated ?
