### PR TITLE
Add is_custom calculated column to features

### DIFF
--- a/api/apps/api/src/migrations/api/1638358277397-AddFeatureIsCustom.ts
+++ b/api/apps/api/src/migrations/api/1638358277397-AddFeatureIsCustom.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFeatureIsCustom1638358277397 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      alter table features add column is_custom boolean generated always as ( case when project_id is null then false else true end) stored;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `alter table features drop column is_custom;`,
+    );
+  }
+}

--- a/api/apps/api/src/modules/geo-features/geo-feature.api.entity.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature.api.entity.ts
@@ -94,6 +94,10 @@ export class GeoFeature extends BaseEntity {
     referencedColumnName: 'id',
   })
   createdBy?: User;
+
+  @ApiPropertyOptional()
+  @Column('boolean', { name: 'is_custom' })
+  isCustom?: boolean;
 }
 
 export class JSONAPIGeoFeaturesData {

--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -91,6 +91,7 @@ export class GeoFeaturesService extends AppBaseService<
         'intersection',
         'tag',
         'properties',
+        'isCustom',
       ],
       keyForAttribute: 'camelCase',
     };

--- a/api/apps/api/test/geo-features.e2e-spec.ts
+++ b/api/apps/api/test/geo-features.e2e-spec.ts
@@ -4,6 +4,7 @@ import { PromiseType } from 'utility-types';
 import {
   GeoFeature,
   geoFeatureResource,
+  JSONAPIGeoFeaturesData,
 } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
 import { tearDown } from './utils/tear-down';
 import { bootstrapApplication } from './utils/api-application';
@@ -78,6 +79,9 @@ describe('GeoFeaturesModule (e2e)', () => {
         expect(response.body.data[0].attributes.featureClassName).toEqual(
           geoFeaturesFilters.cheeta.featureClassName,
         );
+        expect(response.body.data[0].attributes.isCustom).toEqual(
+          !!response.body.data[0].attributes.projectId,
+        );
       });
 
       test.skip('should return a single result of geo-features whose alias property matches a given filter', async () => {
@@ -92,6 +96,9 @@ describe('GeoFeaturesModule (e2e)', () => {
         expect(response.body.data[0].attributes.alias).toEqual(
           geoFeaturesFilters.cheeta.alias,
         );
+        expect(response.body.data[0].attributes.isCustom).toEqual(
+          !!response.body.data[0].attributes.projectId,
+        );
       });
       test('should return a list of geo-features whose featureClassName property match a given substring', async () => {
         const response = await request(app.getHttpServer())
@@ -102,6 +109,11 @@ describe('GeoFeaturesModule (e2e)', () => {
           .expect(HttpStatus.OK);
 
         expect(response.body.data).toHaveLength(5);
+        response.body.data.map((feature: JSONAPIGeoFeaturesData) => {
+          expect(feature.attributes.isCustom).toEqual(
+            !!feature.attributes.projectId,
+          );
+        });
       });
       test('should return all available features if query param has no value', async () => {
         const response = await request(app.getHttpServer())

--- a/api/apps/api/test/geo-features.e2e-spec.ts
+++ b/api/apps/api/test/geo-features.e2e-spec.ts
@@ -79,9 +79,7 @@ describe('GeoFeaturesModule (e2e)', () => {
         expect(response.body.data[0].attributes.featureClassName).toEqual(
           geoFeaturesFilters.cheeta.featureClassName,
         );
-        expect(response.body.data[0].attributes.isCustom).toEqual(
-          !!response.body.data[0].attributes.projectId,
-        );
+        expect(response.body.data[0].attributes.isCustom).toEqual(false);
       });
 
       test.skip('should return a single result of geo-features whose alias property matches a given filter', async () => {
@@ -96,9 +94,7 @@ describe('GeoFeaturesModule (e2e)', () => {
         expect(response.body.data[0].attributes.alias).toEqual(
           geoFeaturesFilters.cheeta.alias,
         );
-        expect(response.body.data[0].attributes.isCustom).toEqual(
-          !!response.body.data[0].attributes.projectId,
-        );
+        expect(response.body.data[0].attributes.isCustom).toEqual(false);
       });
       test('should return a list of geo-features whose featureClassName property match a given substring', async () => {
         const response = await request(app.getHttpServer())
@@ -110,9 +106,7 @@ describe('GeoFeaturesModule (e2e)', () => {
 
         expect(response.body.data).toHaveLength(5);
         response.body.data.map((feature: JSONAPIGeoFeaturesData) => {
-          expect(feature.attributes.isCustom).toEqual(
-            !!feature.attributes.projectId,
-          );
+          expect(feature.attributes.isCustom).toEqual(false);
         });
       });
       test('should return all available features if query param has no value', async () => {
@@ -122,6 +116,9 @@ describe('GeoFeaturesModule (e2e)', () => {
           .expect(HttpStatus.OK);
 
         expect(response.body.data).toHaveLength(9);
+        response.body.data.map((feature: JSONAPIGeoFeaturesData) => {
+          expect(feature.attributes.isCustom).toEqual(false);
+        });
       });
     });
   });

--- a/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
@@ -82,6 +82,7 @@ export const getFixtures = async () => {
           tag: customFeatureTag,
           creationStatus: `done`,
           projectId,
+          isCustom: true,
         },
       ]);
       expect(


### PR DESCRIPTION
## Add is_custom calculated column to features

### Overview

This PR adds a new column `is_custom` to the `features` table in the API DB. This column is calculated according to whether the row has set a `project_id` or not. This column is returned as the attribute `isCustom` when requesting features, and it will allow the FE to easily sort the returned features by whether they were user imported or not.

### Feature relevant tickets

[MARXAN-967](https://vizzuality.atlassian.net/browse/MARXAN-967)