### PR TITLE
test: adds fixtures, improvements in project-acl e2e tests

### DIFF
--- a/api/apps/api/test/access-control/project-acl-delete.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-delete.e2e-spec.ts
@@ -1,0 +1,38 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getFixtures } from './project-acl.fixtures';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+afterEach(async () => {
+  await fixtures?.userRoleCleanup();
+  await fixtures?.cleanup();
+});
+
+test(`delete every type of user from the project as owner`, async () => {
+  const projectId = await fixtures.GivenProjectExistsAndHasUsers();
+  let revokeResponse = await fixtures.WhenRevokingAccessToViewerFromProjectAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(revokeResponse);
+  revokeResponse = await fixtures.WhenRevokingAccessToContributorFromProjectAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(revokeResponse);
+  revokeResponse = await fixtures.WhenRevokingAccessToOwnerFromProjectAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(revokeResponse);
+  const response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
+  fixtures.ThenSingleOwnerUserInProjectIsReturned(response);
+});
+
+test(`delete last owner as the only owner`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  const revokeResponse = await fixtures.WhenRevokingAccessToLastOwnerFromProjectAsOwner(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(revokeResponse);
+});

--- a/api/apps/api/test/access-control/project-acl-delete.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-delete.e2e-spec.ts
@@ -7,26 +7,30 @@ beforeEach(async () => {
   fixtures = await getFixtures();
 });
 afterEach(async () => {
-  await fixtures?.userRoleCleanup();
   await fixtures?.cleanup();
 });
 
 test(`delete every type of user from the project as owner`, async () => {
-  const projectId = await fixtures.GivenProjectExistsAndHasUsers();
-  let revokeResponse = await fixtures.WhenRevokingAccessToViewerFromProjectAsOwner(
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenViewerWasAddedToProject(projectId);
+  await fixtures.GivenContributorWasAddedToProject(projectId);
+  await fixtures.GivenOwnerWasAddedToProject(projectId);
+  const viewerRevokeResponse = await fixtures.WhenRevokingAccessToViewerFromProjectAsOwner(
     projectId,
   );
-  fixtures.ThenNoContentIsReturned(revokeResponse);
-  revokeResponse = await fixtures.WhenRevokingAccessToContributorFromProjectAsOwner(
+  const contributorRevokeResponse = await fixtures.WhenRevokingAccessToContributorFromProjectAsOwner(
     projectId,
   );
-  fixtures.ThenNoContentIsReturned(revokeResponse);
-  revokeResponse = await fixtures.WhenRevokingAccessToOwnerFromProjectAsOwner(
+  const ownerRevokeResponse = await fixtures.WhenRevokingAccessToOwnerFromProjectAsOwner(
     projectId,
   );
-  fixtures.ThenNoContentIsReturned(revokeResponse);
-  const response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
-  fixtures.ThenSingleOwnerUserInProjectIsReturned(response);
+  const singleUserResponse = await fixtures.WhenGettingProjectUsersAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(viewerRevokeResponse);
+  fixtures.ThenNoContentIsReturned(contributorRevokeResponse);
+  fixtures.ThenNoContentIsReturned(ownerRevokeResponse);
+  fixtures.ThenSingleOwnerUserInProjectIsReturned(singleUserResponse);
 });
 
 test(`delete last owner as the only owner`, async () => {

--- a/api/apps/api/test/access-control/project-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-get.e2e-spec.ts
@@ -25,108 +25,17 @@ test(`getting project users as owner and unique user`, async () => {
 });
 
 test(`getting project users as viewer`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewViewerToTheProjectAsOwner(projectId);
+  const projectId = await fixtures.GivenProjectExistsAndHasUsers();
+  await fixtures.GivenAUserWasGivenViewerRoleOnProject(projectId);
   const response = await fixtures.WhenGettingProjectUsersAsViewer(projectId);
   fixtures.ThenForbiddenIsReturned(response);
 });
 
 test(`getting project users as contributor`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
+  const projectId = await fixtures.GivenProjectExistsAndHasUsers();
+  await fixtures.GivenAUserWasGivenContributorRoleOnProject(projectId);
   const response = await fixtures.WhenGettingProjectUsersAsContributor(
     projectId,
   );
   fixtures.ThenForbiddenIsReturned(response);
-});
-
-test(`getting project users with user in project but is other owner`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewOwnerToTheProjectAsOwner(projectId);
-  const response = await fixtures.WhenGettingProjectUsersAsOtherOwner(
-    projectId,
-  );
-  fixtures.ThenAllUsersinProjectAfterAddingAnOwnerAreReturned(response);
-});
-
-test(`add every type of user to a project as a project owner`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  let response = await fixtures.WhenAddingANewViewerToTheProjectAsOwner(
-    projectId,
-  );
-  fixtures.ThenNoContentIsReturned(response);
-  response = await fixtures.WhenAddingANewContributorToTheProjectAsOwner(
-    projectId,
-  );
-  fixtures.ThenNoContentIsReturned(response);
-  response = await fixtures.WhenAddingANewOwnerToTheProjectAsOwner(projectId);
-  fixtures.ThenNoContentIsReturned(response);
-
-  response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
-  fixtures.ThenAllUsersinProjectAfterEveryTypeOfUserHasBeenAddedAreReturned(
-    response,
-  );
-});
-
-test(`add every type of user to a project as a project contributor`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
-
-  let response = await fixtures.WhenAddingANewViewerToTheProjectAsContributor(
-    projectId,
-  );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewContributorToTheProjectAsContributor(
-    projectId,
-  );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewOwnerToTheProjectAsContributor(
-    projectId,
-  );
-  fixtures.ThenForbiddenIsReturned(response);
-});
-
-test(`add every type of user to a project as a project viewer`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
-
-  let response = await fixtures.WhenAddingANewViewerToTheProjectAsViewer(
-    projectId,
-  );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewContributorToTheProjectAsViewer(
-    projectId,
-  );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewOwnerToTheProjectAsViewer(projectId);
-  fixtures.ThenForbiddenIsReturned(response);
-});
-
-test(`delete every type of user from the project as owner`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewViewerToTheProjectAsOwner(projectId);
-  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
-  await fixtures.WhenAddingANewOwnerToTheProjectAsOwner(projectId);
-  let revokeResponse = await fixtures.WhenRevokingAccessToViewerFromProjectAsOwner(
-    projectId,
-  );
-  fixtures.ThenNoContentIsReturned(revokeResponse);
-  revokeResponse = await fixtures.WhenRevokingAccessToContributorFromProjectAsOwner(
-    projectId,
-  );
-  fixtures.ThenNoContentIsReturned(revokeResponse);
-  revokeResponse = await fixtures.WhenRevokingAccessToOwnerFromProjectAsOwner(
-    projectId,
-  );
-  fixtures.ThenNoContentIsReturned(revokeResponse);
-  const response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
-  fixtures.ThenSingleOwnerUserInProjectIsReturned(response);
-});
-
-test(`delete last owner as the only owner`, async () => {
-  const projectId = await fixtures.GivenProjectWasCreated();
-  const revokeResponse = await fixtures.WhenRevokingAccessToLastOwnerFromProjectAsOwner(
-    projectId,
-  );
-  fixtures.ThenForbiddenIsReturned(revokeResponse);
 });

--- a/api/apps/api/test/access-control/project-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-get.e2e-spec.ts
@@ -25,15 +25,15 @@ test(`getting project users as owner and unique user`, async () => {
 });
 
 test(`getting project users as viewer`, async () => {
-  const projectId = await fixtures.GivenProjectExistsAndHasUsers();
-  await fixtures.GivenAUserWasGivenViewerRoleOnProject(projectId);
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenViewerWasAddedToProject(projectId);
   const response = await fixtures.WhenGettingProjectUsersAsViewer(projectId);
   fixtures.ThenForbiddenIsReturned(response);
 });
 
 test(`getting project users as contributor`, async () => {
-  const projectId = await fixtures.GivenProjectExistsAndHasUsers();
-  await fixtures.GivenAUserWasGivenContributorRoleOnProject(projectId);
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenContributorWasAddedToProject(projectId);
   const response = await fixtures.WhenGettingProjectUsersAsContributor(
     projectId,
   );

--- a/api/apps/api/test/access-control/project-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-patch.e2e-spec.ts
@@ -1,0 +1,65 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getFixtures } from './project-acl.fixtures';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+afterEach(async () => {
+  await fixtures?.userRoleCleanup();
+  await fixtures?.cleanup();
+});
+
+test(`add every type of user to a project as project owner`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  let response = await fixtures.WhenAddingANewViewerToTheProjectAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(response);
+  response = await fixtures.WhenAddingANewContributorToTheProjectAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(response);
+  response = await fixtures.WhenAddingANewOwnerToTheProjectAsOwner(projectId);
+  fixtures.ThenNoContentIsReturned(response);
+
+  response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
+  fixtures.ThenAllUsersinProjectAfterEveryTypeOfUserHasBeenAddedAreReturned(
+    response,
+  );
+});
+
+test(`add every type of user to a project as project contributor`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
+
+  let response = await fixtures.WhenAddingANewViewerToTheProjectAsContributor(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+  response = await fixtures.WhenAddingANewContributorToTheProjectAsContributor(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+  response = await fixtures.WhenAddingANewOwnerToTheProjectAsContributor(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+});
+
+test(`add every type of user to a project as project viewer`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
+
+  let response = await fixtures.WhenAddingANewViewerToTheProjectAsViewer(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+  response = await fixtures.WhenAddingANewContributorToTheProjectAsViewer(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+  response = await fixtures.WhenAddingANewOwnerToTheProjectAsViewer(projectId);
+  fixtures.ThenForbiddenIsReturned(response);
+});

--- a/api/apps/api/test/access-control/project-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-patch.e2e-spec.ts
@@ -7,59 +7,61 @@ beforeEach(async () => {
   fixtures = await getFixtures();
 });
 afterEach(async () => {
-  await fixtures?.userRoleCleanup();
   await fixtures?.cleanup();
 });
 
 test(`add every type of user to a project as project owner`, async () => {
   const projectId = await fixtures.GivenProjectWasCreated();
-  let response = await fixtures.WhenAddingANewViewerToTheProjectAsOwner(
+  const viewerResponse = await fixtures.WhenAddingANewViewerToTheProjectAsOwner(
     projectId,
   );
-  fixtures.ThenNoContentIsReturned(response);
-  response = await fixtures.WhenAddingANewContributorToTheProjectAsOwner(
+  const contributorResponse = await fixtures.WhenAddingANewContributorToTheProjectAsOwner(
     projectId,
   );
-  fixtures.ThenNoContentIsReturned(response);
-  response = await fixtures.WhenAddingANewOwnerToTheProjectAsOwner(projectId);
-  fixtures.ThenNoContentIsReturned(response);
-
-  response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
+  const ownerResponse = await fixtures.WhenAddingANewOwnerToTheProjectAsOwner(
+    projectId,
+  );
+  const allUsersInProjectResponse = await fixtures.WhenGettingProjectUsersAsOwner(
+    projectId,
+  );
+  fixtures.ThenNoContentIsReturned(viewerResponse);
+  fixtures.ThenNoContentIsReturned(contributorResponse);
+  fixtures.ThenNoContentIsReturned(ownerResponse);
   fixtures.ThenAllUsersinProjectAfterEveryTypeOfUserHasBeenAddedAreReturned(
-    response,
+    allUsersInProjectResponse,
   );
 });
 
 test(`add every type of user to a project as project contributor`, async () => {
   const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
-
-  let response = await fixtures.WhenAddingANewViewerToTheProjectAsContributor(
+  await fixtures.GivenContributorWasAddedToProject(projectId);
+  const viewerResponse = await fixtures.WhenAddingANewViewerToTheProjectAsContributor(
     projectId,
   );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewContributorToTheProjectAsContributor(
+  const contributorResponse = await fixtures.WhenAddingANewContributorToTheProjectAsContributor(
     projectId,
   );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewOwnerToTheProjectAsContributor(
+  const ownerResponse = await fixtures.WhenAddingANewOwnerToTheProjectAsContributor(
     projectId,
   );
-  fixtures.ThenForbiddenIsReturned(response);
+  fixtures.ThenForbiddenIsReturned(viewerResponse);
+  fixtures.ThenForbiddenIsReturned(contributorResponse);
+  fixtures.ThenForbiddenIsReturned(ownerResponse);
 });
 
 test(`add every type of user to a project as project viewer`, async () => {
   const projectId = await fixtures.GivenProjectWasCreated();
-  await fixtures.WhenAddingANewContributorToTheProjectAsOwner(projectId);
-
-  let response = await fixtures.WhenAddingANewViewerToTheProjectAsViewer(
+  await fixtures.GivenViewerWasAddedToProject(projectId);
+  const viewerResponse = await fixtures.WhenAddingANewViewerToTheProjectAsContributor(
     projectId,
   );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewContributorToTheProjectAsViewer(
+  const contributorResponse = await fixtures.WhenAddingANewContributorToTheProjectAsContributor(
     projectId,
   );
-  fixtures.ThenForbiddenIsReturned(response);
-  response = await fixtures.WhenAddingANewOwnerToTheProjectAsViewer(projectId);
-  fixtures.ThenForbiddenIsReturned(response);
+  const ownerResponse = await fixtures.WhenAddingANewOwnerToTheProjectAsContributor(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(viewerResponse);
+  fixtures.ThenForbiddenIsReturned(contributorResponse);
+  fixtures.ThenForbiddenIsReturned(ownerResponse);
 });

--- a/api/apps/api/test/fixtures/test-data.sql
+++ b/api/apps/api/test/fixtures/test-data.sql
@@ -22,9 +22,11 @@ VALUES
 ((SELECT id FROM users WHERE lower(email) = 'aa@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 1 Org 1'), 'project_owner'),
 ((SELECT id FROM users WHERE lower(email) = 'bb@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 1 Org 1'), 'project_contributor'),
 ((SELECT id FROM users WHERE lower(email) = 'cc@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 1 Org 1'), 'project_viewer'),
+((SELECT id FROM users WHERE lower(email) = 'dd@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 1 Org 1'), 'project_owner'),
 ((SELECT id FROM users WHERE lower(email) = 'aa@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 2 Org 2'), 'project_owner'),
 ((SELECT id FROM users WHERE lower(email) = 'bb@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 2 Org 2'), 'project_contributor'),
-((SELECT id FROM users WHERE lower(email) = 'cc@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 2 Org 2'), 'project_viewer');
+((SELECT id FROM users WHERE lower(email) = 'cc@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 2 Org 2'), 'project_viewer'),
+((SELECT id FROM users WHERE lower(email) = 'dd@example.com'), (SELECT id FROM projects WHERE name = 'Example Project 2 Org 2'), 'project_owner');
 
 INSERT INTO scenarios
 (name, project_id, type, wdpa_threshold, number_of_runs, blm, created_by)

--- a/api/apps/api/test/utils/projects-acl.test.utils.ts
+++ b/api/apps/api/test/utils/projects-acl.test.utils.ts
@@ -1,0 +1,25 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+
+/**
+ * Utility functions for tests related to Projects.
+ *
+ * Hopefully helping to reduce some boilerplate in operations that need to be
+ * carried out throughout tests.
+ *
+ * Create functions return the raw response body - no need to assert anything
+ * here as these utility functions mainly do some work at the edge of what is
+ * actually being tested.
+ */
+export class ProjectsACLTestUtils {
+  static async deleteUserFromProject(
+    app: INestApplication,
+    jwtToken: string,
+    projectId: string,
+    userId: string,
+  ): Promise<void> {
+    await request(app.getHttpServer())
+      .delete(`/api/v1/roles/projects/${projectId}/users/${userId}`)
+      .set('Authorization', `Bearer ${jwtToken}`);
+  }
+}


### PR DESCRIPTION
## E2E test impromevents for project-acl

### Overview

- Split tests into get / patch / delete tests.
- Usage of already created projects to check GET actions without unnecessary steps
- Changes how cleanup is processed for e2e tests


Part of [MARXAN-1076](https://vizzuality.atlassian.net/browse/MARXAN-1076)