### PR TITLE
CanCreateProject check in project endpoint

### DIFF
--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -149,8 +149,16 @@ export class ProjectsController {
     @Body() dto: CreateProjectDTO,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProjectResultSingular> {
+    const result = await this.projectsService.create(dto, {
+      authenticatedUser: req.user,
+    });
+
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
+
     return await this.projectSerializer.serialize(
-      await this.projectsService.create(dto, { authenticatedUser: req.user }),
+      result.right,
       undefined,
       true,
     );
@@ -174,7 +182,10 @@ export class ProjectsController {
   @ApiOperation({ description: 'Delete project' })
   @ApiOkResponse()
   @Delete(':id')
-  async delete(@Param('id') id: string): Promise<void> {
+  async delete(
+    @Param('id') id: string,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<void> {
     return await this.projectsService.remove(id);
   }
 

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { FetchSpecification } from 'nestjs-base-service';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { Either, isLeft, right, left } from 'fp-ts/Either';
+import { Either, isLeft, left, right } from 'fp-ts/Either';
 
 import {
   FindResult,
@@ -54,7 +54,6 @@ export class ProjectsService {
       appInfo.params?.projectId,
       appInfo.authenticatedUser,
     );
-
     if (isLeft(project)) {
       return project;
     }
@@ -93,14 +92,24 @@ export class ProjectsService {
   }
 
   // TODO debt: shouldn't use API's DTO - avoid relating service to given access layer (Rest)
-  async create(input: CreateProjectDTO, info: ProjectsRequest) {
+  async create(
+    input: CreateProjectDTO,
+    info: ProjectsRequest,
+  ): Promise<Either<Permit, Project>> {
     assertDefined(info.authenticatedUser);
+    if (
+      !(await this.projectAclService.canCreateProject(
+        info.authenticatedUser.id,
+      ))
+    ) {
+      return left(false);
+    }
     const project = await this.projectsCrud.create(input, info);
     await this.projectsCrud.assignCreatorRole(
       project.id,
       info.authenticatedUser.id,
     );
-    return project;
+    return right(project);
   }
 
   async update(projectId: string, input: UpdateProjectDTO) {


### PR DESCRIPTION
## As above title says, pretty straightforward.

- Use of check inside the project-service correspondent method.
- Use of monad to handle errors.