### PR TITLE
fix(shapefile): spaces in name no longer cause the crash

### DIFF
--- a/api/libs/shapefile-converter/src/shapefiles/shapefiles.service.ts
+++ b/api/libs/shapefile-converter/src/shapefiles/shapefiles.service.ts
@@ -33,10 +33,10 @@ export class ShapefileService {
     );
 
     await mapshaper.runCommandsXL(
-      `-i snap ${fileInfo.path.replace(
+      `-i snap "${fileInfo.path.replace(
         '.zip',
         '',
-      )}/*.shp -proj EPSG:4326 -clean rewind -info -o ${outputFile}`,
+      )}/*.shp" -proj EPSG:4326 -clean rewind -info -o "${outputFile}"`,
     );
 
     const geoJsonBuffer = await readFile(outputFile);


### PR DESCRIPTION
I don't really understand why this was causing troubles when I was at it previously. Could be some related changes were messing up.