### PR TITLE
Allow uploaded protected area to be given a name

### DIFF
--- a/api/apps/api/src/modules/scenarios/dto/upload.shapefile.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/upload.shapefile.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UploadShapefileDto {
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  name?: string;
+}

--- a/api/apps/api/src/modules/scenarios/protected-area/protected-area.service.ts
+++ b/api/apps/api/src/modules/scenarios/protected-area/protected-area.service.ts
@@ -39,11 +39,13 @@ export class ProtectedAreaService {
     projectId: string,
     scenarioId: string,
     shapefile: JobInput['shapefile'],
+    name: JobInput['name'],
   ): Promise<Either<typeof submissionFailed, true>> {
     const job = await this.queue.add(`add-protected-area`, {
       projectId,
       scenarioId,
       shapefile,
+      name,
     });
 
     // bad typing? may happen that job wasn't added
@@ -61,6 +63,7 @@ export class ProtectedAreaService {
           kind,
           scenarioId,
           projectId,
+          name,
         },
       });
     } catch (error: unknown) {

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -91,6 +91,7 @@ import { asyncJobTag } from '@marxan-api/dto/async-job-tag';
 import { inlineJobTag } from '@marxan-api/dto/inline-job-tag';
 import { submissionFailed } from '@marxan-api/modules/scenarios/protected-area';
 import { ProtectedAreaDto } from '@marxan-api/modules/scenarios/dto/protected-area.dto';
+import { UploadShapefileDto } from '@marxan-api/modules/scenarios/dto/upload.shapefile.dto';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -645,7 +646,6 @@ export class ScenariosController {
     return;
   }
 
-
   @ApiOkResponse({
     type: ProtectedAreaDto,
     isArray: true,
@@ -678,10 +678,14 @@ export class ScenariosController {
     @Param('id') scenarioId: string,
     @UploadedFile() file: Express.Multer.File,
     @Req() req: RequestWithAuthenticatedUser,
+    @Body() dto: UploadShapefileDto,
   ): Promise<JsonApiAsyncJobMeta> {
-    const outcome = await this.service.addProtectedAreaFor(scenarioId, file, {
-      authenticatedUser: req.user,
-    });
+    const outcome = await this.service.addProtectedAreaFor(
+      scenarioId,
+      file,
+      { authenticatedUser: req.user },
+      dto,
+    );
     if (isLeft(outcome)) {
       switch (outcome.left) {
         case submissionFailed:
@@ -692,5 +696,4 @@ export class ScenariosController {
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
-
 }

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -50,6 +50,7 @@ import { QueryBus } from '@nestjs/cqrs';
 import { GetProjectQuery, GetProjectErrors } from '@marxan/projects';
 import { ProtectedAreaService, submissionFailed } from './protected-area';
 import { ScenarioProtectedArea } from '@marxan-api/modules/scenarios/protected-area/scenario-protected-area';
+import { UploadShapefileDto } from '@marxan-api/modules/scenarios/dto/upload.shapefile.dto';
 
 /** @debt move to own module */
 const EmptyGeoFeaturesSpecification: GeoFeatureSetSpecification = {
@@ -414,6 +415,7 @@ export class ScenariosService {
     scenarioId: string,
     file: Express.Multer.File,
     info: AppInfoDTO,
+    dto: UploadShapefileDto,
   ): Promise<Either<SubmitProtectedAreaError, true>> {
     try {
       const scenario = await this.assertScenario(scenarioId);
@@ -428,6 +430,7 @@ export class ScenariosService {
         projectResponse.right.id,
         scenarioId,
         file,
+        dto.name,
       );
 
       if (isLeft(submission)) {

--- a/api/apps/geoprocessing/src/modules/protected-areas/worker/protected-area-processor.ts
+++ b/api/apps/geoprocessing/src/modules/protected-areas/worker/protected-area-processor.ts
@@ -41,7 +41,7 @@ export class ProtectedAreaProcessor
                ) AS f
           RETURNING "id"
         `,
-        [geo, job.data.projectId, job.data.shapefile.filename],
+        [geo, job.data.projectId, job.data.name || job.data.shapefile.filename],
       );
 
       return plainToClass<JobOutput, JobOutput>(JobOutput, {

--- a/api/apps/geoprocessing/test/integration/protected-areas/steps/shapefile-for-wdpa-world.ts
+++ b/api/apps/geoprocessing/test/integration/protected-areas/steps/shapefile-for-wdpa-world.ts
@@ -41,6 +41,18 @@ export const createWorld = (
         },
         id: 'test-job',
       } as unknown) as Job<JobInput>),
+    WhenShapefileAndNameAreSubmitted: (customName: string) =>
+      (({
+        data: {
+          projectId,
+          scenarioId,
+          shapefile: {
+            ...shapefile,
+          },
+          name: customName,
+        },
+        id: 'test-job',
+      } as unknown) as Job<JobInput>),
     projectId,
     ThenOldEntriesAreRemoved: async (oldShapeName: string) =>
       repo

--- a/api/apps/geoprocessing/test/integration/protected-areas/upload-shapefile-for-project.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/protected-areas/upload-shapefile-for-project.e2e-spec.ts
@@ -36,6 +36,14 @@ describe(`when worker processes the job for known project`, () => {
   });
 });
 
+describe(`when providing name in job input`, () => {
+  it(`uses provided name as protected area's "fullName"`, async () => {
+    await sut.process(world.WhenShapefileAndNameAreSubmitted('custom name'));
+    await delay(2000);
+    expect(await world.ThenNewEntriesArePublished('custom name')).toEqual(true);
+  });
+});
+
 afterAll(async () => {
   await world.cleanup();
   await app?.close();

--- a/api/libs/protected-areas/src/add-protected-area-input.ts
+++ b/api/libs/protected-areas/src/add-protected-area-input.ts
@@ -20,4 +20,7 @@ export class JobInput {
   @ValidateNested()
   @Type(() => Shapefile)
   shapefile!: Shapefile;
+
+  @IsString()
+  name?: string;
 }


### PR DESCRIPTION
## Allow uploaded protected area to be given a name

### Overview

This PR adds the possibility of providing (optionally) a `name` when uploading shapefile for a project scenario using the endpoint `POST api/v1/scenarios/':id/protected-areas/shapefile')`.

If no `name` is provided, the current behavior is kept - the file name is used and inserted in the DB as `fullName`.

### Testing instructions

1. Call the `POST api/v1/scenarios/':id/protected-areas/shapefile')` endpoint, providing only the shapefile - the inserted row in the `wdpa` table in the `geo` database should have `fullName` set to the name of the uploaded file (existing behavior).
2. Call the `POST api/v1/scenarios/':id/protected-areas/shapefile')` endpoint, providing the shapefile and a `name` in the request body - the inserted row in the `wdpa` table in the `geo` database should have `fullName` set to the provided `name`.

### Feature relevant tickets

[MARXAN-923](https://vizzuality.atlassian.net/browse/MARXAN-923)

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file