### PR TITLE
libbot: add support for number of runs

### DIFF
--- a/data/bots/core-demos/demo-australia/core.ts
+++ b/data/bots/core-demos/demo-australia/core.ts
@@ -99,6 +99,8 @@ export const runBot = async (settings: MarxanBotConfig) => {
     "some",
   );
 
+  await bot.scenarios.setNumberOfRuns(scenario.id, 100);
+
   await bot.marxanExecutor.runForScenario(scenario.id);
 
   await bot.scenarioStatus.waitForMarxanCalculationsFor(

--- a/data/bots/core-demos/demo-brazil/core.ts
+++ b/data/bots/core-demos/demo-brazil/core.ts
@@ -100,6 +100,8 @@ export const runBot = async (settings: MarxanBotConfig) => {
     "short",
   );
 
+  await bot.scenarios.setNumberOfRuns(scenario.id, 100);
+
   await bot.marxanExecutor.runForScenario(scenario.id);
 
   await bot.scenarioStatus.waitForMarxanCalculationsFor(

--- a/data/bots/lib/libbot/geo-feature-specifications.ts
+++ b/data/bots/lib/libbot/geo-feature-specifications.ts
@@ -24,7 +24,7 @@ export class GeoFeatureSpecifications {
     };
 
     return await this.baseHttpClient.post(
-      `/scenarios/${scenarioId}/features/specification/v2`,
+      `/scenarios/${scenarioId}/features/specification`,
       specification,
     )
       .then(getJsonApiDataFromResponse)

--- a/data/bots/lib/libbot/scenarios.ts
+++ b/data/bots/lib/libbot/scenarios.ts
@@ -76,4 +76,8 @@ export class Scenarios {
     logDebug(`Scenario:\n${Deno.inspect(result)}`);
     return result;
   }
+
+  async setNumberOfRuns(scenarioId: string, numberOfRuns: number = 100) {
+    await this.baseHttpClient.patch(`/scenarios/${scenarioId}`, { numberOfRuns });
+  }
 }


### PR DESCRIPTION
This could be achieved by setting the related property via POST/PATCH /api/v1/scenarios/:id; this PR adds a little convenience method to do so via libbot's "DSL".

The PR also updates the specification submission endpoint path removing the recently deprecated `/v2` suffix.