### PR TITLE
[MARXAN-791] fix missing constraint leading to updating of rows that don't belong to the scenario being processed

### DIFF
--- a/api/apps/geoprocessing/src/modules/scenario-protected-area-calculation/scenario-protected-area-calculation-processor.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-protected-area-calculation/scenario-protected-area-calculation-processor.ts
@@ -45,7 +45,8 @@ export class ScenarioProtectedAreaCalculationProcessor
     UPDATE scenarios_pu_data
       SET (protected_area) = (SELECT protected_area
           FROM result
-          WHERE scenarios_pu_data.id = result.id);
+          WHERE scenarios_pu_data.id = result.id)
+      WHERE scenario_id = $1;
     `;
     const queryBuilder = this.scenarioPlanningUnitsRepo.query(
       query,


### PR DESCRIPTION
Without this constraint, all rows (of any scenarios in any project) would be overwritten.

For rows of the scenario being processed, the value of `protected_area` would be set to the correct value; for all other rows (other scenarios in any project), `protected_area` would be silently set to null as there is no data coming in via the CTE for rows that don't belong to the scenario being processed.

https://vizzuality.atlassian.net/browse/MARXAN-791

I still need to check whether all tiles now include the `percentageProtected` data, which should not have happened in any case at least for the scenario I was actively working on while triaging this issue.