### PR TITLE
update demo bots to use all species features and realistic PU area

### DIFF
--- a/data/bots/core-demos/demo-australia/core.ts
+++ b/data/bots/core-demos/demo-australia/core.ts
@@ -19,7 +19,7 @@ export const runBot = async (settings: MarxanBotConfig) => {
     description: "",
   });
 
-  const planningUnitAreakm2 = 2000;
+  const planningUnitAreakm2 = 25;
 
   const planningAreaId = await bot.planningAreaUploader.uploadFromFile(
     `${scriptPath}/kimberley.zip`,
@@ -68,15 +68,15 @@ export const runBot = async (settings: MarxanBotConfig) => {
   //Setup features in the project
   const wantedFeatures = [
     // "demo_ecoregions_new_class_split",
-    // "calidris_(erolia)_ferruginea",
-    // "chlamydosaurus_kingii",
-    // "erythrura_(chloebia)_gouldiae",
-    // "haliaeetus_(pontoaetus)_leucogaster",
-    // "malurus_(malurus)_coronatus",
-    // "mesembriomys_macrurus",
-    // "onychogalea_unguifera",
-    // "pseudechis_australis",
-    // "wyulda_squamicaudata",
+    "calidris_(erolia)_ferruginea",
+    "chlamydosaurus_kingii",
+    "erythrura_(chloebia)_gouldiae",
+    "haliaeetus_(pontoaetus)_leucogaster",
+    "malurus_(malurus)_coronatus",
+    "mesembriomys_macrurus",
+    "onychogalea_unguifera",
+    "pseudechis_australis",
+    "wyulda_squamicaudata",
     "zyzomys_woodwardi",
   ];
 

--- a/data/bots/core-demos/demo-brazil/core.ts
+++ b/data/bots/core-demos/demo-brazil/core.ts
@@ -19,7 +19,7 @@ export const runBot = async (settings: MarxanBotConfig) => {
     description: "",
   });
 
-  const planningUnitAreakm2 = 2000;
+  const planningUnitAreakm2 = 50;
 
   const planningAreaId = await bot.planningAreaUploader.uploadFromFile(
     `${scriptPath}/test_mata.zip`,
@@ -69,15 +69,15 @@ export const runBot = async (settings: MarxanBotConfig) => {
   //Setup features in the project
   const wantedFeatures = [
     // "demo_ecoregions_new_class_split",
-    // "buteogallus_urubitinga",
-    // "caluromys_philander",
-    // "chiroxiphia_caudata",
-    // "leopardus_pardalis",
-    // "megarynchus_pitangua",
-    // "phyllodytes_tuberculosus",
-    // "priodontes_maximus",
-    // "proceratophrys_bigibbosa",
-    // "tapirus_terrestris",
+    "buteogallus_urubitinga",
+    "caluromys_philander",
+    "chiroxiphia_caudata",
+    "leopardus_pardalis",
+    "megarynchus_pitangua",
+    "phyllodytes_tuberculosus",
+    "priodontes_maximus",
+    "proceratophrys_bigibbosa",
+    "tapirus_terrestris",
     "thalurania_glaucopis",
   ];
 


### PR DESCRIPTION
- uncomment all previously commented-out species features
- use realistic PU area of 50km^2 instead of 2000km^2 as previously used for tests