### PR TITLE
Improvements to get project users endpoint

### DIFF
--- a/api/apps/api/src/modules/access-control/projects-acl/dto/user-role-project.dto.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/dto/user-role-project.dto.ts
@@ -18,3 +18,11 @@ export class UserRoleInProjectDto {
     | Roles.project_contributor
     | Roles.project_owner;
 }
+
+export class UsersInProjectResult {
+  @ApiProperty({
+    isArray: true,
+    type: UserRoleInProjectDto,
+  })
+  data!: UserRoleInProjectDto[];
+}

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.controller.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpCode,
   ForbiddenException,
   HttpStatus,
+  Query,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 import { ProjectAclService } from './project-acl.service';
@@ -46,10 +47,12 @@ export class ProjectAclController {
   async findUsersInProject(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Req() req: RequestWithAuthenticatedUser,
+    @Query('q') nameSearch?: string,
   ): Promise<UsersInProjectResult> {
     const result = await this.projectAclService.findUsersInProject(
       projectId,
       req.user.id,
+      nameSearch,
     );
 
     if (isLeft(result)) {

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.controller.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.controller.ts
@@ -23,8 +23,11 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { UserRoleInProjectDto } from './dto/user-role-project.dto';
 import { isLeft } from 'fp-ts/lib/These';
+import {
+  UserRoleInProjectDto,
+  UsersInProjectResult,
+} from './dto/user-role-project.dto';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -43,7 +46,7 @@ export class ProjectAclController {
   async findUsersInProject(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Req() req: RequestWithAuthenticatedUser,
-  ): Promise<UserRoleInProjectDto[] | boolean> {
+  ): Promise<UsersInProjectResult> {
     const result = await this.projectAclService.findUsersInProject(
       projectId,
       req.user.id,
@@ -53,7 +56,7 @@ export class ProjectAclController {
       throw new ForbiddenException();
     }
 
-    return result.right;
+    return { data: result.right };
   }
 
   @Patch(':projectId/users')

--- a/api/apps/api/test/access-control/project-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-get.e2e-spec.ts
@@ -39,3 +39,21 @@ test(`getting project users as contributor`, async () => {
   );
   fixtures.ThenForbiddenIsReturned(response);
 });
+
+test(`getting project users as owner with a search query`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenViewerWasAddedToProject(projectId);
+  const response = await fixtures.WhenGettingProjectUsersWithSearchTerm(
+    projectId,
+  );
+  fixtures.ThenViewerUserInformationIsReturned(response);
+});
+
+test(`getting project users as owner with a wrong search query`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenViewerWasAddedToProject(projectId);
+  const response = await fixtures.WhenGettingProjectUsersWithWrongSearchTerm(
+    projectId,
+  );
+  fixtures.ThenNoUserInformationIsReturned(response);
+});

--- a/api/apps/api/test/access-control/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl.fixtures.ts
@@ -251,15 +251,15 @@ export const getFixtures = async () => {
 
     ThenSingleOwnerUserInProjectIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(200);
-      expect(response.body).toHaveLength(1);
+      expect(response.body.data).toHaveLength(1);
     },
 
     ThenAllUsersinProjectAfterAddingAnOwnerAreReturned: (
       response: request.Response,
     ) => {
       expect(response.status).toEqual(200);
-      expect(response.body).toHaveLength(2);
-      const newUserCreated = response.body.find(
+      expect(response.body.data).toHaveLength(2);
+      const newUserCreated = response.body.data.find(
         (user: any) => user.user.id === ownerUserId,
       );
       expect(newUserCreated.roleName).toEqual(projectOwnerRole);
@@ -269,7 +269,7 @@ export const getFixtures = async () => {
       response: request.Response,
     ) => {
       expect(response.status).toEqual(200);
-      expect(response.body).toHaveLength(4);
+      expect(response.body.data).toHaveLength(4);
     },
   };
 };

--- a/api/apps/api/test/access-control/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl.fixtures.ts
@@ -105,6 +105,14 @@ export const getFixtures = async () => {
       await request(app.getHttpServer())
         .get(`/api/v1/roles/projects/${projectId}/users`)
         .set('Authorization', `Bearer ${ownerUserToken}`),
+    WhenGettingProjectUsersWithSearchTerm: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .get(`/api/v1/roles/projects/${projectId}/users?q=C C`)
+        .set('Authorization', `Bearer ${ownerUserToken}`),
+    WhenGettingProjectUsersWithWrongSearchTerm: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .get(`/api/v1/roles/projects/${projectId}/users?q=NotAUser`)
+        .set('Authorization', `Bearer ${ownerUserToken}`),
 
     WhenGettingProjectUsersAsContributor: async (projectId: string) =>
       await request(app.getHttpServer())
@@ -252,6 +260,18 @@ export const getFixtures = async () => {
     ThenSingleOwnerUserInProjectIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(200);
       expect(response.body.data).toHaveLength(1);
+    },
+
+    ThenViewerUserInformationIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0].user.displayName).toEqual('User C C');
+      expect(response.body.data[0].user.id).toEqual(viewerUserId);
+    },
+
+    ThenNoUserInformationIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(0);
     },
 
     ThenAllUsersinProjectAfterAddingAnOwnerAreReturned: (


### PR DESCRIPTION
## Improvements to get project users endpoint

### Overview

This PR implements improvements to the `GET api/v1/roles/projects/{id}/users` endpoint, as described in [MARXAN-1121](https://vizzuality.atlassian.net/browse/MARXAN-1121).

### Feature relevant tickets

[MARXAN-1121](https://vizzuality.atlassian.net/browse/MARXAN-1121)