### PR TITLE
feat(blm): project defaults skeleton

### DIFF
--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -32,6 +32,7 @@ import { PlanningUnitsModule } from '@marxan-api/modules/planning-units/planning
 import { SpecificationModule } from '@marxan-api/modules/specification';
 import { ScenarioSpecificationModule } from './modules/scenario-specification';
 import { PublishedProjectModule } from '@marxan-api/modules/published-project/published-project.module';
+import { BlmValuesModule } from '@marxan-api/modules/blm';
 
 @Module({
   imports: [
@@ -63,6 +64,7 @@ import { PublishedProjectModule } from '@marxan-api/modules/published-project/pu
     SpecificationModule,
     ScenarioSpecificationModule,
     PublishedProjectModule,
+    BlmValuesModule,
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/apps/api/src/modules/blm/blm.module.ts
+++ b/api/apps/api/src/modules/blm/blm.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { BlmValuesModule } from './values/blm-values.module';
+
+@Module({
+  imports: [BlmValuesModule],
+  exports: [BlmValuesModule],
+})
+export class BlmModule {}

--- a/api/apps/api/src/modules/blm/index.ts
+++ b/api/apps/api/src/modules/blm/index.ts
@@ -1,0 +1,12 @@
+export { BlmModule } from './blm.module';
+export {
+  projectNotFound,
+  unknownError,
+  alreadyCreated,
+  ProjectBlm,
+  ProjectBlmRepository,
+  CreateFailure,
+  GetFailure,
+  SaveFailure,
+  BlmValuesModule,
+} from './values';

--- a/api/apps/api/src/modules/blm/values/blm-values.module.ts
+++ b/api/apps/api/src/modules/blm/values/blm-values.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+
+import { ProjectBlmRepository } from './project-blm-repository';
+import { TypeormProjectBlmRepository } from './typeorm-project-blm-repository';
+
+@Module({
+  imports: [
+    /**
+     * TypeORM etc.
+     */
+  ],
+  providers: [
+    {
+      provide: ProjectBlmRepository,
+      useClass: TypeormProjectBlmRepository,
+    },
+  ],
+  exports: [ProjectBlmRepository],
+})
+export class BlmValuesModule {}

--- a/api/apps/api/src/modules/blm/values/index.ts
+++ b/api/apps/api/src/modules/blm/values/index.ts
@@ -1,0 +1,11 @@
+export { BlmValuesModule } from './blm-values.module';
+export {
+  ProjectBlmRepository,
+  ProjectBlm,
+  SaveFailure,
+  GetFailure,
+  CreateFailure,
+  alreadyCreated,
+  projectNotFound,
+  unknownError,
+} from './project-blm-repository';

--- a/api/apps/api/src/modules/blm/values/project-blm-repository.ts
+++ b/api/apps/api/src/modules/blm/values/project-blm-repository.ts
@@ -10,8 +10,20 @@ export type GetFailure = typeof unknownError | typeof projectNotFound;
 
 export interface ProjectBlm {
   id: string;
+
+  /**
+   * User-supplied or defaults if none provided,
+   */
   range: [number, number];
+
+  /**
+   * Calculated from range.
+   */
   values: number[];
+
+  /**
+   * Sets once at the project creation chain - once PU are known.
+   */
   defaults: number[];
 }
 

--- a/api/apps/api/src/modules/blm/values/project-blm-repository.ts
+++ b/api/apps/api/src/modules/blm/values/project-blm-repository.ts
@@ -1,0 +1,33 @@
+import { Either } from 'fp-ts/Either';
+
+export const unknownError = Symbol(`unknown error`);
+export const projectNotFound = Symbol(`project not found`);
+export const alreadyCreated = Symbol(`project already has defaults`);
+
+export type CreateFailure = typeof unknownError | typeof alreadyCreated;
+export type SaveFailure = typeof unknownError | typeof projectNotFound;
+export type GetFailure = typeof unknownError | typeof projectNotFound;
+
+export interface ProjectBlm {
+  id: string;
+  range: [number, number];
+  values: number[];
+  defaults: number[];
+}
+
+type SaveSuccess = true;
+
+export abstract class ProjectBlmRepository {
+  abstract create(
+    projectId: string,
+    defaults: ProjectBlm['defaults'],
+  ): Promise<Either<CreateFailure, SaveSuccess>>;
+
+  abstract update(
+    projectId: string,
+    range: ProjectBlm['range'],
+    values: ProjectBlm['values'],
+  ): Promise<Either<SaveFailure, SaveSuccess>>;
+
+  abstract get(projectId: string): Promise<Either<GetFailure, ProjectBlm>>;
+}

--- a/api/apps/api/src/modules/blm/values/typeorm-project-blm-repository.ts
+++ b/api/apps/api/src/modules/blm/values/typeorm-project-blm-repository.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { Either, right } from 'fp-ts/Either';
+
+import {
+  ProjectBlmRepository,
+  ProjectBlm,
+  GetFailure,
+  SaveFailure,
+  CreateFailure,
+} from './project-blm-repository';
+
+@Injectable()
+export class TypeormProjectBlmRepository extends ProjectBlmRepository {
+  async get(projectId: string): Promise<Either<GetFailure, ProjectBlm>> {
+    return right({
+      id: projectId,
+      range: [0, 0],
+      values: [0, 0, 0, 0, 0, 0],
+      defaults: [0, 0, 0, 0, 0, 0],
+    });
+  }
+
+  async create(
+    projectId: string,
+    defaults: ProjectBlm['defaults'],
+  ): Promise<Either<CreateFailure, true>> {
+    return right(true);
+  }
+
+  async update(
+    projectId: string,
+    range: ProjectBlm['range'],
+    values: ProjectBlm['values'],
+  ): Promise<Either<SaveFailure, true>> {
+    return right(true);
+  }
+}

--- a/api/apps/api/src/modules/projects/blm/change-blm-range.command.ts
+++ b/api/apps/api/src/modules/projects/blm/change-blm-range.command.ts
@@ -1,0 +1,16 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+import { Either } from 'fp-ts/Either';
+
+export const invalidRange = Symbol(`invalid range`);
+export const unknownError = Symbol(`unknown error`);
+
+export type ChangeRangeErrors = typeof invalidRange | typeof unknownError;
+
+export class ChangeBlmRange extends Command<Either<ChangeRangeErrors, true>> {
+  constructor(
+    public readonly projectId: string,
+    public readonly range: [number, number],
+  ) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/projects/blm/change-blm-range.handler.ts
+++ b/api/apps/api/src/modules/projects/blm/change-blm-range.handler.ts
@@ -1,0 +1,18 @@
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { Either, right } from 'fp-ts/Either';
+
+import { ChangeBlmRange, ChangeRangeErrors } from './change-blm-range.command';
+import { ProjectBlmRepository } from '@marxan-api/modules/blm';
+
+@CommandHandler(ChangeBlmRange)
+export class ChangeBlmRangeHandler
+  implements IInferredCommandHandler<ChangeBlmRange> {
+  constructor(private readonly blmRepository: ProjectBlmRepository) {}
+
+  async execute({
+    projectId,
+    range,
+  }: ChangeBlmRange): Promise<Either<ChangeRangeErrors, true>> {
+    return right(true);
+  }
+}

--- a/api/apps/api/src/modules/projects/blm/index.ts
+++ b/api/apps/api/src/modules/projects/blm/index.ts
@@ -1,0 +1,8 @@
+export { ProjectBlmModule } from './project-blm.module';
+
+export {
+  ChangeRangeErrors,
+  unknownError,
+  invalidRange,
+  ChangeBlmRange,
+} from './change-blm-range.command';

--- a/api/apps/api/src/modules/projects/blm/project-blm.module.ts
+++ b/api/apps/api/src/modules/projects/blm/project-blm.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+
+import { BlmModule } from '@marxan-api/modules/blm';
+
+import { SetProjectBlmHandler } from './set-project-blm-handler';
+import { ProjectBlmSaga } from './project-blm.saga';
+import { ChangeBlmRangeHandler } from './change-blm-range.handler';
+
+@Module({
+  imports: [CqrsModule, BlmModule],
+  providers: [SetProjectBlmHandler, ChangeBlmRangeHandler, ProjectBlmSaga],
+})
+export class ProjectBlmModule {}

--- a/api/apps/api/src/modules/projects/blm/project-blm.saga.ts
+++ b/api/apps/api/src/modules/projects/blm/project-blm.saga.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { PlanningUnitSet } from '@marxan/planning-units-grid';
+
+import { SetProjectBlm } from './set-project-blm';
+
+@Injectable()
+export class ProjectBlmSaga {
+  @Saga()
+  calculateBlmDefaults = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(PlanningUnitSet),
+      map((event) => new SetProjectBlm(event.projectId)),
+    );
+}

--- a/api/apps/api/src/modules/projects/blm/set-project-blm-handler.ts
+++ b/api/apps/api/src/modules/projects/blm/set-project-blm-handler.ts
@@ -1,0 +1,17 @@
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { ProjectBlmRepository } from '@marxan-api/modules/blm';
+
+import { SetProjectBlm } from './set-project-blm';
+
+@CommandHandler(SetProjectBlm)
+export class SetProjectBlmHandler
+  implements IInferredCommandHandler<SetProjectBlm> {
+  constructor(private readonly blmRepository: ProjectBlmRepository) {}
+
+  async execute({ projectId }: SetProjectBlm): Promise<void> {
+    // calculate ...
+
+    // persist + error handling
+    await this.blmRepository.create(projectId, [0, 1, 2, 3, 4, 5]);
+  }
+}

--- a/api/apps/api/src/modules/projects/blm/set-project-blm.ts
+++ b/api/apps/api/src/modules/projects/blm/set-project-blm.ts
@@ -1,0 +1,7 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+
+export class SetProjectBlm extends Command<void> {
+  constructor(public readonly projectId: string) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -28,6 +28,7 @@ import { ProtectedArea } from '@marxan/protected-areas';
 import { apiConnections } from '@marxan-api/ormconfig';
 import { CqrsModule } from '@nestjs/cqrs';
 import { GetProjectHandler } from './get-project.handler';
+import { ProjectBlmModule } from './blm';
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { GetProjectHandler } from './get-project.handler';
     ApiEventsModule,
     ShapefilesModule,
     PlanningUnitGridModule,
+    ProjectBlmModule,
   ],
   providers: [
     ProjectsCrudService,

--- a/api/libs/planning-units-grid/src/index.ts
+++ b/api/libs/planning-units-grid/src/index.ts
@@ -2,3 +2,5 @@ export { queueName } from './queue-name';
 
 export { JobInput, Shapefile } from './job-input';
 export { JobOutput } from './job-output';
+
+export { PlanningUnitSet } from './planning-unit-set.event';

--- a/api/libs/planning-units-grid/src/planning-unit-set.event.ts
+++ b/api/libs/planning-units-grid/src/planning-unit-set.event.ts
@@ -1,0 +1,13 @@
+import { IEvent } from '@nestjs/cqrs';
+
+/**
+ * after determining planning area, once Planning Units are set
+ * project is fully set.
+ *
+ * This event may be used to trigger calculating initial, default discrete
+ * BLM values.
+ *
+ */
+export class PlanningUnitSet implements IEvent {
+  constructor(public readonly projectId: string) {}
+}


### PR DESCRIPTION
This PR includes a "skeleton" of application shape. The main purpose of it is to fulfill requirements related to calculating default BLM values after project has been created (as its grid/planning units). 

Once its merged, the following tasks/pieces should be relatively easy to complete in isolation:
https://vizzuality.atlassian.net/browse/MARXAN-995
https://vizzuality.atlassian.net/browse/MARXAN-996
https://vizzuality.atlassian.net/browse/MARXAN-997
https://vizzuality.atlassian.net/browse/MARXAN-998
https://vizzuality.atlassian.net/browse/MARXAN-999
https://vizzuality.atlassian.net/browse/MARXAN-1000 (🚀)
