### PR TITLE
derive BLM calibration values from min,max range [MARXAN-890]

### DIFF
--- a/docs/features/boundary-length-modifier/brief.md
+++ b/docs/features/boundary-length-modifier/brief.md
@@ -48,15 +48,32 @@ across each of the runs.
 
 ## Requirements
 
-- Users should be able to set their BLM values.
+- Users should be able to set their BLM values, by supplying a `[min, max]`
+  range, from which the BLM calibration process will derive a set of BLM values
+  to use by splitting the domain in equal intervals, according to the formula
+  below.
 
-The set should be limited to a small cardinality: 6 values for the initial
-implementation, but leaving space for adjustments in the future (i.e. it is ok
-to hardcode the size of the set, but changing it in the future should not break
-other assumptions).
+Whereas the user input consists in exactly two values, the derived set of values
+to be used for the calibration process should be limited to a small cardinality:
+6 values for the initial implementation, but leaving space for adjustments in
+the future (i.e. it is ok to hardcode the size of the set, but changing it in
+the future should not break other assumptions).
 
-- The 6 values given by default will be `BLM = Z*sqrt(PU area)` (with `Z`  being
-  `0.001`, `0.01`, `0.1`, `1`, `10` and `100`).
+- Given a `[min, max]` range and a cardinality of `N` for the set of BLM values
+  to be used, the actual values are derived as:
+
+```
+blmValues(min, max) = [
+  min,
+  (min + ((max-min) / N-1)) * 1,
+  (min + ((max-min) / N-1)) * 2,
+  ...,
+  (min + ((max-min) / N-1)) * N-1
+]
+```
+
+- The 6 values given by default will be `BLM = Z*sqrt(PU area)` (with `Z ∈
+  blmValues(0.001, 100)`).
   
 This will apply for the majority of projects, which are expected to use a
 constant PU area. Some projects may use irregularly-shaped planning units with

--- a/docs/features/boundary-length-modifier/brief.md
+++ b/docs/features/boundary-length-modifier/brief.md
@@ -78,12 +78,10 @@ blmValues(min, max) = [
 This will apply for the majority of projects, which are expected to use a
 constant PU area. Some projects may use irregularly-shaped planning units with
 varying area: in this case the mean of the areas of the planning units in the
-study area should be used [*], with option to further tune this in the future
+study area should be used, with option to further tune this in the future
 (as above, it is ok to hardcode this, as long as using a different aggregation
 formula that doesn't depend on other inputs than PU area and PU count will not
 break other assumptions).
-
-[*] Pending confirmation.
 
 - For each of the BLM values being used in the calibration process:
 

--- a/docs/features/boundary-length-modifier/brief.md
+++ b/docs/features/boundary-length-modifier/brief.md
@@ -32,8 +32,8 @@ Once the calibration results are presented to the user, they may then choose to:
 
 - Select one of the calibrated BLM values, to implement in the scenario (this
   will set the BLM property for the scenario)
-- Change one or more 6 values of the previous calibration run, and re-run the
-  calibration
+- Change the settings (`[min, max]` range, see below) of the previous
+  calibration run and then re-run the calibration
 - Input their own BLM value (without using the platform's calibration feature)
 
 ## Overview of the process

--- a/docs/features/boundary-length-modifier/development-plan.md
+++ b/docs/features/boundary-length-modifier/development-plan.md
@@ -9,7 +9,7 @@ depend on choices such as whether to adapt and reuse
 
 * Workspace setup for BLM calibration runs: fetch input `.dat` files only once
   per set of runs to be scheduled for the calibration process.
-* API interface (endpoint and payload DTO) to accept a BLM calibration request
+* API interface (endpoint and payload DTO) to accept a BLM calibration request;
   this also needs to persist the set of BLM values chosen (even if they are
   the initial recommended ones)
 * Add latest BLM values for calibration to the scenario DTO

--- a/docs/features/boundary-length-modifier/high-level-design.md
+++ b/docs/features/boundary-length-modifier/high-level-design.md
@@ -15,8 +15,8 @@ https://invis.io/G211WEUZFST9#/459986030_Marxan_09a
   possibly to cancel a current calibration process (force-starting a new one
   will need a currently-running one to be cancelled)
 * The Marxan solver must be run N (6) times, each time for 10 iterations and
-  with one of the N BLM values provided by default in the BLM calibration
-  screen, or set there by the user
+  with one of the N BLM values generated from the initial default range bounds
+  in the BLM calibration screen, or set there by the user
 * It may be desirable to set number of runs N as a config default; this number
   is not expected to change once confirmed, and doing so would have implications
   for the frontend, but it would help to make it a configurable setting at least
@@ -28,8 +28,8 @@ https://invis.io/G211WEUZFST9#/459986030_Marxan_09a
   the project result DTO; probably the former would be preferrable, to avoid
   overloading the project result DTO
 * `POST` endpoint (e.g. `/api/v1/scenarios/:id/calibration`) to request a
-  calibration task with specific BLM values (either the initial recommended
-  ones, or those set by users)
+  calibration task using a given `[min, max]` range for BLM values (either the
+  initial recommended ones, or those set by users)
 * User-set values should also be persisted and associated to a scenario: once
   the BLM calibration process has finished the values will also be inferrable
   from the results, but until then there must be a way for the frontend to


### PR DESCRIPTION
This PR updates the BLM calibration brief describing the current/latest functional requirements, whereby users are asked to supply only a `[min, max]` range, from which we derive the intermediate values on a linear scale.