### PR TITLE
fix(geo-features): searching via name should include project-id

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-features-request-info.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features-request-info.ts
@@ -1,0 +1,11 @@
+import { AppInfoDTO } from '@marxan-api/dto/info.dto';
+import { BBox } from 'geojson';
+
+export interface GeoFeaturesRequestInfo extends AppInfoDTO {
+  params?: {
+    featureClassAndAliasFilter?: string;
+    projectId?: string;
+    bbox?: BBox;
+    ids?: string[];
+  };
+}

--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -29,6 +29,7 @@ import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { GeometrySource } from './geometry-source.enum';
 import { v4 } from 'uuid';
 import { UploadShapefileDTO } from '../projects/dto/upload-shapefile.dto';
+import { GeoFeaturesRequestInfo } from './geo-features-request-info';
 
 const geoFeatureFilterKeyNames = [
   'featureClassName',
@@ -45,16 +46,12 @@ type GeoFeatureFilterKeys = keyof Pick<
 >;
 type GeoFeatureFilters = Record<GeoFeatureFilterKeys, string[]>;
 
-type ServiceRequestInfo = AppInfoDTO & {
-  forProject?: Project;
-};
-
 @Injectable()
 export class GeoFeaturesService extends AppBaseService<
   GeoFeature,
   GeoFeatureSetSpecification,
   GeoFeatureSetSpecification,
-  ServiceRequestInfo
+  GeoFeaturesRequestInfo
 > {
   constructor(
     @InjectRepository(GeoFeatureGeometry, DbConnections.geoprocessingDB)
@@ -99,7 +96,7 @@ export class GeoFeaturesService extends AppBaseService<
   setFilters(
     query: SelectQueryBuilder<GeoFeature>,
     filters: GeoFeatureFilters,
-    info?: ServiceRequestInfo,
+    info?: GeoFeaturesRequestInfo,
   ): SelectQueryBuilder<GeoFeature> {
     this._processBaseFilters<GeoFeatureFilters>(
       query,
@@ -115,7 +112,7 @@ export class GeoFeaturesService extends AppBaseService<
   async extendFindAllQuery(
     query: SelectQueryBuilder<GeoFeature>,
     fetchSpecification: FetchSpecification,
-    info: ServiceRequestInfo,
+    info: GeoFeaturesRequestInfo,
   ): Promise<SelectQueryBuilder<GeoFeature>> {
     /**
      * We should either list only "public" features (i.e. they are not from a
@@ -137,15 +134,7 @@ export class GeoFeaturesService extends AppBaseService<
     const projectId: string | undefined =
       (info?.params?.projectId as string) ??
       (fetchSpecification?.filter?.projectId as string);
-    if (projectId) {
-      const relatedProject = await this.projectRepository
-        .findOneOrFail(projectId)
-        .then((project) => project)
-        .catch((_error) => {
-          throw new NotFoundException(
-            `No project with id ${projectId} exists.`,
-          );
-        });
+    if (projectId && info?.params?.bbox) {
       const geoFeaturesWithinProjectBbox = await this.geoFeaturesGeometriesRepository
         .createQueryBuilder('geoFeatureGeometries')
         .distinctOn(['"geoFeatureGeometries"."feature_id"'])
@@ -155,10 +144,10 @@ export class GeoFeaturesService extends AppBaseService<
         "geoFeatureGeometries".the_geom
       )`,
           {
-            xmin: relatedProject.bbox[1],
-            ymin: relatedProject.bbox[3],
-            xmax: relatedProject.bbox[0],
-            ymax: relatedProject.bbox[2],
+            xmin: info.params.bbox[1],
+            ymin: info.params.bbox[3],
+            xmax: info.params.bbox[0],
+            ymax: info.params.bbox[2],
           },
         )
         .getMany()
@@ -210,7 +199,7 @@ export class GeoFeaturesService extends AppBaseService<
   async extendFindAllResults(
     entitiesAndCount: [any[], number],
     fetchSpecification?: DeepReadonly<FetchSpecification>,
-    info?: ServiceRequestInfo,
+    info?: GeoFeaturesRequestInfo,
   ): Promise<[any[], number]> {
     /**
      * Short-circuit if there's no result to extend, or if the API client has
@@ -239,7 +228,7 @@ export class GeoFeaturesService extends AppBaseService<
     );
 
     const entitiesWithProperties = await this.geoFeaturesPropertySet
-      .getFeaturePropertySetsForFeatures(geoFeatureIds, info?.forProject)
+      .getFeaturePropertySetsForFeatures(geoFeatureIds, info?.params?.bbox)
       .then((results) => {
         return this.geoFeaturesPropertySet.extendGeoFeaturesWithPropertiesFromPropertySets(
           entitiesAndCount[0],

--- a/api/apps/api/src/modules/geo-features/index.ts
+++ b/api/apps/api/src/modules/geo-features/index.ts
@@ -1,1 +1,3 @@
 export { FeaturesCalculated } from './processing';
+export { GeoFeaturesService } from './geo-features.service';
+export { GeoFeaturesRequestInfo } from './geo-features-request-info';

--- a/api/apps/api/src/modules/projects/project-requests-info.ts
+++ b/api/apps/api/src/modules/projects/project-requests-info.ts
@@ -1,0 +1,11 @@
+import { AppInfoDTO } from '@marxan-api/dto/info.dto';
+import { BBox } from 'geojson';
+
+export interface ProjectsRequest extends AppInfoDTO {
+  params?: {
+    featureClassAndAliasFilter?: string;
+    projectId?: string;
+    bbox?: BBox;
+    nameSearch?: string;
+  } & AppInfoDTO['params'];
+}

--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -24,9 +24,10 @@ import {
 } from './planning-areas';
 import { UsersProjectsApiEntity } from './control-level/users-projects.api.entity';
 import { Roles } from '@marxan-api/modules/users/role.api.entity';
-import { AppInfoDTO } from '@marxan-api/dto/info.dto';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { ProtectedArea } from '@marxan/protected-areas';
+
+import { ProjectsRequest } from './project-requests-info';
 
 const projectFilterKeyNames = [
   'name',
@@ -41,18 +42,12 @@ type ProjectFilterKeys = keyof Pick<
 >;
 type ProjectFilters = Record<ProjectFilterKeys, string[]>;
 
-export type ProjectsInfoDTO = AppInfoDTO & {
-  params?: {
-    nameSearch?: string;
-  };
-};
-
 @Injectable()
 export class ProjectsCrudService extends AppBaseService<
   Project,
   CreateProjectDTO,
   UpdateProjectDTO,
-  ProjectsInfoDTO
+  ProjectsRequest
 > {
   constructor(
     @InjectRepository(Project)
@@ -131,7 +126,7 @@ export class ProjectsCrudService extends AppBaseService<
   setFilters(
     query: SelectQueryBuilder<Project>,
     filters: ProjectFilters,
-    _info?: ProjectsInfoDTO,
+    _info?: ProjectsRequest,
   ): SelectQueryBuilder<Project> {
     this._processBaseFilters<ProjectFilters>(
       query,
@@ -143,7 +138,7 @@ export class ProjectsCrudService extends AppBaseService<
 
   async setDataCreate(
     create: CreateProjectDTO,
-    info?: ProjectsInfoDTO,
+    info?: ProjectsRequest,
   ): Promise<Project> {
     assertDefined(info?.authenticatedUser?.id);
     /**
@@ -180,7 +175,7 @@ export class ProjectsCrudService extends AppBaseService<
   async actionAfterCreate(
     model: Project,
     createModel: CreateProjectDTO,
-    _info?: ProjectsInfoDTO,
+    _info?: ProjectsRequest,
   ): Promise<void> {
     if (
       createModel.planningUnitAreakm2 &&
@@ -211,7 +206,7 @@ export class ProjectsCrudService extends AppBaseService<
   async actionAfterUpdate(
     model: Project,
     createModel: UpdateProjectDTO,
-    _info?: ProjectsInfoDTO,
+    _info?: ProjectsRequest,
   ): Promise<void> {
     /**
      * @deprecated Workers and jobs should be move to the new functionality
@@ -243,7 +238,7 @@ export class ProjectsCrudService extends AppBaseService<
   async setDataUpdate(
     model: Project,
     update: UpdateProjectDTO,
-    _?: ProjectsInfoDTO,
+    _?: ProjectsRequest,
   ): Promise<Project> {
     const bbox = await this.planningAreasService.getPlanningAreaBBox({
       ...update,
@@ -262,7 +257,7 @@ export class ProjectsCrudService extends AppBaseService<
   async extendGetByIdResult(
     entity: Project,
     _fetchSpecification?: FetchSpecification,
-    _info?: ProjectsInfoDTO,
+    _info?: ProjectsRequest,
   ): Promise<Project> {
     const ids: MultiplePlanningAreaIds = entity;
     const idAndName = await this.planningAreasService.getPlanningAreaIdAndName(
@@ -289,7 +284,7 @@ export class ProjectsCrudService extends AppBaseService<
   extendGetByIdQuery(
     query: SelectQueryBuilder<Project>,
     fetchSpecification?: FetchSpecification,
-    info?: ProjectsInfoDTO,
+    info?: ProjectsRequest,
   ): SelectQueryBuilder<Project> {
     const loggedUser = Boolean(info?.authenticatedUser);
     query.leftJoin(
@@ -316,7 +311,7 @@ export class ProjectsCrudService extends AppBaseService<
   async extendFindAllQuery(
     query: SelectQueryBuilder<Project>,
     fetchSpecification: FetchSpecification,
-    info?: ProjectsInfoDTO,
+    info?: ProjectsRequest,
   ): Promise<SelectQueryBuilder<Project>> {
     const loggedUser = Boolean(info?.authenticatedUser);
 
@@ -382,7 +377,7 @@ export class ProjectsCrudService extends AppBaseService<
   async extendFindAllResults(
     entitiesAndCount: [Project[], number],
     _fetchSpecification?: FetchSpecification,
-    _info?: ProjectsInfoDTO,
+    _info?: ProjectsRequest,
   ): Promise<[Project[], number]> {
     const extendedEntities: Promise<Project>[] = entitiesAndCount[0].map(
       (entity) => this.extendGetByIdResult(entity),

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -93,12 +93,14 @@ export class ProjectsController {
     @ProcessFetchSpecification() fetchSpecification: FetchSpecification,
     @Param() params: { projectId: string },
     @Query('q') featureClassAndAliasFilter: string,
+    @Req() req: RequestWithAuthenticatedUser,
   ): Promise<GeoFeatureResult> {
     const { data, metadata } = await this.projectsService.findAllGeoFeatures(
       fetchSpecification,
       {
+        authenticatedUser: req.user,
         params: {
-          ...params,
+          projectId: params.projectId,
           featureClassAndAliasFilter: featureClassAndAliasFilter,
         },
       },

--- a/api/apps/api/test/geo-features.e2e-spec.ts
+++ b/api/apps/api/test/geo-features.e2e-spec.ts
@@ -98,7 +98,7 @@ describe('GeoFeaturesModule (e2e)', () => {
           .set('Authorization', `Bearer ${jwtToken}`)
           .expect(HttpStatus.OK);
 
-        expect(response.body.data).toHaveLength(6);
+        expect(response.body.data).toHaveLength(4);
       });
       test('should return all available features if query param has no value', async () => {
         const response = await request(app.getHttpServer())


### PR DESCRIPTION
PR is hard to read in one diff - recommended way it commit-by-commit.

First one contains a little re-organization of "AppInfoDTO" thingy to keep known properties really known - during that it proved that some property is "used" but not really created/added at any point, thus leading to not using project id correctly
Second is another fix - previously the `OR like ...` was out of the other conditions, totally ignoring project limitations. Thanks @Sikora00 for spotting this!

With search param:
![image](https://user-images.githubusercontent.com/3466388/137087237-34318ce7-c2c2-4967-8ba9-223fc64d174f.png)
