### PR TITLE
Sign-up confirmation - remove need to provide userId

### DIFF
--- a/api/apps/api/src/modules/authentication/authentication.controller.ts
+++ b/api/apps/api/src/modules/authentication/authentication.controller.ts
@@ -21,6 +21,7 @@ import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 import {
   AccessToken,
   AuthenticationService,
+  ValidationToken,
 } from '@marxan-api/modules/authentication/authentication.service';
 import { LoginDto } from './dto/login.dto';
 import { SignUpDto } from './dto/sign-up.dto';
@@ -72,8 +73,8 @@ export class AuthenticationController {
   async signUp(
     @Request() _req: Request,
     @Body(new ValidationPipe()) signupDto: SignUpDto,
-  ): Promise<void> {
-    await this.authenticationService.createUser(signupDto);
+  ): Promise<ValidationToken> {
+    return this.authenticationService.createUser(signupDto);
   }
 
   @Post('validate')

--- a/api/apps/api/src/modules/authentication/dto/user-account.validation.dto.ts
+++ b/api/apps/api/src/modules/authentication/dto/user-account.validation.dto.ts
@@ -9,12 +9,4 @@ export class UserAccountValidationDTO {
   @IsString()
   @ApiProperty()
   validationToken!: string;
-
-  /**
-   * Subject of the activation flow: in this case, the user's UUID.
-   */
-  @IsUUID(4)
-  @IsString()
-  @ApiProperty()
-  sub!: string;
 }

--- a/api/apps/api/test/auth.e2e-spec.ts
+++ b/api/apps/api/test/auth.e2e-spec.ts
@@ -21,7 +21,7 @@ describe('AppController (e2e)', () => {
       app = moduleFixture.createNestApplication();
       await app.init();
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
   });
 


### PR DESCRIPTION
## Sign-up confirmation - remove need to provide userId

### Overview

This PR removes the need to provide the `userId` in the `validate` endpoint on the sign-up confirmation flow. At that point in time, when the `validate` endpoint is used by the FE, the FE does not know the `userId` yet (because the login didn't happen yet).

This PR makes sure we store the `userId` to be validated in the API event data of the validation token, so that we can validate users based on the token only.

### Testing instructions

`POST /auth/validate` providing only `validationToken` should be possible.

### Feature relevant tickets

[MARXAN-947](https://vizzuality.atlassian.net/browse/MARXAN-947)

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file