### PR TITLE
Feat(front): upload and update protected areas[MARXAN-743]

### DIFF
--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -91,7 +91,7 @@ export function useAdminPreviewLayer({
 export function useWDPAPreviewLayer({
   pid, active, bbox, wdpaIucnCategories, cache = 0, options,
 }: UseWDPAPreviewLayer) {
-  const { opacity = 1 } = options || {};
+  const { opacity = 1, visibility = true } = options || {};
 
   return useMemo(() => {
     if (!active || !bbox) return null;
@@ -109,6 +109,9 @@ export function useWDPAPreviewLayer({
           {
             type: 'fill',
             'source-layer': 'layer0',
+            layout: {
+              visibility: visibility ? 'visible' : 'none',
+            },
             filter: ['all',
               ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]],
             ],
@@ -119,6 +122,9 @@ export function useWDPAPreviewLayer({
           {
             type: 'line',
             'source-layer': 'layer0',
+            layout: {
+              visibility: visibility ? 'visible' : 'none',
+            },
             filter: ['all',
               ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]],
             ],
@@ -129,7 +135,7 @@ export function useWDPAPreviewLayer({
         ],
       },
     };
-  }, [pid, active, bbox, wdpaIucnCategories, cache, opacity]);
+  }, [pid, active, bbox, wdpaIucnCategories, cache, opacity, visibility]);
 }
 
 // Featurepreview

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -112,8 +112,9 @@ export function useWDPAPreviewLayer({
             layout: {
               visibility: visibility ? 'visible' : 'none',
             },
-            filter: ['all',
-              ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]],
+            filter: ['any',
+              ['all', ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]]],
+              ['all', ['in', ['get', 'id'], ['literal', wdpaIucnCategories]]],
             ],
             paint: {
               'fill-color': COLORS.wdpa,
@@ -125,8 +126,9 @@ export function useWDPAPreviewLayer({
             layout: {
               visibility: visibility ? 'visible' : 'none',
             },
-            filter: ['all',
-              ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]],
+            filter: ['any',
+              ['all', ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]]],
+              ['all', ['in', ['get', 'id'], ['literal', wdpaIucnCategories]]],
             ],
             paint: {
               'line-color': '#000',

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -112,6 +112,8 @@ export function useWDPAPreviewLayer({
             layout: {
               visibility: visibility ? 'visible' : 'none',
             },
+            // wdpaIucnCategories are filtered in two steps as they are custom and WDPA.
+            // We have not way to separate them into two arrays but it would be ideal
             filter: ['any',
               ['all', ['in', ['get', 'iucn_cat'], ['literal', wdpaIucnCategories]]],
               ['all', ['in', ['get', 'id'], ['literal', wdpaIucnCategories]]],

--- a/app/hooks/wdpa/index.ts
+++ b/app/hooks/wdpa/index.ts
@@ -38,6 +38,7 @@ export function useWDPACategories({
   );
 
   const { data } = query;
+  console.log('data', data);
 
   return useMemo(() => {
     return {

--- a/app/hooks/wdpa/index.ts
+++ b/app/hooks/wdpa/index.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 
 import { useSession } from 'next-auth/client';
 
@@ -57,7 +57,6 @@ export function useSaveScenarioProtectedAreas({
     method: 'POST',
   },
 }: UseSaveScenarioProtectedAreasProps) {
-  const queryClient = useQueryClient();
   const [session] = useSession();
 
   const saveScenarioProtectedAreas = ({ id, data }: SaveScenarioProtectedAreasProps) => {
@@ -73,10 +72,6 @@ export function useSaveScenarioProtectedAreas({
 
   return useMutation(saveScenarioProtectedAreas, {
     onSuccess: (data: any, variables, context) => {
-      const { id, projectId } = data?.data?.data;
-      queryClient.invalidateQueries(['scenarios', projectId]);
-      queryClient.setQueryData(['scenarios', id], data?.data);
-
       console.info('Succces', data, variables, context);
     },
     onError: (error, variables, context) => {

--- a/app/hooks/wdpa/index.ts
+++ b/app/hooks/wdpa/index.ts
@@ -38,7 +38,6 @@ export function useWDPACategories({
   );
 
   const { data } = query;
-  console.log('data', data);
 
   return useMemo(() => {
     return {

--- a/app/hooks/wdpa/index.ts
+++ b/app/hooks/wdpa/index.ts
@@ -34,7 +34,6 @@ export function useWDPACategories({
     }),
     {
       enabled: !!adminAreaId || !!customAreaId,
-      refetchInterval: 1000,
     },
   );
 

--- a/app/hooks/wdpa/types.ts
+++ b/app/hooks/wdpa/types.ts
@@ -1,5 +1,16 @@
+import { AxiosRequestConfig } from 'axios';
+
 export interface UseWDPACategoriesProps {
   adminAreaId?: string;
   customAreaId?: string;
   scenarioId: string[] | string;
+}
+
+export interface UseSaveScenarioProtectedAreasProps {
+  requestConfig?: AxiosRequestConfig
+}
+
+export interface SaveScenarioProtectedAreasProps {
+  data: unknown;
+  id: string[] | string;
 }

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -190,7 +190,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
     ...wdpaCategories,
     pid: `${pid}`,
     cache,
-    active: tab === 'protected-areas',
+    active: tab === 'protected-areas' && subtab === 'protected-areas-preview',
     bbox,
     options: {
       ...layerSettings['wdpa-preview'],

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -190,7 +190,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
     ...wdpaCategories,
     pid: `${pid}`,
     cache,
-    active: tab === 'protected-areas' && subtab === 'protected-areas-preview',
+    active: tab === 'protected-areas',
     bbox,
     options: {
       ...layerSettings['wdpa-preview'],
@@ -247,8 +247,6 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
     WDPApreviewLayer,
     ...FeaturePreviewLayers,
   ].filter((l) => !!l);
-
-  console.log('LAYERS', LAYERS);
 
   const LEGEND = useLegend({
     layers,

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -186,6 +186,8 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
   //   subregion: adminAreaLevel2Id,
   // });
 
+  console.log('tab', tab, 'subtab', subtab);
+
   const WDPApreviewLayer = useWDPAPreviewLayer({
     ...wdpaCategories,
     pid: `${pid}`,

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -219,7 +219,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
     include,
     sublayers,
     options: {
-      wdpaIucnCategories: tab === 'protected-areas' && subtab === 'protected-areas-preview' ? wdpaCategories.wdpaIucnCategories : scenarioData?.wdpaIucnCategories,
+      wdpaIucnCategories: tab === 'protected-areas' ? wdpaCategories.wdpaIucnCategories : scenarioData?.wdpaIucnCategories,
       wdpaThreshold: tab === 'protected-areas' && subtab === 'protected-areas-percentage' ? wdpaThreshold * 100 : scenarioData?.wdpaThreshold,
       puAction,
       puIncludedValue: puTmpIncludedValue,

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -248,6 +248,8 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
     ...FeaturePreviewLayers,
   ].filter((l) => !!l);
 
+  console.log('LAYERS', LAYERS);
+
   const LEGEND = useLegend({
     layers,
     options: {

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -186,8 +186,6 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
   //   subregion: adminAreaLevel2Id,
   // });
 
-  console.log('tab', tab, 'subtab', subtab);
-
   const WDPApreviewLayer = useWDPAPreviewLayer({
     ...wdpaCategories,
     pid: `${pid}`,

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -81,8 +81,8 @@ export const useScenarioActionsDone = () => {
     addToast,
   ]);
 
-  // WDPA protected calculation
-  const onProtectedAreasCalculationDone = useCallback((JOB_REF) => {
+  // Protected Areas
+  const onProtectedAreasDone = useCallback((JOB_REF) => {
     scenarioMutation.mutate({
       id: `${sid}`,
       data: {
@@ -108,7 +108,7 @@ export const useScenarioActionsDone = () => {
         JOB_REF.current = null;
       },
       onError: () => {
-        addToast('onProtectedAreasCalculationDone', (
+        addToast('onProtectedAreasDone', (
           <>
             <h2 className="font-medium">Error!</h2>
           </>
@@ -164,6 +164,7 @@ export const useScenarioActionsDone = () => {
     setCache,
     addToast,
   ]);
+
   // Cost surface
   const onCostSurfaceDone = useCallback((JOB_REF) => {
     scenarioMutation.mutate({
@@ -283,7 +284,7 @@ export const useScenarioActionsDone = () => {
   return {
     features: onFeaturesDone,
     planningAreaProtectedCalculation: onPlanningAreaProtectedCalculationDone,
-    protectedAreas: onProtectedAreasCalculationDone,
+    protectedAreas: onProtectedAreasDone,
     costSurface: onCostSurfaceDone,
     planningUnitsInclusion: onPlanningUnitsInclusionDone,
     run: onRunDone,

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -48,8 +48,8 @@ export const useScenarioActionsDone = () => {
           ...scenarioData?.metadata,
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
-            tab: 'protected-areas',
-            subtab: 'protected-areas-preview',
+            tab: 'features',
+            subtab: 'features-preview',
             status: {
               'protected-areas': 'draft',
               features: 'empty',
@@ -84,7 +84,6 @@ export const useScenarioActionsDone = () => {
     setCache,
     addToast,
   ]);
-
   // Protected Areas
   const onProtectedAreasDone = useCallback((JOB_REF) => {
     scenarioMutation.mutate({

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -45,7 +45,7 @@ export const useScenarioActionsDone = () => {
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
             tab: 'protected-areas',
-            subtab: 'protected-areas',
+            subtab: 'protected-areas-preview',
             status: {
               'protected-areas': 'draft',
               features: 'empty',
@@ -90,8 +90,8 @@ export const useScenarioActionsDone = () => {
           ...scenarioData?.metadata,
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
-            tab: 'protected-areas',
-            subtab: 'protected-areas',
+            tab: 'features',
+            subtab: 'features-preview',
             status: {
               'protected-areas': 'draft',
               features: 'empty',

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -95,7 +95,7 @@ export const useScenarioActionsDone = () => {
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
             tab: wdpaIucnCategories.length > 0 ? 'features' : 'protected-areas',
-            subtab: wdpaIucnCategories.length > 0 ? 'protected-areas-preview' : 'features-preview',
+            subtab: wdpaIucnCategories.length > 0 ? 'features-preview' : 'protected-areas-preview',
             status: {
               'protected-areas': 'draft',
               features: 'empty',
@@ -129,7 +129,7 @@ export const useScenarioActionsDone = () => {
     setJob,
     setCache,
     addToast,
-    wdpaIucnCategories.length,
+    wdpaIucnCategories?.length,
   ]);
 
   const onFeaturesDone = useCallback((JOB_REF) => {

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -48,13 +48,6 @@ export const useScenarioActionsDone = () => {
           ...scenarioData?.metadata,
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
-            tab: 'features',
-            subtab: 'features-preview',
-            status: {
-              'protected-areas': 'draft',
-              features: 'empty',
-              analysis: 'empty',
-            },
             lastJobCheck: new Date().getTime(),
           },
         },

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 
 import { useQueryClient } from 'react-query';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useRouter } from 'next/router';
 
@@ -22,6 +22,10 @@ export const useScenarioActionsDone = () => {
     setJob,
     setCache,
   } = scenarioSlice.actions;
+
+  const { wdpaCategories } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
+
+  const { wdpaIucnCategories } = wdpaCategories;
 
   const { data: scenarioData } = useScenario(sid);
 
@@ -90,8 +94,8 @@ export const useScenarioActionsDone = () => {
           ...scenarioData?.metadata,
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
-            tab: 'features',
-            subtab: 'features-preview',
+            tab: wdpaIucnCategories.length > 0 ? 'features' : 'protected-areas',
+            subtab: wdpaIucnCategories.length > 0 ? 'protected-areas-preview' : 'features-preview',
             status: {
               'protected-areas': 'draft',
               features: 'empty',
@@ -125,6 +129,7 @@ export const useScenarioActionsDone = () => {
     setJob,
     setCache,
     addToast,
+    wdpaIucnCategories.length,
   ]);
 
   const onFeaturesDone = useCallback((JOB_REF) => {

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -35,8 +35,54 @@ export const useScenarioActionsDone = () => {
 
   const queryClient = useQueryClient();
 
-  // WDPA protected calculation
+  // PLANNING AREA calculation
   const onPlanningAreaProtectedCalculationDone = useCallback((JOB_REF) => {
+    scenarioMutation.mutate({
+      id: `${sid}`,
+      data: {
+        metadata: {
+          ...scenarioData?.metadata,
+          scenarioEditingMetadata: {
+            ...scenarioData?.metadata?.scenarioEditingMetadata,
+            tab: 'protected-areas',
+            subtab: 'protected-areas',
+            status: {
+              'protected-areas': 'draft',
+              features: 'empty',
+              analysis: 'empty',
+            },
+            lastJobCheck: new Date().getTime(),
+          },
+        },
+      },
+    }, {
+      onSuccess: () => {
+        dispatch(setJob(null));
+        dispatch(setCache(Date.now()));
+        JOB_REF.current = null;
+      },
+      onError: () => {
+        addToast('onPlanningAreaProtectedCalculationDone', (
+          <>
+            <h2 className="font-medium">Error!</h2>
+          </>
+        ), {
+          level: 'error',
+        });
+      },
+    });
+  }, [
+    sid,
+    scenarioMutation,
+    scenarioData?.metadata,
+    dispatch,
+    setJob,
+    setCache,
+    addToast,
+  ]);
+
+  // WDPA protected calculation
+  const onProtectedAreasCalculationDone = useCallback((JOB_REF) => {
     scenarioMutation.mutate({
       id: `${sid}`,
       data: {
@@ -62,7 +108,7 @@ export const useScenarioActionsDone = () => {
         JOB_REF.current = null;
       },
       onError: () => {
-        addToast('onPlanningAreaProtectedCalculationDone', (
+        addToast('onProtectedAreasCalculationDone', (
           <>
             <h2 className="font-medium">Error!</h2>
           </>
@@ -237,6 +283,7 @@ export const useScenarioActionsDone = () => {
   return {
     features: onFeaturesDone,
     planningAreaProtectedCalculation: onPlanningAreaProtectedCalculationDone,
+    protectedAreas: onProtectedAreasCalculationDone,
     costSurface: onCostSurfaceDone,
     planningUnitsInclusion: onPlanningUnitsInclusionDone,
     run: onRunDone,

--- a/app/layout/scenarios/edit/status/actions/done.tsx
+++ b/app/layout/scenarios/edit/status/actions/done.tsx
@@ -91,7 +91,7 @@ export const useScenarioActionsDone = () => {
           scenarioEditingMetadata: {
             ...scenarioData?.metadata?.scenarioEditingMetadata,
             tab: 'protected-areas',
-            subtab: 'protected-areas-percentage',
+            subtab: 'protected-areas',
             status: {
               'protected-areas': 'draft',
               features: 'empty',

--- a/app/layout/scenarios/edit/status/actions/failure.tsx
+++ b/app/layout/scenarios/edit/status/actions/failure.tsx
@@ -31,7 +31,7 @@ export const useScenarioActionsFailure = () => {
 
   const { addToast } = useToasts();
 
-  // WDPA protected calculation
+  // Planning Area calculation
   const onPlanningAreaProtectedCalculationFailure = useCallback(() => {
     scenarioMutation.mutate({
       id: `${sid}`,
@@ -51,6 +51,36 @@ export const useScenarioActionsFailure = () => {
       },
       onError: () => {
         addToast('onPlanningAreaProtectedCalculationFailure', (
+          <>
+            <h2 className="font-medium">Error!</h2>
+          </>
+        ), {
+          level: 'error',
+        });
+      },
+    });
+  }, [sid, scenarioMutation, scenarioData?.metadata, dispatch, setJob, addToast]);
+
+  // Protected Areas
+  const onProtectedAreasFailure = useCallback(() => {
+    scenarioMutation.mutate({
+      id: `${sid}`,
+      data: {
+        metadata: {
+          ...scenarioData?.metadata,
+          scenarioEditingMetadata: {
+            ...scenarioData?.metadata?.scenarioEditingMetadata,
+            subtab: 'protected-areas-preview',
+            lastJobCheck: new Date().getTime(),
+          },
+        },
+      },
+    }, {
+      onSuccess: () => {
+        dispatch(setJob(null));
+      },
+      onError: () => {
+        addToast('onProtectedAreasFailure', (
           <>
             <h2 className="font-medium">Error!</h2>
           </>
@@ -194,6 +224,7 @@ export const useScenarioActionsFailure = () => {
   return {
     features: onFeaturesFailure,
     planningAreaProtectedCalculation: onPlanningAreaProtectedCalculationFailure,
+    protectedAreas: onProtectedAreasFailure,
     costSurface: onCostSurfaceFailure,
     planningUnitsInclusion: onPlanningUnitsInclusionFailure,
     run: onRunFailure,

--- a/app/layout/scenarios/edit/status/component.tsx
+++ b/app/layout/scenarios/edit/status/component.tsx
@@ -70,8 +70,9 @@ export const ScenarioStatus: React.FC<ScenarioStatusProps> = () => {
       // show the correct text while the actions are triggered
       JOB_DONE_REF.current = JOB_DONE;
 
-      // Execute the action
       ACTIONS_DONE[JOB_DONE?.kind](JOB_DONE_REF);
+
+      // If
     }
   }, [ACTIONS_DONE, JOB_DONE]);
 

--- a/app/layout/scenarios/edit/status/constants.ts
+++ b/app/layout/scenarios/edit/status/constants.ts
@@ -1,5 +1,6 @@
 export const TEXTS_RUNNING = {
   planningAreaProtectedCalculation: () => 'Calculating the protected areas percentages...',
+  protectedAreas: () => 'Calculating the protected areas...',
   features: () => 'Processing the features...',
   planningUnitsInclusion: () => 'Processing inclusion/exclusion of planning units...',
   costSurface: () => 'Processing cost surface...',
@@ -8,6 +9,7 @@ export const TEXTS_RUNNING = {
 
 export const TEXTS_FAILURE = {
   planningAreaProtectedCalculation: () => 'Fail Calculating the protected areas percentages',
+  protectedAreas: () => 'Fail Calculating the protected areas',
   features: () => 'Fail Processing the features',
   planningUnitsInclusion: () => 'Fail Processing inclusion/exclusion of planning units',
   costSurface: () => 'Fail Processing cost surface',

--- a/app/layout/scenarios/edit/tabs/component.tsx
+++ b/app/layout/scenarios/edit/tabs/component.tsx
@@ -113,7 +113,7 @@ export const ScenariosSidebarTabs: React.FC<ScenariosSidebarTabsProps> = () => {
           </ul>
 
         </div>
-          )}
+      )}
     >
 
       <motion.div

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -5,6 +5,8 @@ import React, {
 import { Form as FormRFF, FormSpy as FormSpyRFF, Field as FieldRFF } from 'react-final-form';
 import { useDispatch } from 'react-redux';
 
+import intersection from 'lodash/intersection';
+
 import { useRouter } from 'next/router';
 
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
@@ -109,58 +111,60 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
   }, [scenarioData]); //eslint-disable-line
 
   // Submit
-  const onSubmit = useCallback((values, form) => {
-    const { modified, dirtyFields } = form.getState();
+  // const onSubmit = useCallback((values, form) => {
+  //   const { modified, dirtyFields } = form.getState();
 
-    if (modified.wdpaIucnCategories || dirtyFields.wdpaIucnCategories) {
-      setSubmitting(true);
+  //   if (modified.wdpaIucnCategories || dirtyFields.wdpaIucnCategories) {
+  //     setSubmitting(true);
 
-      mutation.mutate({
-        id: scenarioData?.id,
-        data: {
-          ...values,
-          metadata: mergeScenarioStatusEditingMetaData(
-            metadata,
-            {
-              tab: 'protected-areas',
-              subtab: 'protected-areas-preview',
-              status: {
-                'protected-areas': 'draft',
-                features: 'empty',
-                analysis: 'empty',
-              },
-            },
-          ),
-        },
-      }, {
-        onSuccess: () => {
-          setSubmitting(false);
-          addToast('save-scenario-wdpa', (
-            <>
-              <h2 className="font-medium">Success!</h2>
-              <p className="text-sm">Scenario WDPA saved</p>
-            </>
-          ), {
-            level: 'success',
-          });
-        },
-        onError: () => {
-          setSubmitting(false);
+  //     mutation.mutate({
+  //       id: scenarioData?.id,
+  //       data: {
+  //         ...values,
+  //         metadata: mergeScenarioStatusEditingMetaData(
+  //           metadata,
+  //           {
+  //             tab: 'protected-areas',
+  //             subtab: 'protected-areas-preview',
+  //             status: {
+  //               'protected-areas': 'draft',
+  //               features: 'empty',
+  //               analysis: 'empty',
+  //             },
+  //           },
+  //         ),
+  //       },
+  //     }, {
+  //       onSuccess: () => {
+  //         setSubmitting(false);
+  //         addToast('save-scenario-wdpa', (
+  //           <>
+  //             <h2 className="font-medium">Success!</h2>
+  //             <p className="text-sm">Scenario WDPA saved</p>
+  //           </>
+  //         ), {
+  //           level: 'success',
+  //         });
+  //       },
+  //       onError: () => {
+  //         setSubmitting(false);
 
-          addToast('error-scenario-wdpa', (
-            <>
-              <h2 className="font-medium">Error!</h2>
-              <p className="text-sm">Scenario WDPA not saved</p>
-            </>
-          ), {
-            level: 'error',
-          });
-        },
-      });
-    } else {
-      onSuccess();
-    }
-  }, [mutation, scenarioData?.id, addToast, onSuccess, metadata]);
+  //         addToast('error-scenario-wdpa', (
+  //           <>
+  //             <h2 className="font-medium">Error!</h2>
+  //             <p className="text-sm">Scenario WDPA not saved</p>
+  //           </>
+  //         ), {
+  //           level: 'error',
+  //         });
+  //       },
+  //     });
+  //   } else {
+  //     onSuccess();
+  //   }
+  // }, [mutation, scenarioData?.id, addToast, onSuccess, metadata]);
+
+  const onSubmit = () => console.log('Hole');
 
   const onSkip = useCallback(() => {
     setSubmitting(true);
@@ -255,10 +259,13 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
       initialValues={INITIAL_VALUES}
     >
       {({ form, values, handleSubmit }) => {
-        const customPAAreSelected = !!values.wdpaIucnCategories.length
-          && values.wdpaIucnCategories.some((w) => w.charAt(0) !== 'I');
-        const wdpaAreSelected = !!values.wdpaIucnCategories.length
-          && values.wdpaIucnCategories.some((w) => w.charAt(0) === 'I');
+        const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
+        const plainCustomPAOptions = CUSTOM_PA_OPTIONS.map((o) => o.value);
+
+        const areWDPAreasSelected = intersection(plainWDPAOptions,
+          values.wdpaIucnCategories).length > 0;
+        const areCustomPAreasSelected = intersection(plainCustomPAOptions,
+          values.wdpaIucnCategories).length > 0;
 
         return (
           <form onSubmit={handleSubmit} autoComplete="off" className="relative flex flex-col flex-grow w-full overflow-hidden">
@@ -364,7 +371,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
                     }}
                   </FieldRFF>
 
-                  {customPAAreSelected && (
+                  {values.wdpaIucnCategories.length > 0 && areCustomPAreasSelected && (
                     <ProtectedAreasSelected
                       form={form}
                       options={CUSTOM_PA_OPTIONS}
@@ -373,7 +380,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
                     />
                   )}
 
-                  {wdpaAreSelected && (
+                  {values.wdpaIucnCategories.length > 0 && areWDPAreasSelected && (
                     <ProtectedAreasSelected
                       form={form}
                       options={WDPA_OPTIONS}

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -160,6 +160,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
             className="relative flex flex-col flex-grow w-full overflow-hidden"
           >
             <FormSpyRFF onChange={(state) => {
+              console.log('--->', state.values);
               dispatch(setWDPACategories(state.values));
             }}
             />

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -171,10 +171,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
       }}
       initialValues={INITIAL_VALUES}
       render={({ form, values, handleSubmit }) => {
-        if (form.getState().touched.uploadedProtectedArea) {
-          refetchProtectedAreas();
-        }
-
         const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
         const plainProjectPAOptions = PROJECT_PA_OPTIONS.map((o) => o.value);
 
@@ -192,6 +188,9 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
           >
             <FormSpyRFF onChange={(state) => {
               dispatch(setWDPACategories(state.values));
+              if (state.touched.uploadedProtectedArea) {
+                refetchProtectedAreas();
+              }
             }}
             />
 

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -1,6 +1,4 @@
-import React, {
-  useCallback, useEffect, useMemo, useState,
-} from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { Form as FormRFF, FormSpy as FormSpyRFF, Field as FieldRFF } from 'react-final-form';
 import { useDispatch } from 'react-redux';
@@ -37,7 +35,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
 }: WDPACategoriesProps) => {
   const { query } = useRouter();
   const { pid, sid } = query;
-  const [submitting, setSubmitting] = useState(false);
 
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setWDPACategories, setWDPAThreshold } = scenarioSlice.actions;
@@ -100,11 +97,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     }
   }, [scenarioData]); //eslint-disable-line
 
-  const onSkip = useCallback(() => {
-    setSubmitting(true);
-    onDismiss();
-  }, [onDismiss]);
-
   const onSubmit = () => console.log('on');
 
   // Loading
@@ -124,7 +116,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
         <div className="text-sm">This planning area doesn&apos;t have any protected areas associated with it. You can go directly to the features tab.</div>
 
         <div className="flex justify-center mt-20">
-          <Button theme="secondary-alt" size="lg" type="button" className="relative px-20" onClick={onSkip}>
+          <Button theme="secondary-alt" size="lg" type="button" className="relative px-20" onClick={onDismiss}>
             <span>Continue to features</span>
           </Button>
         </div>
@@ -167,12 +159,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
             autoComplete="off"
             className="relative flex flex-col flex-grow w-full overflow-hidden"
           >
-            <Loading
-              visible={submitting}
-              className="absolute top-0 bottom-0 left-0 right-0 z-40 flex items-center justify-center w-full h-full bg-gray-700 bg-opacity-90"
-              iconClassName="w-10 h-10 text-white"
-            />
-
             <FormSpyRFF onChange={(state) => {
               dispatch(setWDPACategories(state.values));
             }}
@@ -271,20 +257,20 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
                     }}
                   </FieldRFF>
 
-                  {values.wdpaIucnCategories.length > 0 && areProjectPAreasSelected && (
-                    <ProtectedAreasSelected
-                      form={form}
-                      options={PROJECT_PA_OPTIONS}
-                      title="Uploaded protected areas:"
-                      wdpaIucnCategories={values.wdpaIucnCategories}
-                    />
-                  )}
-
                   {values.wdpaIucnCategories.length > 0 && areWDPAreasSelected && (
                     <ProtectedAreasSelected
                       form={form}
                       options={WDPA_OPTIONS}
                       title="Selected protected areas:"
+                      wdpaIucnCategories={values.wdpaIucnCategories}
+                    />
+                  )}
+
+                  {values.wdpaIucnCategories.length > 0 && areProjectPAreasSelected && (
+                    <ProtectedAreasSelected
+                      form={form}
+                      options={PROJECT_PA_OPTIONS}
+                      title="Uploaded protected areas:"
                       wdpaIucnCategories={values.wdpaIucnCategories}
                     />
                   )}
@@ -299,8 +285,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
                 size="lg"
                 type={values.wdpaIucnCategories.length > 0 ? 'submit' : 'button'}
                 className="relative px-20"
-                disabled={submitting}
-                onClick={() => (values.wdpaIucnCategories.length > 0 ? onSuccess() : onSkip())}
+                onClick={() => (values.wdpaIucnCategories.length > 0 ? onSuccess() : onDismiss())}
               >
                 {!!values.wdpaIucnCategories.length && (
                   <span>Continue</span>

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -97,8 +97,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     }
   }, [scenarioData]); //eslint-disable-line
 
-  const onSubmit = () => console.log('on');
-
   // Loading
   if ((scenarioIsFetching && !scenarioIsFetched) || (wdpaIsFetching && !wdpaIsFetched)) {
     return (
@@ -126,7 +124,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
 
   return (
     <FormRFF
-      onSubmit={onSubmit}
+      onSubmit={() => { }}
       mutators={{
         removeWDPAFilter: (args, state, utils) => {
           const [id, arr] = args;
@@ -160,7 +158,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
             className="relative flex flex-col flex-grow w-full overflow-hidden"
           >
             <FormSpyRFF onChange={(state) => {
-              console.log('--->', state.values);
               dispatch(setWDPACategories(state.values));
             }}
             />
@@ -284,7 +281,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
               <Button
                 theme="secondary-alt"
                 size="lg"
-                type={values.wdpaIucnCategories.length > 0 ? 'submit' : 'button'}
+                type="button"
                 className="relative px-20"
                 onClick={() => (values.wdpaIucnCategories.length > 0 ? onSuccess() : onDismiss())}
               >

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -82,20 +82,21 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     if (!wdpaData) return [];
 
     return wdpaData.map((w) => ({
-      label: `${w.kind === 'global' ? 'IUCN' : '👤'} ${w.name}`,
+      label: w.kind === 'global' ? `IUCN ${w.name}` : `${w.name}`,
       value: w.id,
-      ...w.kind === 'global' && { kind: 'global' },
+      kind: w.kind,
+      selected: w.selected,
     }));
   }, [wdpaData]);
 
-  const CUSTOM_PA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => !w.kind);
-  const WDPA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((o) => o.kind === 'global');
+  const PROJECT_PA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => w.kind === 'project');
+  const WDPA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => w.kind === 'global');
 
   const ORDERED_WDPA_CATEGORIES_OPTIONS = useMemo(() => {
-    if (!WDPA_CATEGORIES_OPTIONS) return [];
+    if (!wdpaData) return [];
 
-    return CUSTOM_PA_OPTIONS.concat(WDPA_OPTIONS);
-  }, [WDPA_CATEGORIES_OPTIONS, WDPA_OPTIONS, CUSTOM_PA_OPTIONS]);
+    return PROJECT_PA_OPTIONS.concat(WDPA_OPTIONS);
+  }, [wdpaData, WDPA_OPTIONS, PROJECT_PA_OPTIONS]);
 
   const INITIAL_VALUES = useMemo(() => {
     return {
@@ -260,11 +261,11 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     >
       {({ form, values, handleSubmit }) => {
         const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
-        const plainCustomPAOptions = CUSTOM_PA_OPTIONS.map((o) => o.value);
+        const plainProjectPAOptions = PROJECT_PA_OPTIONS.map((o) => o.value);
 
         const areWDPAreasSelected = intersection(plainWDPAOptions,
           values.wdpaIucnCategories).length > 0;
-        const areCustomPAreasSelected = intersection(plainCustomPAOptions,
+        const areProjectPAreasSelected = intersection(plainProjectPAOptions,
           values.wdpaIucnCategories).length > 0;
 
         return (
@@ -361,20 +362,19 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
                     name="protectedAreaId"
                     validate={composeValidators([{ presence: true }])}
                   >
-                    {(fprops) => {
+                    {(flprops) => {
                       return (
                         <ProtectedAreaUploader
-                          {...fprops}
-                          form={form}
+                          {...flprops}
                         />
                       );
                     }}
                   </FieldRFF>
 
-                  {values.wdpaIucnCategories.length > 0 && areCustomPAreasSelected && (
+                  {values.wdpaIucnCategories.length > 0 && areProjectPAreasSelected && (
                     <ProtectedAreasSelected
                       form={form}
-                      options={CUSTOM_PA_OPTIONS}
+                      options={PROJECT_PA_OPTIONS}
                       title="Uploaded protected areas:"
                       wdpaIucnCategories={values.wdpaIucnCategories}
                     />

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -117,10 +117,13 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
   }, [wdpaData, WDPA_OPTIONS, PROJECT_PA_OPTIONS]);
 
   const INITIAL_VALUES = useMemo(() => {
+    const selectedAreas = wdpaData?.filter((pa) => pa.selected) || [];
+    const areas = selectedAreas.map((i) => i.id) || [];
+
     return {
-      wdpaIucnCategories: scenarioData?.wdpaIucnCategories || [],
+      wdpaIucnCategories: areas,
     };
-  }, [scenarioData?.wdpaIucnCategories]);
+  }, [wdpaData]);
 
   useEffect(() => {
     const { wdpaThreshold } = scenarioData;
@@ -176,7 +179,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
 
         const areWDPAreasSelected = intersection(plainWDPAOptions,
           values.wdpaIucnCategories).length > 0;
-        // or
+
         const areProjectPAreasSelected = intersection(plainProjectPAOptions,
           values.wdpaIucnCategories).length > 0;
 

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -38,9 +38,9 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
   onSuccess,
   onDismiss,
 }: WDPACategoriesProps) => {
-  const [submitting, setSubmitting] = useState(false);
   const { query } = useRouter();
   const { pid, sid } = query;
+  const [submitting, setSubmitting] = useState(false);
 
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setWDPACategories, setWDPAThreshold } = scenarioSlice.actions;
@@ -59,6 +59,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     data: wdpaData,
     isFetching: wdpaIsFetching,
     isFetched: wdpaIsFetched,
+    refetch: refetchProtectedAreas,
   } = useWDPACategories({
     adminAreaId: projectData?.adminAreaLevel2Id
       || projectData?.adminAreaLevel1I
@@ -260,6 +261,10 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
       initialValues={INITIAL_VALUES}
     >
       {({ form, values, handleSubmit }) => {
+        if (form.getState().touched.uploadedProtectedArea) {
+          refetchProtectedAreas();
+        }
+
         const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
         const plainProjectPAOptions = PROJECT_PA_OPTIONS.map((o) => o.value);
 
@@ -276,7 +281,10 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
               iconClassName="w-10 h-10 text-white"
             />
 
-            <FormSpyRFF onChange={(state) => dispatch(setWDPACategories(state.values))} />
+            <FormSpyRFF onChange={(state) => {
+              dispatch(setWDPACategories(state.values));
+            }}
+            />
 
             <div className="relative flex flex-col flex-grow overflow-hidden">
               <div className="absolute top-0 left-0 z-10 w-full h-6 pointer-events-none bg-gradient-to-b from-gray-700 via-gray-700" />
@@ -359,7 +367,7 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
 
                   <p className="py-4 text-sm text-center">or</p>
                   <FieldRFF
-                    name="protectedAreaId"
+                    name="uploadedProtectedArea"
                     validate={composeValidators([{ presence: true }])}
                   >
                     {(flprops) => {

--- a/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
@@ -111,7 +111,6 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
 
       onSuccess: ({ data: { data: PAdata, id: PAid } }) => {
         setLoading(false);
-        console.log('PA', PAdata);
         setSuccessFile({ ...successFile, id: PAid, geom: PAdata });
 
         input.onChange(PAid);

--- a/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
@@ -111,7 +111,9 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
 
       onSuccess: ({ data: { data: PAdata, id: PAid } }) => {
         setLoading(false);
+        console.log('PA', PAdata);
         setSuccessFile({ ...successFile, id: PAid, geom: PAdata });
+
         input.onChange(PAid);
 
         addToast('success-upload-protected-area', (

--- a/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
@@ -32,13 +32,10 @@ import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
 
 export interface ProtectedAreaUploaderProps {
   input: any;
-  meta: any;
-  form: any,
 }
 
 export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
   input,
-  form,
 }: ProtectedAreaUploaderProps) => {
   const { query } = useRouter();
   const { sid } = query;

--- a/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
@@ -173,6 +173,7 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
         onSubmit={onDropAccepted}
         render={({ form: uploaderForm }) => {
           formRef.current = uploaderForm;
+          const { name } = formRef.current.getState().values;
 
           return (
             <form onSubmit={handleSubmit}>
@@ -302,6 +303,7 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
                     theme="primary"
                     size="xl"
                     type="submit"
+                    disabled={!name}
                   >
                     Save
                   </Button>

--- a/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/pa-uploader/component.tsx
@@ -83,6 +83,14 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
 
     setSuccessFile({ ...successFile, name: f.name });
     saveFileData(data);
+    addToast('success-upload-protected-area', (
+      <>
+        <h2 className="font-medium">Success!</h2>
+        <p className="text-sm">Protected area uploaded</p>
+      </>
+    ), {
+      level: 'success',
+    });
   };
 
   const onDropRejected = (rejectedFiles) => {
@@ -109,24 +117,12 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
     fileData.append('name', name);
     uploadPAMutation.mutate({ id: `${sid}`, data: fileData }, {
 
-      onSuccess: ({ data: { data: PAdata, id: PAid } }) => {
+      onSuccess: () => {
         setLoading(false);
-        setSuccessFile({ ...successFile, id: PAid, geom: PAdata });
-
-        input.onChange(PAid);
-
-        addToast('success-upload-protected-area', (
-          <>
-            <h2 className="font-medium">Success!</h2>
-            <p className="text-sm">Protected area uploaded</p>
-          </>
-        ), {
-          level: 'success',
-        });
+        setSuccessFile({ ...successFile });
 
         dispatch(setCache(Date.now()));
         setOpened(false);
-        console.info('Protected area shapefile uploaded', PAdata);
       },
       onError: () => {
         setLoading(false);
@@ -142,7 +138,7 @@ export const ProtectedAreaUploader: React.FC<ProtectedAreaUploaderProps> = ({
         });
       },
     });
-  }, [uploadPAMutation, addToast, dispatch, setCache, input, sid, successFile, fileData]);
+  }, [uploadPAMutation, addToast, dispatch, setCache, sid, successFile, fileData]);
 
   const {
     getRootProps,

--- a/app/layout/scenarios/edit/wdpa/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/component.tsx
@@ -131,10 +131,13 @@ export const ScenariosSidebarEditWDPA: React.FC<ScenariosSidebarEditWDPAProps> =
                 onDismiss={() => dispatch(setTab(ScenarioSidebarTabs.FEATURES))}
               />
             )}
-
+            {console.log('tab', tab)}
             {step === 1 && (
               <ScenariosSidebarWDPAThreshold
-                onSuccess={() => dispatch(setTab(ScenarioSidebarTabs.FEATURES))}
+                onSuccess={() => {
+                  dispatch(setTab(ScenarioSidebarTabs.FEATURES));
+                  dispatch(setSubTab(ScenarioSidebarSubTabs.FEATURES_PREVIEW));
+                }}
                 onBack={() => {
                   setStep(0);
                   dispatch(setSubTab(ScenarioSidebarSubTabs.PROTECTED_AREAS_PREVIEW));

--- a/app/layout/scenarios/edit/wdpa/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/component.tsx
@@ -131,7 +131,6 @@ export const ScenariosSidebarEditWDPA: React.FC<ScenariosSidebarEditWDPAProps> =
                 onDismiss={() => dispatch(setTab(ScenarioSidebarTabs.FEATURES))}
               />
             )}
-            {console.log('tab', tab)}
             {step === 1 && (
               <ScenariosSidebarWDPAThreshold
                 onSuccess={() => {

--- a/app/layout/scenarios/edit/wdpa/pa-selected/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/pa-selected/component.tsx
@@ -8,6 +8,7 @@ export interface ProtectedAreasSelectedProps {
   form?: any;
   options: Record<string, any>[];
   title: string;
+  isView?: boolean;
   wdpaIucnCategories: Record<string, any>[];
 }
 
@@ -15,6 +16,7 @@ export const ProtectedAreasSelected: React.FC<ProtectedAreasSelectedProps> = ({
   form,
   options,
   title,
+  isView = false,
   wdpaIucnCategories,
 }: ProtectedAreasSelectedProps) => {
   return (
@@ -40,19 +42,21 @@ export const ProtectedAreasSelected: React.FC<ProtectedAreasSelectedProps> = ({
                 }
               </span>
 
-              <button
-                aria-label="remove"
-                type="button"
-                className="flex items-center justify-center w-6 h-6 transition bg-transparent border border-gray-400 rounded-full hover:bg-gray-400"
-                onClick={() => {
-                  form.mutators.removeWDPAFilter(
-                    wdpa.value,
-                    wdpaIucnCategories,
-                  );
-                }}
-              >
-                <Icon icon={CLOSE_SVG} className="w-2.5 h-2.5" />
-              </button>
+              {!isView && (
+                <button
+                  aria-label="remove"
+                  type="button"
+                  className="flex items-center justify-center w-6 h-6 transition bg-transparent border border-gray-400 rounded-full hover:bg-gray-400"
+                  onClick={() => {
+                    form.mutators.removeWDPAFilter(
+                      wdpa.value,
+                      wdpaIucnCategories,
+                    );
+                  }}
+                >
+                  <Icon icon={CLOSE_SVG} className="w-2.5 h-2.5" />
+                </button>
+              )}
 
             </div>
           );

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -88,21 +88,22 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     if (!wdpaData) return [];
 
     return wdpaData.map((w) => ({
-      label: `${w.kind === 'global' ? 'IUCN' : '👤'} ${w.name}`,
+      label: w.kind === 'global' ? `IUCN ${w.name}` : `${w.name}`,
       value: w.id,
-      ...w.kind === 'global' && { kind: 'global' },
+      kind: w.kind,
+      selected: w.selected,
     }));
   }, [wdpaData]);
 
-  const CUSTOM_PA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => !w.kind);
-  const WDPA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((o) => o.kind === 'global');
+  const PROJECT_PA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => w.kind === 'project');
+  const WDPA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => w.kind === 'global');
 
   const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
-  const plainCustomPAOptions = CUSTOM_PA_OPTIONS.map((o) => o.value);
+  const plainProjectPAOptions = PROJECT_PA_OPTIONS.map((o) => o.value);
 
   const areWDPAreasSelected = intersection(plainWDPAOptions,
     wdpaCategories.wdpaIucnCategories).length > 0;
-  const areCustomPAreasSelected = intersection(plainCustomPAOptions,
+  const areProjectPAreasSelected = intersection(plainProjectPAOptions,
     wdpaCategories.wdpaIucnCategories).length > 0;
   const INITIAL_VALUES = useMemo(() => {
     const { wdpaThreshold, wdpaIucnCategories } = scenarioData;
@@ -302,9 +303,9 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
                   />
                 )}
 
-                {wdpaCategories.wdpaIucnCategories && areCustomPAreasSelected && (
+                {wdpaCategories.wdpaIucnCategories && areProjectPAreasSelected && (
                   <ProtectedAreasSelected
-                    options={CUSTOM_PA_OPTIONS}
+                    options={PROJECT_PA_OPTIONS}
                     title="Uploaded protected areas:"
                     isView
                     wdpaIucnCategories={wdpaCategories.wdpaIucnCategories}

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -9,8 +9,10 @@ import { useRouter } from 'next/router';
 
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
+import { mergeScenarioStatusMetaData } from 'utils/utils-scenarios';
+
 import { useProject } from 'hooks/projects';
-import { useScenario } from 'hooks/scenarios';
+import { useScenario, useSaveScenario } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 import { useWDPACategories, useSaveScenarioProtectedAreas } from 'hooks/wdpa';
 
@@ -57,6 +59,8 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     isFetched: scenarioIsFetched,
   } = useScenario(sid);
 
+  const { metadata } = scenarioData || {};
+
   const {
     data: wdpaData,
     isFetching: wdpaIsFetching,
@@ -69,6 +73,12 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
       && !projectData?.adminAreaLevel1I
       && !projectData?.countryId ? projectData?.planningAreaId : null,
     scenarioId: sid,
+  });
+
+  const saveScenarioMutation = useSaveScenario({
+    requestConfig: {
+      method: 'PATCH',
+    },
   });
 
   const saveScenarioProtectedAreasMutation = useSaveScenarioProtectedAreas({
@@ -158,6 +168,12 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
         ), {
           level: 'success',
         });
+        saveScenarioMutation.mutate({
+          id: `${sid}`,
+          data: {
+            metadata: mergeScenarioStatusMetaData(metadata, { tab: 'features', subtab: 'features-preview' }),
+          },
+        });
       },
       onError: () => {
         setSubmitting(false);
@@ -176,6 +192,8 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     saveScenarioProtectedAreasMutation,
     selectedProtectedAreas,
     sid,
+    saveScenarioMutation,
+    metadata,
     addToast,
     onSuccess]);
 

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -148,6 +148,7 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
       },
     }, {
       onSuccess: () => {
+        onSuccess();
         setSubmitting(false);
         addToast('save-scenario-wdpa', (
           <>
@@ -157,7 +158,6 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
         ), {
           level: 'success',
         });
-        onSuccess();
       },
       onError: () => {
         setSubmitting(false);

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -38,6 +38,7 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
   onBack,
 }: WDPAThresholdCategories) => {
   const [submitting, setSubmitting] = useState(false);
+
   const { addToast } = useToasts();
   const { query } = useRouter();
   const { pid, sid } = query;
@@ -112,21 +113,19 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     };
   }, [scenarioData]);
 
-  const areGlobalPAreasSelected = () => {
+  const areGlobalPAreasSelected = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
     return GLOBAL_PA_OPTIONS.map((p) => wdpaIucnCategories.includes(p.value))[0];
-  };
+  }, [wdpaCategories, GLOBAL_PA_OPTIONS]);
 
-  const areProjectPAreasSelected = () => {
+  const areProjectPAreasSelected = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
     return PROJECT_PA_OPTIONS.map((p) => wdpaIucnCategories.includes(p.value))[0];
-  };
+  }, [wdpaCategories, PROJECT_PA_OPTIONS]);
 
   useEffect(() => {
     const { wdpaThreshold } = scenarioData;
     dispatch(setWDPAThreshold(wdpaThreshold ? wdpaThreshold / 100 : 0.75));
-    areGlobalPAreasSelected();
-    areProjectPAreasSelected();
   }, [scenarioData]); //eslint-disable-line
 
   const handleSubmit = useCallback((values) => {

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/router';
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import { useProject } from 'hooks/projects';
-import { useScenario/* , useSaveScenario */ } from 'hooks/scenarios';
+import { useScenario } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 import { useWDPACategories, useSaveScenarioProtectedAreas } from 'hooks/wdpa';
 
@@ -76,12 +76,6 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
       method: 'POST',
     },
   });
-
-  // const saveScenarioMutation = useSaveScenario({
-  //   requestConfig: {
-  //     method: 'PATCH',
-  //   },
-  // });
 
   const labelRef = React.useRef(null);
 
@@ -155,17 +149,6 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     }, {
       onSuccess: () => {
         setSubmitting(false);
-        // saveScenarioMutation.mutate({
-        //   id: `${sid}`,
-        //   data: {
-        //     customProtectedAreaIds: projectPAreasSelectedIds || null,
-        //     wdpaIucnCategories: globalPAreasSelectedIds || null,
-        //   },
-        // }, {
-        //   onSuccess: () => { },
-        //   onError: () => { },
-        // });
-
         addToast('save-scenario-wdpa', (
           <>
             <h2 className="font-medium">Success!</h2>
@@ -191,11 +174,8 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     });
   }, [
     saveScenarioProtectedAreasMutation,
-    // saveScenarioMutation,
     selectedProtectedAreas,
     sid,
-    // projectPAreasSelectedIds,
-    // globalPAreasSelectedIds,
     addToast,
     onSuccess]);
 

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -115,12 +115,13 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
 
   const areGlobalPAreasSelected = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
-    return GLOBAL_PA_OPTIONS.map((p) => wdpaIucnCategories.includes(p.value))[0];
+    return GLOBAL_PA_OPTIONS
+      .map((p) => wdpaIucnCategories.includes(p.value)).filter(Boolean).length > 0;
   }, [wdpaCategories, GLOBAL_PA_OPTIONS]);
 
   const areProjectPAreasSelected = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
-    return PROJECT_PA_OPTIONS.map((p) => wdpaIucnCategories.includes(p.value))[0];
+    return PROJECT_PA_OPTIONS.map((p) => wdpaIucnCategories.includes(p.value));
   }, [wdpaCategories, PROJECT_PA_OPTIONS]);
 
   useEffect(() => {

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -77,7 +77,7 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
 
   const saveScenarioMutation = useSaveScenario({
     requestConfig: {
-      method: 'PATCH',
+      method: 'POST',
     },
   });
 
@@ -132,7 +132,7 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
       saveScenarioMutation.mutate({
         id: `${sid}`,
         data: {
-          wdpaThreshold: +(wdpaThreshold * 100).toFixed(0),
+          threshold: +(wdpaThreshold * 100).toFixed(0),
           metadata: mergeScenarioStatusEditingMetaData(
             metadata,
             {

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/router';
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import { useProject } from 'hooks/projects';
-import { useScenario } from 'hooks/scenarios';
+import { useScenario/* , useSaveScenario */ } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 import { useWDPACategories, useSaveScenarioProtectedAreas } from 'hooks/wdpa';
 
@@ -77,6 +77,12 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     },
   });
 
+  // const saveScenarioMutation = useSaveScenario({
+  //   requestConfig: {
+  //     method: 'PATCH',
+  //   },
+  // });
+
   const labelRef = React.useRef(null);
 
   // Constants
@@ -113,19 +119,22 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     };
   }, [scenarioData]);
 
-  const areGlobalPAreasSelected = useMemo(() => {
+  const globalPAreasSelectedIds = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
     return GLOBAL_PA_OPTIONS
-      .map((p) => wdpaIucnCategories.includes(p.value))
-      .filter(Boolean).length > 0;
+      .map((p) => p.value)
+      .filter((p) => wdpaIucnCategories?.includes(p));
   }, [wdpaCategories, GLOBAL_PA_OPTIONS]);
 
-  const areProjectPAreasSelected = useMemo(() => {
+  const projectPAreasSelectedIds = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
     return PROJECT_PA_OPTIONS
-      .map((p) => wdpaIucnCategories.includes(p.value))
-      .filter(Boolean).length > 0;
+      .map((p) => p.value)
+      .filter((p) => wdpaIucnCategories?.includes(p));
   }, [wdpaCategories, PROJECT_PA_OPTIONS]);
+
+  const areGlobalPAreasSelected = !!globalPAreasSelectedIds.length;
+  const areProjectPAreasSelected = !!projectPAreasSelectedIds.length;
 
   useEffect(() => {
     const { wdpaThreshold } = scenarioData;
@@ -146,6 +155,16 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     }, {
       onSuccess: () => {
         setSubmitting(false);
+        // saveScenarioMutation.mutate({
+        //   id: `${sid}`,
+        //   data: {
+        //     customProtectedAreaIds: projectPAreasSelectedIds || null,
+        //     wdpaIucnCategories: globalPAreasSelectedIds || null,
+        //   },
+        // }, {
+        //   onSuccess: () => { },
+        //   onError: () => { },
+        // });
 
         addToast('save-scenario-wdpa', (
           <>
@@ -172,8 +191,11 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     });
   }, [
     saveScenarioProtectedAreasMutation,
+    // saveScenarioMutation,
     selectedProtectedAreas,
     sid,
+    // projectPAreasSelectedIds,
+    // globalPAreasSelectedIds,
     addToast,
     onSuccess]);
 

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -116,12 +116,15 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
   const areGlobalPAreasSelected = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
     return GLOBAL_PA_OPTIONS
-      .map((p) => wdpaIucnCategories.includes(p.value)).filter(Boolean).length > 0;
+      .map((p) => wdpaIucnCategories.includes(p.value))
+      .filter(Boolean).length > 0;
   }, [wdpaCategories, GLOBAL_PA_OPTIONS]);
 
   const areProjectPAreasSelected = useMemo(() => {
     const { wdpaIucnCategories } = wdpaCategories;
-    return PROJECT_PA_OPTIONS.map((p) => wdpaIucnCategories.includes(p.value));
+    return PROJECT_PA_OPTIONS
+      .map((p) => wdpaIucnCategories.includes(p.value))
+      .filter(Boolean).length > 0;
   }, [wdpaCategories, PROJECT_PA_OPTIONS]);
 
   useEffect(() => {

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -5,8 +5,6 @@ import React, {
 import { Form as FormRFF, Field as FieldRFF } from 'react-final-form';
 import { useDispatch, useSelector } from 'react-redux';
 
-import intersection from 'lodash/intersection';
-
 import { useRouter } from 'next/router';
 
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
@@ -77,7 +75,7 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
 
   const saveScenarioMutation = useSaveScenario({
     requestConfig: {
-      method: 'POST',
+      method: 'PATCH',
     },
   });
 
@@ -98,13 +96,9 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
   const PROJECT_PA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => w.kind === 'project');
   const WDPA_OPTIONS = WDPA_CATEGORIES_OPTIONS.filter((w) => w.kind === 'global');
 
-  const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
-  const plainProjectPAOptions = PROJECT_PA_OPTIONS.map((o) => o.value);
+  const areWDPAreasSelected = WDPA_OPTIONS.filter((p) => p.selected);
+  const areProjectPAreasSelected = PROJECT_PA_OPTIONS.filter((p) => p.selected);
 
-  const areWDPAreasSelected = intersection(plainWDPAOptions,
-    wdpaCategories.wdpaIucnCategories).length > 0;
-  const areProjectPAreasSelected = intersection(plainProjectPAOptions,
-    wdpaCategories.wdpaIucnCategories).length > 0;
   const INITIAL_VALUES = useMemo(() => {
     const { wdpaThreshold, wdpaIucnCategories } = scenarioData;
 
@@ -127,12 +121,12 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     if (modified.wdpaThreshold || scenarioEditingMetadata.tab === 'protected-areas') {
       setSubmitting(true);
 
-      const { wdpaThreshold } = values;
+      // const { wdpaThreshold } = values;
 
       saveScenarioMutation.mutate({
         id: `${sid}`,
         data: {
-          threshold: +(wdpaThreshold * 100).toFixed(0),
+          // threshold: +(wdpaThreshold * 100).toFixed(0),
           metadata: mergeScenarioStatusEditingMetaData(
             metadata,
             {

--- a/app/layout/scenarios/show/map/component.tsx
+++ b/app/layout/scenarios/show/map/component.tsx
@@ -73,6 +73,7 @@ export const ScenariosMap: React.FC<ScenariosShowMapProps> = () => {
   const {
     data: scenarioData,
   } = useScenario(sid);
+
   const { wdpaIucnCategories, wdpaThreshold } = scenarioData || {};
 
   const {

--- a/app/layout/scenarios/show/wdpa/component.tsx
+++ b/app/layout/scenarios/show/wdpa/component.tsx
@@ -49,6 +49,9 @@ export const ScenariosSidebarShowWDPA: React.FC<ScenariosSidebarShowWDPAProps> =
     scenarioId: sid,
   });
 
+  console.log('wdpaData', wdpaData);
+  console.log('scenarioData', scenarioData);
+
   const selectedProtectedAreas = useMemo(() => {
     return wdpaData?.filter((pa) => pa.selected);
   }, [wdpaData]);

--- a/app/layout/scenarios/show/wdpa/component.tsx
+++ b/app/layout/scenarios/show/wdpa/component.tsx
@@ -49,9 +49,6 @@ export const ScenariosSidebarShowWDPA: React.FC<ScenariosSidebarShowWDPAProps> =
     scenarioId: sid,
   });
 
-  console.log('wdpaData', wdpaData);
-  console.log('scenarioData', scenarioData);
-
   const selectedProtectedAreas = useMemo(() => {
     return wdpaData?.filter((pa) => pa.selected);
   }, [wdpaData]);

--- a/app/layout/scenarios/show/wdpa/component.tsx
+++ b/app/layout/scenarios/show/wdpa/component.tsx
@@ -41,21 +41,16 @@ export const ScenariosSidebarShowWDPA: React.FC<ScenariosSidebarShowWDPAProps> =
     isFetched: wdpaIsFetched,
   } = useWDPACategories({
     adminAreaId: projectData?.adminAreaLevel2Id
-                 || projectData?.adminAreaLevel1I
-                 || projectData?.countryId,
+      || projectData?.adminAreaLevel1I
+      || projectData?.countryId,
     customAreaId: !projectData?.adminAreaLevel2Id
-                  && !projectData?.adminAreaLevel1I
-                  && !projectData?.countryId ? projectData?.planningAreaId : null,
+      && !projectData?.adminAreaLevel1I
+      && !projectData?.countryId ? projectData?.planningAreaId : null,
     scenarioId: sid,
   });
 
-  const WDPA_CATEGORIES_OPTIONS = useMemo(() => {
-    if (!wdpaData) return [];
-
-    return wdpaData.map((w) => ({
-      label: `IUCN ${w.iucnCategory}`,
-      value: w.id,
-    }));
+  const selectedProtectedAreas = useMemo(() => {
+    return wdpaData?.filter((pa) => pa.selected);
   }, [wdpaData]);
 
   if (!scenarioData || tab !== 'protected-areas') return null;
@@ -123,76 +118,72 @@ export const ScenariosSidebarShowWDPA: React.FC<ScenariosSidebarShowWDPAProps> =
               <div className="relative px-0.5 overflow-x-visible overflow-y-auto">
                 <div className="py-8 space-y-6">
 
-                  {!scenarioData?.wdpaIucnCategories && (
-                  <div>
-                    <p className="mb-3 text-sm text-gray-300">No protected areas has been selected.</p>
-                  </div>
+                  {selectedProtectedAreas?.length === 0 && (
+                    <div>
+                      <p className="mb-3 text-sm text-gray-300">No protected areas has been selected.</p>
+                    </div>
                   )}
-                  {scenarioData?.wdpaIucnCategories && (
-                  <>
-                    <div>
-                      <h3 className="text-xs uppercase">Selected protected areas:</h3>
-                      <div className="flex flex-wrap mt-2.5">
-                        {scenarioData && scenarioData?.wdpaIucnCategories
-                    && scenarioData?.wdpaIucnCategories.map((w) => {
-                      const wdpa = WDPA_CATEGORIES_OPTIONS.find((o) => o.value === w);
 
-                      if (!wdpa) return null;
-
-                      return (
-                        <div
-                          key={`${wdpa.value}`}
-                          className="flex mb-2.5 mr-5"
-                        >
-                          <span className="text-sm text-blue-400 bg-blue-400 bg-opacity-20 rounded-3xl px-2.5 h-6 inline-flex items-center mr-1">
-                            {wdpa.label}
-                          </span>
+                  {selectedProtectedAreas?.length > 0 && (
+                    <>
+                      <div>
+                        <h3 className="text-xs uppercase">Selected protected areas:</h3>
+                        <div className="flex flex-wrap mt-2.5">
+                          {selectedProtectedAreas.map((pa) => {
+                            return (
+                              <div
+                                key={`${pa.id}`}
+                                className="flex mb-2.5 mr-5"
+                              >
+                                <span className="text-sm text-blue-400 bg-blue-400 bg-opacity-20 rounded-3xl px-2.5 h-6 inline-flex items-center mr-1">
+                                  {pa.kind === 'global' ? `IUCN ${pa.name}` : `${pa.name}`}
+                                </span>
+                              </div>
+                            );
+                          })}
                         </div>
-                      );
-                    })}
                       </div>
-                    </div>
 
-                    <div>
-                      <div className="flex items-center mb-3">
-                        <Label theme="dark" className="mr-3 text-xs uppercase">Threshold for protected areas:</Label>
-                        <InfoButton>
-                          <div>
-                            <h4 className="font-heading text-lg mb-2.5">What is a threshold?</h4>
-                            <div className="space-y-2">
-                              <p>
-                                Inside Marxan, planning units are considered as either
-                                protected
-                                or not protected.
-                              </p>
-                              <p>
-                                The threshold value represents a
-                                percentage of the area
-                                inside a planning unit. By setting the threshold you decide
-                                how much of a protected area needs to fall inside a
-                                planning unit to consider the whole planning unit
-                                as &quot;protected&quot;.
-                              </p>
-                              <p>
-                                The following
-                                image shows an example setting a threshold of 50%:
-                              </p>
+                      <div>
+                        <div className="flex items-center mb-3">
+                          <Label theme="dark" className="mr-3 text-xs uppercase">Threshold for protected areas:</Label>
+                          <InfoButton>
+                            <div>
+                              <h4 className="font-heading text-lg mb-2.5">What is a threshold?</h4>
+                              <div className="space-y-2">
+                                <p>
+                                  Inside Marxan, planning units are considered as either
+                                  protected
+                                  or not protected.
+                                </p>
+                                <p>
+                                  The threshold value represents a
+                                  percentage of the area
+                                  inside a planning unit. By setting the threshold you decide
+                                  how much of a protected area needs to fall inside a
+                                  planning unit to consider the whole planning unit
+                                  as &quot;protected&quot;.
+                                </p>
+                                <p>
+                                  The following
+                                  image shows an example setting a threshold of 50%:
+                                </p>
+                              </div>
+
+                              <img src={THRESHOLD_IMG} alt="Threshold" />
+
                             </div>
+                          </InfoButton>
+                        </div>
 
-                            <img src={THRESHOLD_IMG} alt="Threshold" />
-
-                          </div>
-                        </InfoButton>
+                        <p className="mb-3 text-sm text-gray-300">
+                          Refers to what percentage of a planning unit must
+                          {' '}
+                          be covered by a protected area to be considered “protected”.
+                        </p>
+                        <p>{`${scenarioData?.wdpaThreshold}%`}</p>
                       </div>
-
-                      <p className="mb-3 text-sm text-gray-300">
-                        Refers to what percentage of a planning unit must
-                        {' '}
-                        be covered by a protected area to be considered “protected”.
-                      </p>
-                      <p>{`${scenarioData?.wdpaThreshold}%`}</p>
-                    </div>
-                  </>
+                    </>
                   )}
 
                 </div>


### PR DESCRIPTION
## Custom protected areas

### Overview

Add custom protected areas when user creates scenarios.

### Testing instructions

1. Connect to m56 env.
2. Create a Botswana project.
3. Create a scenario.
4. Upload a custom protected area with custom name.
5. Add custom area to scenario.
6. Set a low threshold (PAs shapefile are very small).
7. Fill rest of the parameters o a scenario.
8. Run scenario.
9. Create an other scenario with same custom protected area shapefile. 
10. Try to edit first scenario created adding new protected areas 

### Feature relevant tickets

[MARXAN-743](https://vizzuality.atlassian.net/browse/MARXAN-743)

---

## Checklist before submitting

- [ ] A custom protected area can be upload to a scenario.
- [ ] Protected areas selector should be updated after a new protected area is uploaded.
- [ ] Another custom protected area can be uploaded to another scenario of the same project.
- [ ] Is not possible to upload the same protected area twice in the same project. In the event that this occurs, a message that the process has failed should appear.
- [ ] If the protected area does not have a given name, it cannot be uploaded.

