### PR TITLE
Bug/marxan 1152 change unique project role

### DIFF
--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
@@ -188,6 +188,10 @@ export class ProjectAclService implements ProjectAccessControl {
       return left(false);
     }
 
+    if (!(await this.hasOtherOwner(userId, projectId))) {
+      return left(false);
+    }
+
     const apiDbConnection = getConnection(DbConnections.default);
     const apiQueryRunner = apiDbConnection.createQueryRunner();
 

--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -346,7 +346,10 @@ export class ProjectsCrudService extends AppBaseService<
           userId: info?.authenticatedUser?.id,
         })
         .andWhere(`acl.role_id = :roleId`, {
-          roleId: Roles.project_owner,
+          roleId:
+            Roles.project_owner ||
+            Roles.project_contributor ||
+            Roles.project_viewer,
         });
     }
 

--- a/api/apps/api/test/access-control/project-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl-patch.e2e-spec.ts
@@ -65,3 +65,11 @@ test(`add every type of user to a project as project viewer`, async () => {
   fixtures.ThenForbiddenIsReturned(contributorResponse);
   fixtures.ThenForbiddenIsReturned(ownerResponse);
 });
+
+test(`change owner role as last owner`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  const response = await fixtures.WhenChangingOwnerUserRoleAsLastOwner(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+});

--- a/api/apps/api/test/access-control/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl.fixtures.ts
@@ -8,6 +8,7 @@ import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/proje
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ProjectsACLTestUtils } from '../utils/projects-acl.test.utils';
+import { async } from 'rxjs';
 
 export const getFixtures = async () => {
   const app = await bootstrapApplication();
@@ -146,6 +147,15 @@ export const getFixtures = async () => {
           projectId,
           userId: otherOwnerUserId,
           roleName: projectOwnerRole,
+        }),
+    WhenChangingOwnerUserRoleAsLastOwner: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/projects/${projectId}/users`)
+        .set('Authorization', `Bearer ${ownerUserToken}`)
+        .send({
+          projectId,
+          userId: ownerUserId,
+          roleName: projectViewerRole,
         }),
     WhenAddingANewViewerToTheProjectAsContributor: async (projectId: string) =>
       await request(app.getHttpServer())


### PR DESCRIPTION
## Fix for users roles in project-acl

- Fix unique owner being able of changing their role and effectively locking out the project.
- Fix `project_contributor` and `project_viewer` roles not seeing their projects in the general view.
- Add test to check that the unique owner cannot change their role and locking out the project.