### PR TITLE
feat(cloning): file repository

### DIFF
--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -34,6 +34,7 @@ import { ScenarioSpecificationModule } from './modules/scenario-specification';
 import { PublishedProjectModule } from '@marxan-api/modules/published-project/published-project.module';
 import { BlmValuesModule } from '@marxan-api/modules/blm';
 import { AccessControlModule } from '@marxan-api/modules/access-control';
+import { FileRepositoryModule } from '@marxan/files-repository';
 
 @Module({
   imports: [
@@ -67,6 +68,7 @@ import { AccessControlModule } from '@marxan-api/modules/access-control';
     PublishedProjectModule,
     BlmValuesModule,
     AccessControlModule,
+    FileRepositoryModule,
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/apps/api/test/files-repository/files-repository.e2e-spec.ts
+++ b/api/apps/api/test/files-repository/files-repository.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { createReadStream } from 'fs';
+import { Readable } from 'stream';
+import { isRight, Right } from 'fp-ts/Either';
+import { Test } from '@nestjs/testing';
+
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import {
+  FileRepository,
+  FileRepositoryModule,
+  TempStorageRepository,
+} from '@marxan/files-repository';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+afterEach(async () => {
+  await fixtures?.cleanup();
+});
+
+/**
+ * Please note that bootstrapApplication overrides default implementation
+ * with `/tmp/storage/` usage
+ */
+test(`adding a file`, async () => {
+  const uri = await fixtures.GivenFileWasAdded();
+  const file = await fixtures.WhenGettingFile(uri);
+  await fixtures.ThenFileIsRetrieved(file);
+});
+
+const getFixtures = async () => {
+  /**
+   * overriding repository implementation happens while bootstrapping test app
+   * to avoid communicating with potential storage provider
+   */
+  const app = await Test.createTestingModule({
+    imports: [FileRepositoryModule],
+  })
+    .overrideProvider(FileRepository)
+    .useClass(TempStorageRepository)
+    .compile();
+  const sut = app.get(FileRepository);
+
+  return {
+    cleanup: async () => app.close(),
+    GivenFileWasAdded: async () => {
+      const result = await sut.save(
+        createReadStream(__dirname + `/some-file.json`),
+        '.json',
+      );
+      expect(isRight(result)).toBeTruthy();
+      return (result as Right<string>).right;
+    },
+    WhenGettingFile: async (file: string): Promise<Readable> => {
+      const result = await sut.get(file);
+      expect(isRight(result)).toBeTruthy();
+      return (result as Right<Readable>).right;
+    },
+    ThenFileIsRetrieved: async (stream: Readable) => {
+      const rawContent = await streamToString(stream);
+      expect(JSON.parse(rawContent).marxan.isCool).toBeTruthy();
+    },
+  };
+};
+
+const streamToString = (stream: Readable): Promise<string> => {
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    stream.on('error', (err) => reject(err));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+  });
+};

--- a/api/apps/api/test/files-repository/some-file.json
+++ b/api/apps/api/test/files-repository/some-file.json
@@ -1,0 +1,5 @@
+{
+  "marxan": {
+    "isCool": true
+  }
+}

--- a/api/apps/api/test/jest-e2e.json
+++ b/api/apps/api/test/jest-e2e.json
@@ -78,6 +78,8 @@
     "@marxan/projects/(.*)": "<rootDir>/../../../libs/projects/src/$1",
     "@marxan/projects": "<rootDir>/../../../libs/projects/src",
     "@marxan/blm-calibration/(.*)": "<rootDir>/../../../libs/blm-calibration/src/$1",
-    "@marxan/blm-calibration": "<rootDir>/../../../libs/blm-calibration/src"
+    "@marxan/blm-calibration": "<rootDir>/../../../libs/blm-calibration/src",
+    "@marxan/files-repository/(.*)": "<rootDir>/../../../libs/files-repository/src/$1",
+    "@marxan/files-repository": "<rootDir>/../../../libs/files-repository/src"
   }
 }

--- a/api/apps/api/test/utils/api-application.ts
+++ b/api/apps/api/test/utils/api-application.ts
@@ -7,6 +7,10 @@ import { FakeQueue, FakeQueueBuilder } from './queues';
 import { QueueBuilder } from '@marxan-api/modules/queue/queue.builder';
 import { ProjectChecker } from '@marxan-api/modules/scenarios/project-checker.service';
 import { right } from 'fp-ts/Either';
+import {
+  FileRepository,
+  TempStorageRepository,
+} from '@marxan/files-repository';
 
 export const fakeProjectChecker: Pick<ProjectChecker, 'isProjectReady'> = {
   isProjectReady: async () => right(true),
@@ -24,6 +28,8 @@ export const bootstrapApplication = async (
     .useClass(FakeQueueBuilder)
     .overrideProvider(ProjectChecker)
     .useValue(fakeProjectChecker)
+    .overrideProvider(FileRepository)
+    .useClass(TempStorageRepository)
     .compile();
 
   return await moduleFixture

--- a/api/apps/geoprocessing/test/jest-e2e.json
+++ b/api/apps/geoprocessing/test/jest-e2e.json
@@ -83,6 +83,8 @@
     "@marxan/projects/(.*)": "<rootDir>/../../libs/projects/src/$1",
     "@marxan/projects": "<rootDir>/../../libs/projects/src",
     "@marxan/blm-calibration/(.*)": "<rootDir>/../../libs/blm-calibration/src/$1",
-    "@marxan/blm-calibration": "<rootDir>/../../libs/blm-calibration/src"
+    "@marxan/blm-calibration": "<rootDir>/../../libs/blm-calibration/src",
+    "@marxan/files-repository/(.*)": "<rootDir>/../../libs/files-repository/src/$1",
+    "@marxan/files-repository": "<rootDir>/../../libs/files-repository/src"
   }
 }

--- a/api/libs/files-repository/src/file-repo.config.ts
+++ b/api/libs/files-repository/src/file-repo.config.ts
@@ -1,0 +1,26 @@
+import { IsString, validateSync } from 'class-validator';
+import { plainToClass } from 'class-transformer';
+
+export class FileRepoConfig {
+  @IsString()
+  API_SHARED_FILE_STORAGE_LOCAL_PATH!: string;
+}
+
+export const validate = (config: Record<string, unknown>) => {
+  const validatedConfig = plainToClass(
+    FileRepoConfig,
+    {
+      API_SHARED_FILE_STORAGE_LOCAL_PATH: '/tmp/storage',
+      ...config,
+    },
+    {
+      enableImplicitConversion: true,
+    },
+  );
+  const errors = validateSync(validatedConfig);
+
+  if (errors.length > 0) {
+    throw new Error(errors.toString());
+  }
+  return validatedConfig;
+};

--- a/api/libs/files-repository/src/file-repository.module.ts
+++ b/api/libs/files-repository/src/file-repository.module.ts
@@ -1,0 +1,27 @@
+import { HttpModule, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { FileRepository } from './file.repository';
+import { validate } from './file-repo.config';
+import { TempStorageRepository } from './temp-storage.repository';
+
+@Module({
+  imports: [
+    HttpModule,
+    ConfigModule.forRoot({
+      validate,
+    }),
+  ],
+  providers: [
+    {
+      provide: FileRepository,
+      /**
+       * Temporary override in lib core - to avoid overrides in each application.
+       * Once actual `FileRepository` is implemented, should be removed.
+       */
+      useClass: TempStorageRepository,
+    },
+  ],
+  exports: [FileRepository],
+})
+export class FileRepositoryModule {}

--- a/api/libs/files-repository/src/file-upload.service.spec.ts
+++ b/api/libs/files-repository/src/file-upload.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FileRepository } from './file.repository';
+
+describe('FileUploadService', () => {
+  let service: FileRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FileRepository],
+    }).compile();
+
+    service = module.get<FileRepository>(FileRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api/libs/files-repository/src/file.repository.ts
+++ b/api/libs/files-repository/src/file.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { Readable } from 'stream';
+import { Either, left } from 'fp-ts/Either';
+
+export const unknownError = Symbol(`unknown error`);
+export const storageNotReachable = Symbol(`storage not reachable`);
+export const notFound = Symbol(`not found`);
+export const hackerFound = Symbol(`please hands off`);
+
+export type SaveFileError =
+  | typeof unknownError
+  | typeof storageNotReachable
+  | typeof hackerFound;
+
+export type GetFileError =
+  | typeof storageNotReachable
+  | typeof notFound
+  | typeof hackerFound;
+
+@Injectable()
+export class FileRepository {
+  async save(
+    stream: Readable,
+    extension?: string,
+  ): Promise<Either<SaveFileError, string>> {
+    return left(storageNotReachable);
+  }
+
+  async get(uri: string): Promise<Either<GetFileError, Readable>> {
+    return left(storageNotReachable);
+  }
+}

--- a/api/libs/files-repository/src/index.ts
+++ b/api/libs/files-repository/src/index.ts
@@ -1,0 +1,9 @@
+export { FileRepositoryModule } from './file-repository.module';
+export {
+  FileRepository,
+  SaveFileError,
+  unknownError,
+  storageNotReachable,
+} from './file.repository';
+
+export { TempStorageRepository } from './temp-storage.repository';

--- a/api/libs/files-repository/src/temp-storage.repository.ts
+++ b/api/libs/files-repository/src/temp-storage.repository.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { Readable } from 'stream';
+import { Either, left, right } from 'fp-ts/Either';
+import { createReadStream, createWriteStream } from 'fs';
+import { ConfigService } from '@nestjs/config';
+
+import {
+  FileRepository,
+  GetFileError,
+  hackerFound,
+  SaveFileError,
+  unknownError,
+} from './file.repository';
+import { FileRepoConfig } from './file-repo.config';
+import { v4 } from 'uuid';
+
+@Injectable()
+export class TempStorageRepository implements FileRepository {
+  readonly #storage: string;
+
+  constructor(readonly config: ConfigService<FileRepoConfig, true>) {
+    this.#storage = config.get('API_SHARED_FILE_STORAGE_LOCAL_PATH');
+  }
+
+  async get(uri: string): Promise<Either<GetFileError, Readable>> {
+    if (!uri.startsWith(this.#storage)) {
+      return left(hackerFound);
+    }
+
+    // as it is mainly temporary/dev module, we can live with not ideal
+    // error handling
+    return right(createReadStream(uri));
+  }
+
+  async save(
+    stream: Readable,
+    extension?: string,
+  ): Promise<Either<SaveFileError, string>> {
+    const name = v4() + `${extension ? `.${extension}` : ''}`;
+    const path = this.#storage + `/` + name;
+    const writer = createWriteStream(path);
+
+    return new Promise((resolve) => {
+      writer.on('close', () => {
+        resolve(right(path));
+      });
+      writer.on('error', (error) => {
+        console.error(error);
+        resolve(left(unknownError));
+      });
+
+      // as it is mainly temporary/dev module, we can live with not ideal
+      // error handling;
+      stream.pipe(writer);
+    });
+  }
+}

--- a/api/libs/files-repository/tsconfig.lib.json
+++ b/api/libs/files-repository/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/files-repository"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/api/nest-cli.json
+++ b/api/nest-cli.json
@@ -223,6 +223,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/blm-calibration/tsconfig.lib.json"
       }
+    },
+    "files-repository": {
+      "type": "library",
+      "root": "libs/files-repository",
+      "entryFile": "index",
+      "sourceRoot": "libs/files-repository/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/files-repository/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -43,6 +43,7 @@
     "@greenelab/hclust": "0.0.1",
     "@nestjs-architects/typed-cqrs": "0.1.1",
     "@nestjs/common": "7.6.18",
+    "@nestjs/config": "1.1.5",
     "@nestjs/core": "7.6.18",
     "@nestjs/cqrs": "7.0.1",
     "@nestjs/jwt": "^7.2.0",
@@ -216,7 +217,9 @@
       "@marxan/projects/(.*)": "<rootDir>/libs/projects/src/$1",
       "@marxan/projects": "<rootDir>/libs/projects/src",
       "@marxan/blm-calibration/(.*)": "<rootDir>/libs/blm-calibration/src/$1",
-      "@marxan/blm-calibration": "<rootDir>/libs/blm-calibration/src"
+      "@marxan/blm-calibration": "<rootDir>/libs/blm-calibration/src",
+      "@marxan/files-repository/(.*)": "<rootDir>/libs/files-repository/src/$1",
+      "@marxan/files-repository": "<rootDir>/libs/files-repository/src"
     }
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -150,6 +150,12 @@
       ],
       "@marxan/blm-calibration/*": [
         "libs/blm-calibration/src/*"
+      ],
+      "@marxan/files-repository": [
+        "libs/files-repository/src"
+      ],
+      "@marxan/files-repository/*": [
+        "libs/files-repositoryd/src/*"
       ]
     }
   },

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -624,6 +624,18 @@
     tslib "2.0.3"
     uuid "8.3.2"
 
+"@nestjs/config@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@nestjs/config/-/config-1.1.5.tgz#6242274706e5b0d4849eb3217b47fdabd63182dc"
+  integrity sha512-xSpp/6TIHFhicuuwRu2fFGmClzN+YXtpVSLGX3LT9iAwtNDcccX3qVDOX1BLdFdBbqZTqT3KezsT+iE/czd/xg==
+  dependencies:
+    dotenv "10.0.0"
+    dotenv-expand "5.1.0"
+    lodash.get "4.4.2"
+    lodash.has "4.5.2"
+    lodash.set "4.3.2"
+    uuid "8.3.2"
+
 "@nestjs/core@7.6.18":
   version "7.6.18"
   resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-7.6.18.tgz#36448f0ae7f7d08f032e1e7e53b4a4c82ae844d7"
@@ -4352,6 +4364,16 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-expand@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
+dotenv@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
@@ -6908,6 +6930,16 @@ lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.get@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.has@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -6958,7 +6990,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.set@^4.3.2:
+lodash.set@4.3.2, lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=


### PR DESCRIPTION
# Scope

Introduces FileRepository to be used within `cloning` feature (and possibly others).
Provides "local" development implementation - but may as well become "target" one.

# Key changes
Environment variable isn't read from existing `AppConfig` for reasons:
* duplicating json configs
* FileRepository is a library
* avoids "global" config with everything inside - focuses on per-module needs
* leverages from built-in NestJS tooling

# Key notes / future advisory
* consider remove/unlink to be "standalone" - to avoid allowing removal of non-owned files (?) - to be discussed, who should be responsible and when this should happen (for example: add `remove` indeed to this module but each feature, like cloning, would have a wrapped storing all related files, may be even for given resource...)
* when deleting, be aware of path traversal issues (providing `../../../etc/passwd` like) and poison null byte (`\0`)
* `local/temporary` solution isn't error-safe. Consider updating it if it happens to become `current` solution