### PR TITLE
fix/marxan-905

### DIFF
--- a/app/hooks/auth/index.ts
+++ b/app/hooks/auth/index.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+
+import { useSession } from 'next-auth/client';
+
+export function useAccessToken() {
+  const [session] = useSession();
+  return useMemo(() => {
+    return session.accessToken;
+  }, [session.accessToken]);
+}

--- a/app/layout/community/published-projects/detail/map/component.tsx
+++ b/app/layout/community/published-projects/detail/map/component.tsx
@@ -11,8 +11,8 @@ import { setLayerSettings } from 'store/slices/projects/[id]';
 import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useSession } from 'next-auth/client';
 
+import { useAccessToken } from 'hooks/auth';
 import { useLegend, usePUGridLayer } from 'hooks/map';
 import { useProject } from 'hooks/projects';
 import { useScenarios } from 'hooks/scenarios';
@@ -38,7 +38,7 @@ export const PublishedProjectMap: React.FC<PublishedProjectMapProps> = () => {
   const [open, setOpen] = useState(false);
   const [mapInteractive, setMapInteractive] = useState(false);
 
-  const [session] = useSession();
+  const accessToken = useAccessToken();
 
   const minZoom = 2;
   const maxZoom = 20;
@@ -131,7 +131,7 @@ export const PublishedProjectMap: React.FC<PublishedProjectMapProps> = () => {
       return {
         url,
         headers: {
-          Authorization: `Bearer ${session.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       };
     }

--- a/app/layout/projects/new/map/component.tsx
+++ b/app/layout/projects/new/map/component.tsx
@@ -4,9 +4,9 @@ import { useSelector } from 'react-redux';
 
 import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
-// Map
-import { useSession } from 'next-auth/client';
 
+// Map
+import { useAccessToken } from 'hooks/auth';
 import { useAdminPreviewLayer, usePUGridPreviewLayer, useGeoJsonLayer } from 'hooks/map';
 
 import Loading from 'components/loading';
@@ -34,7 +34,7 @@ export const ProjectNewMap: React.FC<ProjectMapProps> = ({
   const [bounds, setBounds] = useState(null);
   const [mapInteractive, setMapInteractive] = useState(false);
 
-  const [session] = useSession();
+  const accessToken = useAccessToken();
 
   const LAYERS = [
     useGeoJsonLayer({
@@ -99,7 +99,7 @@ export const ProjectNewMap: React.FC<ProjectMapProps> = ({
       return {
         url,
         headers: {
-          Authorization: `Bearer ${session.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       };
     }

--- a/app/layout/projects/show/map/component.tsx
+++ b/app/layout/projects/show/map/component.tsx
@@ -12,8 +12,8 @@ import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useSession } from 'next-auth/client';
 
+import { useAccessToken } from 'hooks/auth';
 import {
   /* useAdminPreviewLayer, */
   useLegend,
@@ -46,7 +46,8 @@ export const ProjectMap: React.FC<ProjectMapProps> = () => {
   const [open, setOpen] = useState(false);
   const [sid1, setSid1] = useState(null);
   const [sid2, setSid2] = useState(null);
-  const [session] = useSession();
+
+  const accessToken = useAccessToken();
 
   const minZoom = 2;
   const maxZoom = 20;
@@ -208,7 +209,7 @@ export const ProjectMap: React.FC<ProjectMapProps> = () => {
       return {
         url,
         headers: {
-          Authorization: `Bearer ${session.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       };
     }

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -10,8 +10,8 @@ import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
-import { useSession } from 'next-auth/client';
 
+import { useAccessToken } from 'hooks/auth';
 import { useSelectedFeatures } from 'hooks/features';
 import { useAllGapAnalysis } from 'hooks/gap-analysis';
 import {
@@ -47,7 +47,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
   const [open, setOpen] = useState(true);
   const [mapInteractive, setMapInteractive] = useState(false);
 
-  const [session] = useSession();
+  const accessToken = useAccessToken();
 
   const { query } = useRouter();
   const { pid, sid } = query;
@@ -341,7 +341,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
       return {
         url,
         headers: {
-          Authorization: `Bearer ${session.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       };
     }

--- a/app/layout/scenarios/show/map/component.tsx
+++ b/app/layout/scenarios/show/map/component.tsx
@@ -12,8 +12,8 @@ import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import PluginMapboxGl from '@vizzuality/layer-manager-plugin-mapboxgl';
 import { LayerManager, Layer } from '@vizzuality/layer-manager-react';
-import { useSession } from 'next-auth/client';
 
+import { useAccessToken } from 'hooks/auth';
 import { useSelectedFeatures } from 'hooks/features';
 import { useAllGapAnalysis } from 'hooks/gap-analysis';
 import {
@@ -41,7 +41,8 @@ export interface ScenariosShowMapProps {
 
 export const ScenariosMap: React.FC<ScenariosShowMapProps> = () => {
   const [open, setOpen] = useState(true);
-  const [session] = useSession();
+
+  const accessToken = useAccessToken();
 
   const dispatch = useDispatch();
 
@@ -255,7 +256,7 @@ export const ScenariosMap: React.FC<ScenariosShowMapProps> = () => {
       return {
         url,
         headers: {
-          Authorization: `Bearer ${session.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       };
     }


### PR DESCRIPTION
### Overview

When token expires and call to refresh token occurs, the map `handleTransformRequest` is not aware this change occurred, as it is called in a different scope. Created a small utility hook for getting the access token, and automatically refresh it when its value changes.

### Testing instructions


set client AuthenticationProvider to something like this, to refetch tokens more frequently.

```
 <AuthenticationProvider
      session={pageProps.session}
      options={{
        clientMaxAge: 10
        keepAlive: 15
      }}
>
```

In the next auth router, always return true on refresh token inside `api/auth/nextauth`

````
// Refresh token
if (true) return refreshAccessToken(token);
```

Play around with the map, check sent headers and make sure authorization header updates accordingly.
