### PR TITLE
Initial setup for 1007 and projects-acl

### DIFF
--- a/api/apps/api/src/modules/access-control/access-control.types.ts
+++ b/api/apps/api/src/modules/access-control/access-control.types.ts
@@ -1,3 +1,5 @@
 export type Allowed = true;
 export type Denied = false;
 export type Permit = Allowed | Denied;
+
+export const forbiddenError = Symbol(`unauthorized access`);

--- a/api/apps/api/src/modules/access-control/index.ts
+++ b/api/apps/api/src/modules/access-control/index.ts
@@ -1,2 +1,3 @@
 export { AccessControlModule } from './access-control.module';
 export { ProjectAccessControl } from './projects-acl/project-access-control';
+export { forbiddenError } from './access-control.types';

--- a/api/apps/api/src/modules/access-control/projects-acl/project-access-control.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-access-control.ts
@@ -1,6 +1,6 @@
 import { Permit } from '../access-control.types';
 export abstract class ProjectAccessControl {
-  abstract canCreateProject(userId: string, projectId: string): Promise<Permit>;
+  abstract canCreateProject(userId: string): Promise<Permit>;
   abstract canEditProject(userId: string, projectId: string): Promise<Permit>;
   abstract canViewProject(userId: string, projectId: string): Promise<Permit>;
   abstract canPublishProject(

--- a/api/apps/api/src/modules/access-control/projects-acl/project-access-control.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-access-control.ts
@@ -1,11 +1,13 @@
 import { Permit } from '../access-control.types';
 export abstract class ProjectAccessControl {
   abstract canCreateProject(userId: string, projectId: string): Promise<Permit>;
+  abstract canEditProject(userId: string, projectId: string): Promise<Permit>;
   abstract canViewProject(userId: string, projectId: string): Promise<Permit>;
   abstract canPublishProject(
     userId: string,
     projectId: string,
   ): Promise<Permit>;
+  abstract canDeleteProject(userId: string, projectId: string): Promise<Permit>;
   abstract canCreateScenario(
     userId: string,
     projectId: string,

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.spec.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.spec.ts
@@ -141,10 +141,10 @@ const getFixtures = async () => {
         }),
       ),
     ThenCannotCreateProject: async () => {
-      expect(await sut.canCreateProject(userId, projectId)).toEqual(false);
+      expect(await sut.canCreateProject(userId)).toEqual(false);
     },
     ThenCanCreateProject: async () => {
-      expect(await sut.canCreateProject(userId, projectId)).toEqual(true);
+      expect(await sut.canCreateProject(userId)).toEqual(true);
       expect(userProjectsRepoMock.find).toHaveBeenCalledWith({
         where: {
           projectId,

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
@@ -26,6 +26,11 @@ export class ProjectAclService implements ProjectAccessControl {
     Roles.project_contributor,
     Roles.project_viewer,
   ];
+  private readonly canEditProjectRoles = [
+    Roles.project_contributor,
+    Roles.project_owner,
+  ];
+  private readonly canDeleteProjectRoles = [Roles.project_owner];
 
   private async getRolesWithinProjectForUser(
     userId: string,
@@ -58,8 +63,22 @@ export class ProjectAclService implements ProjectAccessControl {
   // TODO: this will be changed in the following release of user requirements.
   // For now, anyone should be able to create projects, regardless of having roles or not.
   // In the future project creation will be limited to organization contributors, so this logic will be moved to the access control module
-  async canCreateProject(_userId: string, _projectId: string): Promise<Permit> {
+  async canCreateProject(_userId: string): Promise<Permit> {
     return true;
+  }
+
+  async canEditProject(userId: string, projectId: string): Promise<Permit> {
+    return this.doesUserHaveRole(
+      await this.getRolesWithinProjectForUser(userId, projectId),
+      this.canEditProjectRoles,
+    );
+  }
+
+  async canDeleteProject(userId: string, projectId: string): Promise<Permit> {
+    return this.doesUserHaveRole(
+      await this.getRolesWithinProjectForUser(userId, projectId),
+      this.canDeleteProjectRoles,
+    );
   }
 
   async canViewProject(userId: string, projectId: string): Promise<Permit> {

--- a/api/apps/api/src/modules/blm/values/project-blm-repo.ts
+++ b/api/apps/api/src/modules/blm/values/project-blm-repo.ts
@@ -3,10 +3,14 @@ import { Either } from 'fp-ts/Either';
 export const unknownError = Symbol(`unknown error`);
 export const projectNotFound = Symbol(`project not found`);
 export const alreadyCreated = Symbol(`project already has defaults`);
+export const forbidden = Symbol(`access unauthorized`);
 
 export type CreateFailure = typeof unknownError | typeof alreadyCreated;
 export type SaveFailure = typeof unknownError | typeof projectNotFound;
-export type GetFailure = typeof unknownError | typeof projectNotFound;
+export type GetFailure =
+  | typeof unknownError
+  | typeof projectNotFound
+  | typeof forbidden;
 
 export interface ProjectBlm {
   id: string;

--- a/api/apps/api/src/modules/blm/values/project-blm-repo.ts
+++ b/api/apps/api/src/modules/blm/values/project-blm-repo.ts
@@ -3,15 +3,9 @@ import { Either } from 'fp-ts/Either';
 export const unknownError = Symbol(`unknown error`);
 export const projectNotFound = Symbol(`project not found`);
 export const alreadyCreated = Symbol(`project already has defaults`);
-export const forbidden = Symbol(`access unauthorized`);
-
 export type CreateFailure = typeof unknownError | typeof alreadyCreated;
 export type SaveFailure = typeof unknownError | typeof projectNotFound;
-export type GetFailure =
-  | typeof unknownError
-  | typeof projectNotFound
-  | typeof forbidden;
-
+export type GetFailure = typeof unknownError | typeof projectNotFound;
 export interface ProjectBlm {
   id: string;
 

--- a/api/apps/api/src/modules/projects/blm/change-blm-range.command.ts
+++ b/api/apps/api/src/modules/projects/blm/change-blm-range.command.ts
@@ -2,6 +2,7 @@ import { Command } from '@nestjs-architects/typed-cqrs';
 import { Either } from 'fp-ts/Either';
 import { ProjectBlm } from '@marxan-api/modules/blm';
 
+export const forbidden = Symbol(`unauthorized access`);
 export const invalidRange = Symbol(`invalid range`);
 export const unknownError = Symbol(`unknown error`);
 export const updateFailure = Symbol(`update failure`);
@@ -15,6 +16,7 @@ export type ChangeRangeErrors =
   | typeof invalidRange
   | typeof unknownError
   | typeof updateFailure
+  | typeof forbidden
   | PlanningUnitAreaNotFoundError;
 
 export class ChangeBlmRange extends Command<

--- a/api/apps/api/src/modules/projects/blm/change-blm-range.command.ts
+++ b/api/apps/api/src/modules/projects/blm/change-blm-range.command.ts
@@ -2,7 +2,6 @@ import { Command } from '@nestjs-architects/typed-cqrs';
 import { Either } from 'fp-ts/Either';
 import { ProjectBlm } from '@marxan-api/modules/blm';
 
-export const forbidden = Symbol(`unauthorized access`);
 export const invalidRange = Symbol(`invalid range`);
 export const unknownError = Symbol(`unknown error`);
 export const updateFailure = Symbol(`update failure`);
@@ -16,7 +15,6 @@ export type ChangeRangeErrors =
   | typeof invalidRange
   | typeof unknownError
   | typeof updateFailure
-  | typeof forbidden
   | PlanningUnitAreaNotFoundError;
 
 export class ChangeBlmRange extends Command<

--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -304,31 +304,6 @@ export class ProjectsCrudService extends AppBaseService<
     return entity;
   }
 
-  extendGetByIdQuery(
-    query: SelectQueryBuilder<Project>,
-    fetchSpecification?: FetchSpecification,
-    info?: ProjectsRequest,
-  ): SelectQueryBuilder<Project> {
-    const loggedUser = Boolean(info?.authenticatedUser);
-    query.leftJoin(
-      UsersProjectsApiEntity,
-      `acl`,
-      `${this.alias}.id = acl.project_id`,
-    );
-
-    if (loggedUser) {
-      query
-        .andWhere(`acl.user_id = :userId`, {
-          userId: info?.authenticatedUser?.id,
-        })
-        .andWhere(`acl.role_id = :roleId`, {
-          roleId: Roles.project_owner,
-        });
-    }
-
-    return query;
-  }
-
   async extendFindAllQuery(
     query: SelectQueryBuilder<Project>,
     fetchSpecification: FetchSpecification,

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -363,13 +363,19 @@ export class ProjectsController {
   @Get(':id/calibration')
   async getProjectBlmValues(
     @Param('id') id: string,
+    @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProjectBlmValuesResponseDto> {
-    const result = await this.projectsService.findProjectBlm(id);
+    const result = await this.projectsService.findProjectBlm(id, req.user.id);
 
     if (isLeft(result))
-      throw new NotFoundException(
-        `Could not find project BLM values for project with ID: ${id}`,
-      );
+      switch (result.left) {
+        case forbiddenError:
+          throw new ForbiddenException();
+        default:
+          throw new NotFoundException(
+            `Could not find project BLM values for project with ID: ${id}`,
+          );
+      }
     return result.right;
   }
 

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -320,8 +320,17 @@ export class ProjectsController {
   async updateBlmRange(
     @Param('id') id: string,
     @Body() { range }: UpdateProjectBlmRangeDTO,
+    @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProjectBlmValuesResponseDto> {
-    const result = await this.projectsService.updateBlmValues(id, range);
+    const result = await this.projectsService.updateBlmValues(
+      req.user.id,
+      id,
+      range,
+    );
+
+    if (!result) {
+      throw new ForbiddenException();
+    }
 
     if (isLeft(result)) {
       switch (result.left) {

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -74,6 +74,7 @@ import {
   GeometryKind,
 } from '@marxan-api/decorators/file-interceptors.decorator';
 import { forbiddenError } from '../access-control/access-control.types';
+import { projectNotFound } from '../blm';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -369,12 +370,14 @@ export class ProjectsController {
 
     if (isLeft(result))
       switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        default:
+        case projectNotFound:
           throw new NotFoundException(
             `Could not find project BLM values for project with ID: ${id}`,
           );
+        case forbiddenError:
+          throw new ForbiddenException();
+        default:
+          throw new InternalServerErrorException();
       }
     return result.right;
   }

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -181,9 +181,15 @@ export class ProjectsController {
   async update(
     @Param('id') id: string,
     @Body() dto: UpdateProjectDTO,
+    @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProjectResultSingular> {
+    const result = await this.projectsService.update(id, dto, req.user.id);
+
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
     return await this.projectSerializer.serialize(
-      await this.projectsService.update(id, dto),
+      result.right,
       undefined,
       true,
     );

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -329,10 +329,6 @@ export class ProjectsController {
       range,
     );
 
-    if (!result) {
-      throw new ForbiddenException();
-    }
-
     if (isLeft(result)) {
       switch (result.left) {
         case invalidRange:

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Delete,
   Get,
+  ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
   Param,

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -202,7 +202,12 @@ export class ProjectsController {
     @Param('id') id: string,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<void> {
-    return await this.projectsService.remove(id);
+    const result = await this.projectsService.remove(id, req.user.id);
+
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
+    return result.right;
   }
 
   @ApiConsumesShapefile({ withGeoJsonResponse: false })

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -74,7 +74,7 @@ import {
   GeometryKind,
 } from '@marxan-api/decorators/file-interceptors.decorator';
 import { forbiddenError } from '../access-control/access-control.types';
-import { projectNotFound } from '../blm';
+import { projectNotFound, unknownError } from '../blm';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -376,8 +376,11 @@ export class ProjectsController {
           );
         case forbiddenError:
           throw new ForbiddenException();
-        default:
+        case unknownError:
           throw new InternalServerErrorException();
+        default:
+          const _exhaustiveCheck: never = result.left;
+          throw _exhaustiveCheck;
       }
     return result.right;
   }

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -65,6 +65,7 @@ import { FeatureTags } from '@marxan-api/modules/geo-features/geo-feature-set.ap
 import { UpdateProjectBlmRangeDTO } from '@marxan-api/modules/projects/dto/update-project-blm-range.dto';
 import { invalidRange } from '@marxan-api/modules/projects/blm';
 import {
+  forbidden,
   planningUnitAreaNotFound,
   updateFailure,
 } from '@marxan-api/modules/projects/blm/change-blm-range.command';
@@ -344,6 +345,8 @@ export class ProjectsController {
           throw new InternalServerErrorException(
             `Could not update with range ${range} project BLM values for project with ID: ${id}`,
           );
+        case forbidden:
+          throw new ForbiddenException();
         default:
           throw new InternalServerErrorException();
       }

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -149,8 +149,16 @@ export class ProjectsController {
     @Body() dto: CreateProjectDTO,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProjectResultSingular> {
+    const result = await this.projectsService.create(dto, {
+      authenticatedUser: req.user,
+    });
+
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
+
     return await this.projectSerializer.serialize(
-      await this.projectsService.create(dto, { authenticatedUser: req.user }),
+      result.right,
       undefined,
       true,
     );
@@ -174,7 +182,10 @@ export class ProjectsController {
   @ApiOperation({ description: 'Delete project' })
   @ApiOkResponse()
   @Delete(':id')
-  async delete(@Param('id') id: string): Promise<void> {
+  async delete(
+    @Param('id') id: string,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<void> {
     return await this.projectsService.remove(id);
   }
 

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -65,7 +65,6 @@ import { FeatureTags } from '@marxan-api/modules/geo-features/geo-feature-set.ap
 import { UpdateProjectBlmRangeDTO } from '@marxan-api/modules/projects/dto/update-project-blm-range.dto';
 import { invalidRange } from '@marxan-api/modules/projects/blm';
 import {
-  forbidden,
   planningUnitAreaNotFound,
   updateFailure,
 } from '@marxan-api/modules/projects/blm/change-blm-range.command';
@@ -74,6 +73,7 @@ import {
   GeometryFileInterceptor,
   GeometryKind,
 } from '@marxan-api/decorators/file-interceptors.decorator';
+import { forbiddenError } from '../access-control/access-control.types';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -345,7 +345,7 @@ export class ProjectsController {
           throw new InternalServerErrorException(
             `Could not update with range ${range} project BLM values for project with ID: ${id}`,
           );
-        case forbidden:
+        case forbiddenError:
           throw new ForbiddenException();
         default:
           throw new InternalServerErrorException();

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -137,8 +137,18 @@ export class ProjectsController {
   @Post('legacy')
   async importLegacyProject(
     @UploadedFile() file: Express.Multer.File,
+    @Req() req: RequestWithAuthenticatedUser,
   ): Promise<Project> {
-    return this.projectsService.importLegacyProject(file);
+    const result = await this.projectsService.importLegacyProject(
+      file,
+      req.user.id,
+    );
+
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
+
+    return result.right;
   }
 
   @ApiOperation({ description: 'Create project' })

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -30,6 +30,7 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { GetProjectHandler } from './get-project.handler';
 import { ProjectBlmModule } from './blm';
 import { CloneModule } from '@marxan-api/modules/clone';
+import { AccessControlModule } from '../access-control';
 
 @Module({
   imports: [
@@ -56,6 +57,7 @@ import { CloneModule } from '@marxan-api/modules/clone';
     PlanningUnitGridModule,
     ProjectBlmModule,
     CloneModule,
+    AccessControlModule,
   ],
   providers: [
     ProjectsCrudService,

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -142,8 +142,11 @@ export class ProjectsService {
     return await this.jobStatusService.getJobStatusFor(projectId);
   }
 
-  async importLegacyProject(_: Express.Multer.File) {
-    return new Project();
+  async importLegacyProject(_: Express.Multer.File, userId: string) {
+    if (!(await this.projectAclService.canCreateProject(userId))) {
+      return left(false);
+    }
+    return right(new Project());
   }
 
   savePlanningAreaFromShapefile = this.planningAreaService.savePlanningAreaFromShapefile.bind(

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -33,6 +33,7 @@ import {
 } from '@marxan-api/modules/blm';
 import { ProjectAccessControl } from '../access-control';
 import { forbiddenError } from '@marxan-api/modules/access-control';
+import { Permit } from '../access-control/access-control.types';
 
 import { ExportProject } from '@marxan-api/modules/clone';
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
@@ -93,8 +94,15 @@ export class ProjectsService {
     }
   }
 
-  async findProjectBlm(id: string): Promise<Either<GetFailure, ProjectBlm>> {
-    return await this.projectBlmRepository.get(id);
+  async findProjectBlm(
+    projectId: string,
+    userId: string,
+  ): Promise<Either<GetFailure | typeof forbiddenError, ProjectBlm>> {
+    if (!(await this.projectAclService.canViewProject(userId, projectId))) {
+      return left(forbiddenError);
+    }
+
+    return await this.projectBlmRepository.get(projectId);
   }
 
   // TODO debt: shouldn't use API's DTO - avoid relating service to given access layer (Rest)

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -115,8 +115,15 @@ export class ProjectsService {
     return right(project);
   }
 
-  async update(projectId: string, input: UpdateProjectDTO) {
-    return this.projectsCrud.update(projectId, input);
+  async update(
+    projectId: string,
+    input: UpdateProjectDTO,
+    userId: string,
+  ): Promise<Either<Permit, Project>> {
+    if (!(await this.projectAclService.canEditProject(userId, projectId))) {
+      return left(false);
+    }
+    return right(await this.projectsCrud.update(projectId, input));
   }
 
   async updateBlmValues(projectId: string, range: [number, number]) {

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { FetchSpecification } from 'nestjs-base-service';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { Either, isLeft, right } from 'fp-ts/Either';
+import { Either, isLeft, right, left } from 'fp-ts/Either';
 
 import {
   FindResult,
@@ -28,6 +28,8 @@ import {
   ProjectBlm,
   ProjectBlmRepo,
 } from '@marxan-api/modules/blm';
+import { ProjectAccessControl } from '../access-control';
+import { Permit } from '../access-control/access-control.types';
 
 import { ExportProject } from '@marxan-api/modules/clone';
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
@@ -44,6 +46,7 @@ export class ProjectsService {
     private readonly projectBlmRepository: ProjectBlmRepo,
     private readonly queryBus: QueryBus,
     private readonly commandBus: CommandBus,
+    private readonly projectAclService: ProjectAccessControl,
   ) {}
 
   async findAllGeoFeatures(
@@ -104,7 +107,6 @@ export class ProjectsService {
   }
 
   async update(projectId: string, input: UpdateProjectDTO) {
-    // /ACL slot - can?/
     return this.projectsCrud.update(projectId, input);
   }
 

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -22,7 +22,10 @@ import {
   ProjectsServiceRequest,
 } from './project-requests-info';
 import { GetProjectErrors, GetProjectQuery } from '@marxan/projects';
-import { ChangeBlmRange } from '@marxan-api/modules/projects/blm';
+import {
+  ChangeBlmRange,
+  ChangeRangeErrors,
+} from '@marxan-api/modules/projects/blm';
 import {
   GetFailure,
   ProjectBlm,
@@ -30,6 +33,7 @@ import {
 } from '@marxan-api/modules/blm';
 import { ProjectAccessControl } from '../access-control';
 import { Permit } from '../access-control/access-control.types';
+import { forbidden } from './blm/change-blm-range.command';
 
 import { ExportProject } from '@marxan-api/modules/clone';
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
@@ -130,9 +134,9 @@ export class ProjectsService {
     userId: string,
     projectId: string,
     range: [number, number],
-  ) {
+  ): Promise<Either<ChangeRangeErrors, ProjectBlm>> {
     if (!(await this.projectAclService.canEditProject(userId, projectId))) {
-      return false;
+      return left(forbidden);
     }
     return await this.commandBus.execute(new ChangeBlmRange(projectId, range));
   }

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -32,7 +32,7 @@ import {
   ProjectBlmRepo,
 } from '@marxan-api/modules/blm';
 import { ProjectAccessControl } from '../access-control';
-import { Permit, forbiddenError } from '../access-control/access-control.types';
+import { forbiddenError } from '@marxan-api/modules/access-control';
 
 import { ExportProject } from '@marxan-api/modules/clone';
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -139,9 +139,14 @@ export class ProjectsService {
     ).value;
   }
 
-  async remove(projectId: string) {
-    // /ACL slot - can?/
-    return this.projectsCrud.remove(projectId);
+  async remove(
+    projectId: string,
+    userId: string,
+  ): Promise<Either<Permit, void>> {
+    if (!(await this.projectAclService.canDeleteProject(userId, projectId))) {
+      return left(false);
+    }
+    return right(await this.projectsCrud.remove(projectId));
   }
 
   async getJobStatusFor(projectId: string, info: ProjectsRequest) {

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -126,7 +126,14 @@ export class ProjectsService {
     return right(await this.projectsCrud.update(projectId, input));
   }
 
-  async updateBlmValues(projectId: string, range: [number, number]) {
+  async updateBlmValues(
+    userId: string,
+    projectId: string,
+    range: [number, number],
+  ) {
+    if (!(await this.projectAclService.canEditProject(userId, projectId))) {
+      return false;
+    }
     return await this.commandBus.execute(new ChangeBlmRange(projectId, range));
   }
 

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -32,8 +32,7 @@ import {
   ProjectBlmRepo,
 } from '@marxan-api/modules/blm';
 import { ProjectAccessControl } from '../access-control';
-import { Permit } from '../access-control/access-control.types';
-import { forbidden } from './blm/change-blm-range.command';
+import { Permit, forbiddenError } from '../access-control/access-control.types';
 
 import { ExportProject } from '@marxan-api/modules/clone';
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
@@ -134,9 +133,9 @@ export class ProjectsService {
     userId: string,
     projectId: string,
     range: [number, number],
-  ): Promise<Either<ChangeRangeErrors, ProjectBlm>> {
+  ): Promise<Either<ChangeRangeErrors | typeof forbiddenError, ProjectBlm>> {
     if (!(await this.projectAclService.canEditProject(userId, projectId))) {
-      return left(forbidden);
+      return left(forbiddenError);
     }
     return await this.commandBus.execute(new ChangeBlmRange(projectId, range));
   }

--- a/api/apps/api/test/project/delete-project.e2e-spec.ts
+++ b/api/apps/api/test/project/delete-project.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
-import { getFixtures } from './update-project.fixtures';
+import { getFixtures } from './delete-project.fixtures';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -11,18 +11,18 @@ afterEach(async () => {
   await fixtures?.cleanup();
 });
 
-test(`updating a project should work`, async () => {
+test(`deleting a project should work`, async () => {
   await fixtures.GivenProjectWasCreated();
 
-  await fixtures.WhenProjectIsUpdated();
+  await fixtures.WhenProjectIsDeleted();
 
-  await fixtures.ThenWhenReadingProjectItHasNewData();
+  await fixtures.ThenProjectIsNotFound();
 });
 
-test(`updating a project does not work if user is not in project`, async () => {
+test(`deleting a project does not work if user is not in project`, async () => {
   await fixtures.GivenProjectWasCreated();
 
-  const request = await fixtures.WhenProjectIsUpdatedAsNotIncludedUser();
+  const request = await fixtures.WhenProjectIsDeletedAsNotIncludedUser();
 
   await fixtures.ThenForbiddenIsReturned(request);
 });

--- a/api/apps/api/test/project/delete-project.fixtures.ts
+++ b/api/apps/api/test/project/delete-project.fixtures.ts
@@ -35,26 +35,20 @@ export const getFixtures = async () => {
         })
       ).data.id;
     },
-    WhenProjectIsUpdated: async () =>
+    WhenProjectIsDeleted: async () =>
       await request(app.getHttpServer())
-        .patch(`/api/v1/projects/${projectId}`)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          name: 'Test updated',
-        }),
-    WhenProjectIsUpdatedAsNotIncludedUser: async () =>
+        .delete(`/api/v1/projects/${projectId}`)
+        .set('Authorization', `Bearer ${token}`),
+    WhenProjectIsDeletedAsNotIncludedUser: async () =>
       await request(app.getHttpServer())
-        .patch(`/api/v1/projects/${projectId}`)
-        .set('Authorization', `Bearer ${notIncludedUserToken}`)
-        .send({
-          name: 'Test updated',
-        }),
-    ThenWhenReadingProjectItHasNewData: async () => {
-      const projectData = await request(app.getHttpServer())
+        .delete(`/api/v1/projects/${projectId}`)
+        .set('Authorization', `Bearer ${notIncludedUserToken}`),
+    ThenProjectIsNotFound: async () => {
+      const projectResponse = await request(app.getHttpServer())
         .get(`/api/v1/projects/${projectId}`)
         .set('Authorization', `Bearer ${token}`);
 
-      expect(projectData.body.data.attributes.name).toBe('Test updated');
+      expect(projectResponse.status).toEqual(404);
     },
     ThenForbiddenIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(403);

--- a/api/apps/api/test/project/project-get.e2e-spec.ts
+++ b/api/apps/api/test/project/project-get.e2e-spec.ts
@@ -27,3 +27,11 @@ test(`getting non-public project as logged-in owner`, async () => {
   const response = await fixtures.WhenGettingProject(projectId);
   fixtures.ThenProjectDetailsArePresent(projectId, response);
 });
+
+test(`getting a project where the user is not in project`, async () => {
+  const projectId = await fixtures.GivenPrivateProjectWasCreated();
+  const response = await fixtures.WhenGettingProjectAsNotIncludedUser(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+});

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -9,6 +9,7 @@ import { PublishedProject } from '@marxan-api/modules/published-project/entities
 export const getFixtures = async () => {
   const app = await bootstrapApplication();
   const randomUserToken = await GivenUserIsLoggedIn(app);
+  const notIncludedUserToken = await GivenUserIsLoggedIn(app, 'bb');
   const publishedProjectsRepo: Repository<PublishedProject> = app.get(
     getRepositoryToken(PublishedProject),
   );
@@ -115,9 +116,16 @@ export const getFixtures = async () => {
         meta: {},
       });
     },
+    ThenForbiddenIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(403);
+    },
     WhenGettingProject: async (projectId: string) =>
       await request(app.getHttpServer())
         .get(`/api/v1/projects/${projectId}`)
         .set('Authorization', `Bearer ${randomUserToken}`),
+    WhenGettingProjectAsNotIncludedUser: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .get(`/api/v1/projects/${projectId}`)
+        .set('Authorization', `Bearer ${notIncludedUserToken}`),
   };
 };

--- a/api/apps/api/test/project/update-project-calibration.e2e-spec.ts
+++ b/api/apps/api/test/project/update-project-calibration.e2e-spec.ts
@@ -32,3 +32,14 @@ test(`updating a project calibration with incorrect ranges should throw an excep
     .ThenShouldFailWhenStartingAnScenarioCalibrationWithA()
     .RangeWithNegativeNumbers();
 });
+
+test(`updating a project calibration range should not work if user is not in project`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  const userToken = await fixtures.GivenUserIsNotInProject();
+  const request = await fixtures.WhenProjectCalibrationIsUpdatedAsNotIncludedUser(
+    projectId,
+    userToken,
+  );
+
+  await fixtures.ThenForbiddenIsReturned(request);
+});

--- a/api/apps/api/test/project/update-project-calibration.fixtures.ts
+++ b/api/apps/api/test/project/update-project-calibration.fixtures.ts
@@ -38,11 +38,26 @@ export const getFixtures = async () => {
       });
       projectId = project.data.id;
       await commandBus.execute(new SetProjectBlm(projectId));
+      return projectId;
+    },
+    GivenUserIsNotInProject: async () => {
+      const notIncludedUserToken = await GivenUserIsLoggedIn(app, 'bb');
+      return notIncludedUserToken;
     },
     WhenProjectCalibrationIsUpdated: async () =>
       await request(app.getHttpServer())
         .patch(`/api/v1/projects/${projectId}/calibration`)
         .set('Authorization', `Bearer ${token}`)
+        .send({
+          range: updatedRange,
+        }),
+    WhenProjectCalibrationIsUpdatedAsNotIncludedUser: async (
+      projectId: string,
+      userToken: string,
+    ) =>
+      await request(app.getHttpServer())
+        .patch(`/api/v1/projects/${projectId}/calibration`)
+        .set('Authorization', `Bearer ${userToken}`)
         .send({
           range: updatedRange,
         }),
@@ -83,6 +98,9 @@ export const getFixtures = async () => {
             .expect(HttpStatus.BAD_REQUEST);
         },
       };
+    },
+    ThenForbiddenIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(403);
     },
   };
 };


### PR DESCRIPTION
## Initial setup and PR for 1007: Add ACL to projects endpoints.

This PR would only include basic changes made to use the ACL inside the projects-controller.

Future PRs would be apply to this one for each endpoint, so it is easier to follow and review the ACL included.