### PR TITLE
Sign-up confirmation base URL configurable through env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,23 @@ details.
      will not work correctly); please check [SparkPost's
      documentation](https://developers.sparkpost.com/api/#header-sparkpost-eu)
      and the client library's own documentation for details
-   * `PASSWORD_RESET_TOKEN_PREFIX` (string, required): the public URL of the
-     **frontend** page on the running instance where users are redirected from
+   * `APPLICATION_BASE_URL` (string, required): the public URL of the
+     **frontend** application on the running instance (without trailing slash). 
+     This URL will be used to compose links sent via email for some flows of the 
+     platform, such as password recovery or sign-up confirmation (see also 
+     `PASSWORD_RESET_TOKEN_PREFIX` and `SIGNUP_CONFIRMATION_TOKEN_PREFIX`)
+   * `PASSWORD_RESET_TOKEN_PREFIX` (string, required): the path that should be 
+     appended after the application base URL (`APPLICATION_BASE_URL`), 
+     corresponding to the **frontend** route where users are redirected from
      password reset emails to complete the process of resetting their
      password; the reset token is appended at the end of this URL to compose
      the actual link that is included in password reset emails
    * `PASSWORD_RESET_EXPIRATION` (string, optional, default is 1800000
      milliseconds: 30 minutes): a time (in milliseconds) that a token for a
      password reset is valid for
-   * `SIGNUP_CONFIRMATION_TOKEN_PREFIX` (string, required): the public URL of the
-     **frontend** page on the running instance where users are redirected from
+   * `SIGNUP_CONFIRMATION_TOKEN_PREFIX` (string, required): the path that should be
+     appended after the application base URL (`APPLICATION_BASE_URL`),
+     corresponding to the **frontend** route where users are redirected from
      sign-up confirmation emails to complete the process validating their account; 
      the validation token is appended at the end of this URL to compose the actual 
      link that is included in sign-up confirmation emails

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ details.
    * `PASSWORD_RESET_EXPIRATION` (string, optional, default is 1800000
      milliseconds: 30 minutes): a time (in milliseconds) that a token for a
      password reset is valid for
+   * `SIGNUP_CONFIRMATION_TOKEN_PREFIX` (string, required): the public URL of the
+     **frontend** page on the running instance where users are redirected from
+     sign-up confirmation emails to complete the process validating their account; 
+     the validation token is appended at the end of this URL to compose the actual 
+     link that is included in sign-up confirmation emails
 
 The PostgreSQL credentials are used to create a database user when the
 PostgreSQL container is started for the first time. PostgreSQL data is persisted

--- a/api/apps/api/config/custom-environment-variables.json
+++ b/api/apps/api/config/custom-environment-variables.json
@@ -65,5 +65,8 @@
   "passwordReset": {
     "tokenPrefix": "PASSWORD_RESET_TOKEN_PREFIX",
     "expiration": "PASSWORD_RESET_EXPIRATION"
+  },
+  "signUpConfirmation": {
+    "tokenPrefix": "SIGNUP_CONFIRMATION_TOKEN_PREFIX"
   }
 }

--- a/api/apps/api/config/custom-environment-variables.json
+++ b/api/apps/api/config/custom-environment-variables.json
@@ -62,6 +62,9 @@
     "apikey": "SPARKPOST_APIKEY",
     "origin": "SPARKPOST_ORIGIN"
   },
+  "application": {
+    "baseUrl": "APPLICATION_BASE_URL"
+  },
   "passwordReset": {
     "tokenPrefix": "PASSWORD_RESET_TOKEN_PREFIX",
     "expiration": "PASSWORD_RESET_EXPIRATION"

--- a/api/apps/api/config/default.json
+++ b/api/apps/api/config/default.json
@@ -58,12 +58,15 @@
     "apikey": "invalidSparkpostApikey",
     "origin": "https://api.eu.sparkpost.com:443"
   },
+  "application": {
+    "baseUrl": "http://localhost:3000"
+  },
   "passwordReset": {
-    "tokenPrefix": "http://localhost:3000/auth/reset-password?token=",
+    "tokenPrefix": "/auth/reset-password?token=",
     "expiration": 1800000
   },
   "signUpConfirmation": {
-    "tokenPrefix": "http://localhost:3000/auth/sign-up-confirmation?token="
+    "tokenPrefix": "/auth/sign-up-confirmation?token="
   }
 }
 

--- a/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
+++ b/api/apps/api/src/modules/authentication/password-recovery/mailer.ts
@@ -92,7 +92,9 @@ export class SparkPostMailer implements Mailer {
   async sendRecoveryEmail(userId: string, token: string): Promise<void> {
     const user = await this.usersService.getById(userId);
     return this.sendEmail(SparkpostTemplate.PasswordRecovery, user.email, {
-      urlRecover: this.passwordResetPrefix + token,
+      urlRecover: `${AppConfig.get('application.baseUrl')}${
+        this.passwordResetPrefix
+      }${token}`,
     });
   }
 
@@ -103,6 +105,8 @@ export class SparkPostMailer implements Mailer {
     const user = await this.usersService.getById(userId);
     return this.sendEmail(SparkpostTemplate.SignUpConfirmation, user.email, {
       urlSignUpConfirmation: `${AppConfig.get(
+        'application.baseUrl',
+      )}${AppConfig.get(
         'signUpConfirmation.tokenPrefix',
       )}${token}&userId=${userId}`,
     });

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -20,6 +20,7 @@ import { tearDown } from './utils/tear-down';
 import { API_EVENT_KINDS } from '@marxan/api-events';
 import * as nock from 'nock';
 import { CreateTransmission, Recipient } from 'sparkpost';
+import { AppConfig } from '@marxan-api/utils/config.utils';
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
@@ -67,7 +68,12 @@ describe('UsersModule (e2e)', () => {
           .map((el) => el.substitution_data)
           .every(
             (el) =>
-              el.urlSignUpConfirmation.match(/\?token=\w+/) &&
+              el.urlSignUpConfirmation.includes(
+                AppConfig.get('application.baseUrl'),
+              ) &&
+              el.urlSignUpConfirmation.includes(
+                AppConfig.get('signUpConfirmation.tokenPrefix'),
+              ) &&
               el.urlSignUpConfirmation.match(/&userId=\w+/),
           );
       })

--- a/env.default
+++ b/env.default
@@ -30,3 +30,4 @@ SPARKPOST_APIKEY=
 SPARKPOST_ORIGIN=https://api.eu.sparkpost.com:443
 PASSWORD_RESET_TOKEN_PREFIX=http://localhost:3000/auth/reset-password?token=
 PASSWORD_RESET_EXPIRATION=1800000
+SIGNUP_CONFIRMATION_TOKEN_PREFIX=http://localhost:3000/auth/sign-up-confirmation?token=

--- a/env.default
+++ b/env.default
@@ -28,6 +28,7 @@ API_AUTH_X_API_KEY=
 API_SERVICE_URL=http://api:3030
 SPARKPOST_APIKEY=
 SPARKPOST_ORIGIN=https://api.eu.sparkpost.com:443
-PASSWORD_RESET_TOKEN_PREFIX=http://localhost:3000/auth/reset-password?token=
+APPLICATION_BASE_URL=http://localhost:3000
+PASSWORD_RESET_TOKEN_PREFIX=/auth/reset-password?token=
 PASSWORD_RESET_EXPIRATION=1800000
-SIGNUP_CONFIRMATION_TOKEN_PREFIX=http://localhost:3000/auth/sign-up-confirmation?token=
+SIGNUP_CONFIRMATION_TOKEN_PREFIX=/auth/sign-up-confirmation?token=


### PR DESCRIPTION
## Make signup confirmation base URL configurable through env var

### Overview

This PR enables the sign up confirmation URL to be configurable through an environment variable (`SIGNUP_CONFIRMATION_TOKEN_PREFIX`). This variable should take the appropriate value according to the environment where the code is deployed.

### Feature relevant tickets

[MARXAN-947](https://vizzuality.atlassian.net/browse/MARXAN-947)