### PR TITLE
Provide user id to Sparkpost template data on sign up confirmation

### DIFF
--- a/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
+++ b/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
@@ -102,8 +102,9 @@ export class SparkPostMailer implements Mailer {
   ): Promise<void> {
     const user = await this.usersService.getById(userId);
     return this.sendEmail(SparkpostTemplate.SignUpConfirmation, user.email, {
-      urlSignUpConfirmation:
-        AppConfig.get('signUpConfirmation.tokenPrefix') + token,
+      urlSignUpConfirmation: `${AppConfig.get(
+        'signUpConfirmation.tokenPrefix',
+      )}${token}&userId=${userId}`,
     });
   }
 }


### PR DESCRIPTION
## Provide user id to Sparkpost template data

### Overview

This PR adds `userId` to the confirmation URL sent via Sparkpost, so that it can be used by the FE when validating the account. 

### Testing instructions

The confirmation URL included in sign up confirmation URL sent via email to the user should include the ID of the user trying to log in as query parameter (`userId`).

### Feature relevant tickets

[MARXAN-947](https://vizzuality.atlassian.net/browse/MARXAN-947)

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file