### PR TITLE
User account confirmation after signing up

### DIFF
--- a/api/apps/api/config/default.json
+++ b/api/apps/api/config/default.json
@@ -62,6 +62,9 @@
   "passwordReset": {
     "tokenPrefix": "http://localhost:3000/auth/reset-password?token=",
     "expiration": 1800000
+  },
+  "signUpConfirmation": {
+    "tokenPrefix": "http://localhost:3000/auth/sign-up-confirmation?token="
   }
 }
 

--- a/api/apps/api/src/modules/authentication/authentication.controller.ts
+++ b/api/apps/api/src/modules/authentication/authentication.controller.ts
@@ -1,8 +1,6 @@
 import {
   Body,
   Controller,
-  Get,
-  Param,
   Post,
   Request,
   UseGuards,
@@ -78,13 +76,13 @@ export class AuthenticationController {
     await this.authenticationService.createUser(signupDto);
   }
 
-  @Get('validate-account/:sub/:validationToken')
+  @Post('validate')
   @ApiOperation({ description: 'Confirm an activation token for a new user.' })
   @ApiOkResponse()
   async confirm(
-    @Param() activationToken: UserAccountValidationDTO,
+    @Body(new ValidationPipe()) validationDto: UserAccountValidationDTO,
   ): Promise<void> {
-    await this.authenticationService.validateActivationToken(activationToken);
+    await this.authenticationService.validateActivationToken(validationDto);
   }
 
   /**

--- a/api/apps/api/src/modules/authentication/authentication.service.ts
+++ b/api/apps/api/src/modules/authentication/authentication.service.ts
@@ -21,6 +21,7 @@ import { SignUpDto } from './dto/sign-up.dto';
 import { ApiEventsService } from '@marxan-api/modules/api-events/api-events.service';
 import { v4 } from 'uuid';
 import * as ApiEventsUserData from '@marxan-api/modules/api-events/dto/apiEvents.user.data.dto';
+import { Mailer } from '@marxan-api/modules/authentication/password-recovery/mailer';
 import { API_EVENT_KINDS } from '@marxan/api-events';
 
 /**
@@ -77,6 +78,7 @@ export class AuthenticationService {
     @InjectRepository(IssuedAuthnToken)
     private readonly issuedAuthnTokensRepository: Repository<IssuedAuthnToken>,
     @InjectRepository(User) private readonly usersRepository: Repository<User>,
+    private readonly mailer: Mailer,
   ) {}
 
   /**
@@ -106,20 +108,12 @@ export class AuthenticationService {
    * Create a new user from the signup data provided.
    *
    * @todo Allow to set all of a user's data on signup, if needed.
-   * @todo Implement email verification.
    */
   async createUser(signupDto: SignUpDto): Promise<Partial<User>> {
     const user = new User();
     user.displayName = signupDto.displayName;
     user.passwordHash = await hash(signupDto.password, 10);
     user.email = signupDto.email;
-    /**
-     * @todo `isActive` should never be set to true here - we do this only in
-     * dev environments until the email validation feature is ready.
-     */
-    if (process.env['NODE_ENV'] === 'development') {
-      user.isActive = true;
-    }
     const newUser = UsersService.getSanitizedUserMetadata(
       await this.usersRepository.save(user),
     );
@@ -152,6 +146,7 @@ export class AuthenticationService {
         `An account was created for ${newUser.email}. Please validate the account via GET /auth/validate-account/${newUser.id}/${validationToken}.`,
       );
     }
+    await this.mailer.sendSignUpConfirmationEmail(newUser.id, validationToken);
     return newUser;
   }
 

--- a/api/apps/api/src/modules/authentication/authentication.service.ts
+++ b/api/apps/api/src/modules/authentication/authentication.service.ts
@@ -143,7 +143,7 @@ export class AuthenticationService {
      */
     if (process.env['NODE_ENV'] === 'development') {
       this.logger.log(
-        `An account was created for ${newUser.email}. Please validate the account via GET /auth/validate-account/${newUser.id}/${validationToken}.`,
+        `An account was created for ${newUser.email}. Please validate the account via POST /auth/validate and body { sub: "${newUser.id}", validationToken: "${validationToken}" }`,
       );
     }
     await this.mailer.sendSignUpConfirmationEmail(newUser.id, validationToken);

--- a/api/apps/api/src/modules/authentication/dto/user-account.validation.dto.ts
+++ b/api/apps/api/src/modules/authentication/dto/user-account.validation.dto.ts
@@ -1,15 +1,20 @@
-import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsUUID } from 'class-validator';
 
 export class UserAccountValidationDTO {
   /**
    * Unique activation token generated during user signup flow.
    */
   @IsUUID(4)
+  @IsString()
+  @ApiProperty()
   validationToken!: string;
 
   /**
    * Subject of the activation flow: in this case, the user's UUID.
    */
   @IsUUID(4)
+  @IsString()
+  @ApiProperty()
   sub!: string;
 }

--- a/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
+++ b/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
@@ -10,6 +10,12 @@ import { CreateTransmission, Recipient } from 'sparkpost';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { UsersService } from '@marxan-api/modules/users/users.service';
 
+enum SparkpostTemplate {
+  PasswordChangedConfirmation = 'confirmation-password-changed',
+  PasswordRecovery = 'marxan-reset-password',
+  SignUpConfirmation = 'confirmation-account',
+}
+
 export abstract class Mailer {
   abstract sendRecoveryEmail(userId: string, token: string): Promise<void>;
   abstract sendPasswordChangedConfirmation(userId: string): Promise<void>;
@@ -57,7 +63,7 @@ export class SparkPostMailer implements Mailer {
   ) {}
 
   private async sendEmail(
-    template: string,
+    template: SparkpostTemplate,
     targetEmail: string,
     data: Record<string, any> = {},
   ): Promise<void> {
@@ -77,12 +83,15 @@ export class SparkPostMailer implements Mailer {
 
   async sendPasswordChangedConfirmation(userId: string): Promise<void> {
     const user = await this.usersService.getById(userId);
-    return this.sendEmail('confirmation-password-changed', user.email);
+    return this.sendEmail(
+      SparkpostTemplate.PasswordChangedConfirmation,
+      user.email,
+    );
   }
 
   async sendRecoveryEmail(userId: string, token: string): Promise<void> {
     const user = await this.usersService.getById(userId);
-    return this.sendEmail('marxan-reset-password', user.email, {
+    return this.sendEmail(SparkpostTemplate.PasswordRecovery, user.email, {
       urlRecover: this.passwordResetPrefix + token,
     });
   }
@@ -92,7 +101,7 @@ export class SparkPostMailer implements Mailer {
     token: string,
   ): Promise<void> {
     const user = await this.usersService.getById(userId);
-    return this.sendEmail('confirmation-account', user.email, {
+    return this.sendEmail(SparkpostTemplate.SignUpConfirmation, user.email, {
       urlSignUpConfirmation:
         AppConfig.get('signUpConfirmation.tokenPrefix') + token,
     });

--- a/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
+++ b/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
@@ -1,4 +1,10 @@
-import { FactoryProvider, Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  FactoryProvider,
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import * as Sparkpost from 'sparkpost';
 import { CreateTransmission, Recipient } from 'sparkpost';
 import { AppConfig } from '@marxan-api/utils/config.utils';
@@ -6,8 +12,11 @@ import { UsersService } from '@marxan-api/modules/users/users.service';
 
 export abstract class Mailer {
   abstract sendRecoveryEmail(userId: string, token: string): Promise<void>;
-
   abstract sendPasswordChangedConfirmation(userId: string): Promise<void>;
+  abstract sendSignUpConfirmationEmail(
+    userId: string,
+    token: string,
+  ): Promise<void>;
 }
 
 export const sparkPostProvider: FactoryProvider<Sparkpost> = {
@@ -25,9 +34,14 @@ const passwordResetPrefixToken = Symbol('password reset prefix token');
 export const passwordResetPrefixProvider: FactoryProvider<string> = {
   provide: passwordResetPrefixToken,
   useFactory: () => {
-    const prefix = AppConfig.get<string>('passwordReset.tokenPrefix');
-    return prefix;
+    return AppConfig.get<string>('passwordReset.tokenPrefix');
   },
+};
+
+const signUpConfirmationPrefixToken = Symbol('sign-up confirm prefix token');
+export const signUpConfirmationPrefixProvider: FactoryProvider<string> = {
+  provide: signUpConfirmationPrefixToken,
+  useFactory: () => AppConfig.get<string>('signUpConfirmation.tokenPrefix'),
 };
 
 @Injectable()
@@ -36,41 +50,52 @@ export class SparkPostMailer implements Mailer {
 
   constructor(
     private readonly sparkpost: Sparkpost,
+    @Inject(forwardRef(() => UsersService))
     private readonly usersService: UsersService,
     @Inject(passwordResetPrefixToken)
     private readonly passwordResetPrefix: string,
   ) {}
-  async sendPasswordChangedConfirmation(userId: string): Promise<void> {
-    const user = await this.usersService.getById(userId);
+
+  private async sendEmail(
+    template: string,
+    targetEmail: string,
+    data: Record<string, any> = {},
+  ): Promise<void> {
     const recipient: Recipient = {
-      address: user.email,
+      substitution_data: data,
+      address: targetEmail,
     };
+
     const transmission: CreateTransmission = {
       recipients: [recipient],
-      content: {
-        template_id: 'confirmation-password-changed',
-      },
+      content: { template_id: template },
     };
+
     const result = await this.sparkpost.transmissions.send(transmission);
     this.logger.log(result);
   }
 
+  async sendPasswordChangedConfirmation(userId: string): Promise<void> {
+    const user = await this.usersService.getById(userId);
+    return this.sendEmail('confirmation-password-changed', user.email);
+  }
+
   async sendRecoveryEmail(userId: string, token: string): Promise<void> {
     const user = await this.usersService.getById(userId);
-    const recipient: Recipient = {
-      substitution_data: {
-        urlRecover: this.passwordResetPrefix + token,
-      },
-      address: user.email,
-    };
-    const transmission: CreateTransmission = {
-      recipients: [recipient],
-      content: {
-        template_id: 'marxan-reset-password',
-      },
-    };
-    const result = await this.sparkpost.transmissions.send(transmission);
-    this.logger.log(result);
+    return this.sendEmail('marxan-reset-password', user.email, {
+      urlRecover: this.passwordResetPrefix + token,
+    });
+  }
+
+  async sendSignUpConfirmationEmail(
+    userId: string,
+    token: string,
+  ): Promise<void> {
+    const user = await this.usersService.getById(userId);
+    return this.sendEmail('confirmation-account', user.email, {
+      urlSignUpConfirmation:
+        AppConfig.get('signUpConfirmation.tokenPrefix') + token,
+    });
   }
 }
 
@@ -84,6 +109,15 @@ export class ConsoleMailer implements Mailer {
   async sendRecoveryEmail(userId: string, token: string): Promise<void> {
     this.logger.log(
       `sending recovery email to user ${userId} with token ${token}`,
+    );
+  }
+
+  async sendSignUpConfirmationEmail(
+    userId: string,
+    token: string,
+  ): Promise<void> {
+    this.logger.log(
+      `Sending sign-up confirmation email to user ${userId} with token ${token}`,
     );
   }
 }

--- a/api/apps/api/src/modules/authentication/password-recovery/password-recovery.spec.ts
+++ b/api/apps/api/src/modules/authentication/password-recovery/password-recovery.spec.ts
@@ -92,6 +92,7 @@ async function getFixtures() {
   const fakeMailer: jest.Mocked<Mailer> = {
     sendRecoveryEmail: jest.fn<any, any>(fail),
     sendPasswordChangedConfirmation: jest.fn<any, any>(fail),
+    sendSignUpConfirmationEmail: jest.fn<any, any>(fail),
   };
   class FakeTokenFactory {
     count = 0;

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -108,11 +108,7 @@ describe('UsersModule (e2e)', () => {
         .expect(HttpStatus.INTERNAL_SERVER_ERROR);
     });
 
-    /**
-     * @todo Enable this test once we drop the temporary automatic whitelisting
-     * of new accounts in development environments.
-     */
-    test.skip('A user should not be able to log in until their account has been validated', async () => {
+    test('A user should not be able to log in until their account has been validated', async () => {
       await request(app.getHttpServer())
         .post('/auth/sign-in')
         .send(loginDto)
@@ -139,10 +135,12 @@ describe('UsersModule (e2e)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(
-          `/auth/validate-account/${newUser.id}/${validationTokenEvent?.data?.validationToken}`,
-        )
-        .expect(HttpStatus.OK);
+        .post(`/auth/validate`)
+        .send({
+          sub: newUser.id,
+          validationToken: validationTokenEvent?.data?.validationToken,
+        })
+        .expect(HttpStatus.CREATED);
     });
 
     test('A user account validation token should not be allowed to be spent more than once', async () => {
@@ -151,9 +149,11 @@ describe('UsersModule (e2e)', () => {
       }
 
       await request(app.getHttpServer())
-        .get(
-          `/auth/validate-account/${newUser.id}/${validationTokenEvent?.data?.validationToken}`,
-        )
+        .post(`/auth/validate`)
+        .send({
+          sub: newUser.id,
+          validationToken: validationTokenEvent?.data?.validationToken,
+        })
         .expect(HttpStatus.NOT_FOUND);
     });
 
@@ -326,10 +326,12 @@ describe('UsersModule (e2e)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(
-          `/auth/validate-account/${newUser.id}/${validationTokenEvent?.data?.validationToken}`,
-        )
-        .expect(HttpStatus.OK);
+        .post(`/auth/validate`)
+        .send({
+          sub: newUser.id,
+          validationToken: validationTokenEvent?.data?.validationToken,
+        })
+        .expect(HttpStatus.CREATED);
     });
 
     test('A user should be able to log in once their account has been validated', async () => {

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -18,6 +18,10 @@ import { LoginDto } from '@marxan-api/modules/authentication/dto/login.dto';
 import { ApiEventByTopicAndKind } from '@marxan-api/modules/api-events/api-event.topic+kind.api.entity';
 import { tearDown } from './utils/tear-down';
 import { API_EVENT_KINDS } from '@marxan/api-events';
+import * as nock from 'nock';
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
 
 /**
  * Tests for the UsersModule.
@@ -91,6 +95,10 @@ describe('UsersModule (e2e)', () => {
     let validationTokenEvent: ApiEventByTopicAndKind | undefined;
 
     test('A user should be able to create an account using an email address not currently in use', async () => {
+      nock('https://api.eu.sparkpost.com')
+        .post(`/api/v1/transmissions`)
+        .reply(200);
+
       await request(app.getHttpServer())
         .post('/auth/sign-up')
         .send(signUpDto)
@@ -300,6 +308,10 @@ describe('UsersModule (e2e)', () => {
     let validationTokenEvent: ApiEventByTopicAndKind | undefined;
 
     test('A user should be able to sign up using the same email address as that of an account that has been deleted', async () => {
+      nock('https://api.eu.sparkpost.com')
+        .post(`/api/v1/transmissions`)
+        .reply(200);
+
       await request(app.getHttpServer())
         .post('/auth/sign-up')
         .send(signUpDto)


### PR DESCRIPTION
## User account confirmation after signing up

### Overview

This PR adds the user account confirmation flow, as described [in this document](https://docs.google.com/document/d/1kEEgckbv6K7MoCpUSClJMUl3AV9hNUsjPN52CZte9DY/edit?usp=sharing).

### Testing instructions

After signing-up, an email should be sent to the new user with instructions on how to confirm their account:
1. If the user does not click on the confirm link in the email, they should not be able to log in to the platform;
2. If the user clicks on the confirm link in the email, they should be taken to the front end of the platform, where their account will be activated and they will be able to log in.

### Feature relevant tickets

[MARXAN-947](https://vizzuality.atlassian.net/browse/MARXAN-947)

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file