### PR TITLE
Not returning project users on project endpoints

### DIFF
--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -85,7 +85,6 @@ export class ProjectsCrudService extends AppBaseService<
         'adminAreaLevel2Id',
         'planningUnitGridShape',
         'planningUnitAreakm2',
-        'users',
         'scenarios',
         'createdAt',
         'lastModifiedAt',
@@ -95,14 +94,6 @@ export class ProjectsCrudService extends AppBaseService<
         'customProtectedAreas',
       ],
       keyForAttribute: 'camelCase',
-      users: {
-        ref: 'id',
-        attributes: ['fname', 'lname', 'email', 'projectRoles'],
-        projectRoles: {
-          ref: 'name',
-          attributes: ['name'],
-        },
-      },
       scenarios: {
         ref: 'id',
         attributes: [


### PR DESCRIPTION
## Not returning project users on project endpoints

### Overview

This PR removes the `users` field returned in project endpoints, which previously contained the users assigned to a project. Users assigned to a project should now be fetched from the `GET /api/v1/roles/projects/{id}/users` endpoint, which applies the proper ACL checks to see if the request user is authorized to see the project users.

### Feature relevant tickets

[MARXAN-1075](https://vizzuality.atlassian.net/browse/MARXAN-1075)