### PR TITLE
Allowing sliders' values to be editable via label [MARXAN-1153]

### DIFF
--- a/app/components/forms/slider/component.stories.tsx
+++ b/app/components/forms/slider/component.stories.tsx
@@ -52,6 +52,7 @@ export const Default = Template.bind({});
 Default.args = {
   theme: 'dark',
   status: 'none',
+  allowEdit: true,
   disabled: false,
   formatOptions: { style: 'percent' },
   minValue: 0,

--- a/app/components/forms/slider/component.tsx
+++ b/app/components/forms/slider/component.tsx
@@ -100,6 +100,7 @@ export const Slider: React.FC<SliderProps> = ({
   labelRef,
   maxValue,
   minValue,
+  step,
   ...rest
 }: SliderProps) => {
   const status = disabled ? 'disabled' : rawState;
@@ -122,6 +123,7 @@ export const Slider: React.FC<SliderProps> = ({
   const sliderState = useSliderState({
     maxValue,
     minValue,
+    step,
     ...rest,
     ...propsOverride,
     numberFormatter: useNumberFormatter(formatOptions),
@@ -137,6 +139,7 @@ export const Slider: React.FC<SliderProps> = ({
       // input has the `id` attribute and the label has a `for` attribute
       // For this reason, we remove the `id` attribute from the object
       id: undefined,
+      step,
     },
     sliderState,
     trackRef,
@@ -194,11 +197,13 @@ export const Slider: React.FC<SliderProps> = ({
       <Value
         minValue={minValue}
         maxValue={maxValue}
+        step={step}
         allowEdit={allowEdit}
         isDisabled={disabled}
         theme={theme}
         sliderState={sliderState}
         outputProps={outputProps}
+        formatOptions={formatOptions}
         style={{
           left: `${sliderState.getThumbPercent(0) * 100}%`,
         }}

--- a/app/components/forms/slider/component.tsx
+++ b/app/components/forms/slider/component.tsx
@@ -7,26 +7,21 @@ import { useSliderState } from '@react-stately/slider';
 import cx from 'classnames';
 
 import Thumb from './thumb';
+import Value from './value';
 
 const THEME = {
   dark: {
-    base: 'w-full h-12 pt-8 touch-action-none',
-    output:
-      'absolute bottom-1 transform -translate-y-full -translate-x-1/2 text-sm text-white border border-t-0 border-l-0 border-r-0 border-dashed border-white',
+    base: 'relative w-full h-12 pt-8 touch-action-none',
     filledTrack: 'absolute left-0 h-1.5 bg-white rounded',
     track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
   },
   light: {
-    base: 'w-full h-12 pt-8 touch-action-none',
-    output:
-      'absolute bottom-1 transform -translate-y-full -translate-x-1/2 text-sm text-gray-800 border border-t-0 border-l-0 border-r-0 border-dashed border-gray-800',
+    base: 'relative w-full h-12 pt-8 touch-action-none',
     filledTrack: 'absolute left-0 h-1.5 bg-gray-800 rounded',
     track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
   },
   'dark-small': {
-    base: 'w-full h-12 pt-8 touch-action-none',
-    output:
-      'absolute bottom-1 transform -translate-y-full -translate-x-1/2 text-xs text-black',
+    base: 'relative w-full h-12 pt-8 touch-action-none',
     filledTrack: 'absolute left-0 h-1.5 bg-black rounded',
     track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
   },
@@ -50,6 +45,10 @@ export interface SliderProps {
    * Whether the input is disabled
    */
   disabled?: boolean;
+  /**
+   * Whether to allow the user to click the output and edit it directly. Defaults to `true`
+   */
+  allowEdit?: boolean,
   /**
    * Format of the value
    */
@@ -95,9 +94,12 @@ export interface SliderProps {
 export const Slider: React.FC<SliderProps> = ({
   theme = 'dark',
   status: rawState = 'none',
+  allowEdit = true,
   disabled = false,
   formatOptions = { style: 'percent' },
   labelRef,
+  maxValue,
+  minValue,
   ...rest
 }: SliderProps) => {
   const status = disabled ? 'disabled' : rawState;
@@ -118,6 +120,8 @@ export const Slider: React.FC<SliderProps> = ({
 
   const trackRef = React.useRef(null);
   const sliderState = useSliderState({
+    maxValue,
+    minValue,
     ...rest,
     ...propsOverride,
     numberFormatter: useNumberFormatter(formatOptions),
@@ -171,15 +175,6 @@ export const Slider: React.FC<SliderProps> = ({
         ref={trackRef}
         className="relative flex items-center w-full h-full"
       >
-        <output
-          {...outputProps}
-          className={THEME[theme].output}
-          style={{
-            left: `${sliderState.getThumbPercent(0) * 100}%`,
-          }}
-        >
-          {sliderState.getThumbValueLabel(0)}
-        </output>
         <div
           className={THEME[theme].filledTrack}
           style={{
@@ -196,6 +191,18 @@ export const Slider: React.FC<SliderProps> = ({
           isDisabled={disabled}
         />
       </div>
+      <Value
+        minValue={minValue}
+        maxValue={maxValue}
+        allowEdit={allowEdit}
+        isDisabled={disabled}
+        theme={theme}
+        sliderState={sliderState}
+        outputProps={outputProps}
+        style={{
+          left: `${sliderState.getThumbPercent(0) * 100}%`,
+        }}
+      />
     </div>
   );
 };

--- a/app/components/forms/slider/value/component.tsx
+++ b/app/components/forms/slider/value/component.tsx
@@ -1,0 +1,178 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+import { useButton } from '@react-aria/button';
+import { useFocus, useKeyboard } from '@react-aria/interactions';
+import { SliderState } from '@react-stately/slider';
+import cx from 'classnames';
+
+const THEME = {
+  dark: {
+    base: 'absolute top-0 transform -translate-x-1/2 text-black',
+    output: 'text-sm text-white border border-t-0 border-l-0 border-r-0 border-dashed border-white',
+    input: 'absolute left-0 top-0 w-full h-full text-sm border-none bg-primary-300 rounded rounded-lg cursor-text text-center font-medium appearance-none bg-transparent text-gray-500 focus:outline-none',
+  },
+  light: {
+    base: 'absolute top-0 transform -translate-x-1/2 text-black',
+    input: 'absolute left-0 top-0 w-full h-full text-sm border-none bg-primary-300 rounded rounded-lg cursor-text text-center font-medium appearance-none bg-transparent text-gray-500 focus:outline-none',
+    output: 'text-sm text-gray-800 border border-t-0 border-l-0 border-r-0 border-dashed border-gray-800',
+  },
+  'dark-small': {
+    base: 'absolute top-0 transform -translate-x-1/2 text-black',
+    input: 'absolute left-0 top-0 w-full h-full text-sm border-none bg-primary-300 rounded rounded-lg cursor-text text-center font-medium appearance-none bg-transparent text-gray-500 focus:outline-none',
+    output: 'text-xs text-black',
+  },
+};
+
+export interface ValueProps {
+  minValue: number,
+  maxValue: number,
+  allowEdit: boolean,
+  isDisabled: boolean,
+  theme: 'dark' | 'light' | 'dark-small';
+  sliderState: SliderState,
+  outputProps: React.OutputHTMLAttributes<HTMLOutputElement>,
+  style: Record<string, unknown>;
+}
+
+export const Value: React.FC<ValueProps> = ({
+  minValue,
+  maxValue,
+  theme,
+  allowEdit,
+  isDisabled,
+  sliderState,
+  outputProps,
+  style,
+
+}: ValueProps) => {
+  const wrapperRef = useRef<HTMLInputElement>(null);
+  const outputButtonRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [value, setValue] = useState<number>(sliderState.getThumbValue(0));
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
+  // Saving and Cancelling the edit
+
+  const cancelEdit = () => {
+    setValue(sliderState.getThumbValue(0) * 100);
+    setIsEditing(false);
+  };
+
+  const saveEdit = () => {
+    const thumbValue = value / 100;
+
+    if (thumbValue >= minValue && thumbValue <= maxValue) {
+      sliderState.setThumbValue(0, thumbValue);
+      setIsEditing(false);
+    } else {
+      cancelEdit();
+    }
+  };
+
+  // Handling inputs/ouputs interactions
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLElement>) => {
+    const target = event.target as HTMLTextAreaElement;
+    setValue(parseInt(target.value, 10));
+  };
+
+  const handleOutputPress = () => {
+    if (isDisabled || !allowEdit) return;
+    setIsEditing(true);
+  };
+
+  const { focusProps: inputFocusProps } = useFocus({
+    onBlur: saveEdit,
+  });
+
+  const { keyboardProps: inputKeyboardProps } = useKeyboard({
+    onKeyDown: (event) => {
+      switch (event.key) {
+        case 'Enter':
+          // This may be used inside a form, so we want to prevent it from submitting
+          event.preventDefault();
+          saveEdit();
+          break;
+        case 'Escape':
+          cancelEdit();
+          break;
+        default:
+      }
+    },
+  });
+
+  const { buttonProps: outputButtonProps } = useButton({
+    elementType: 'div',
+    'aria-label': 'Edit',
+    onPress: handleOutputPress,
+  }, outputButtonRef);
+
+  // Effects
+
+  useEffect(() => {
+    setValue(sliderState.getThumbValue(0) * 100);
+  }, [sliderState]);
+
+  useEffect(() => {
+    setIsEditing(false);
+  }, [isDisabled]);
+
+  useEffect(() => {
+    if (!isEditing) return;
+    inputRef.current.focus();
+  }, [inputRef, isEditing]);
+
+  // JSX
+
+  return (
+    <div
+      className={THEME[theme].base}
+      ref={wrapperRef}
+      style={style}
+    >
+      { isEditing ? (
+        <div>
+          <span
+            className="invisible px-2"
+            aria-hidden="true"
+          >
+            {/* Math.random To overcome floating point issues */}
+            {Number.isNaN(value) ? '' : Math.round(value)}
+          </span>
+          <input
+            ref={inputRef}
+            className={THEME[theme].input}
+            type="number"
+            // Math.random To overcome floating point issues
+            value={Math.round(value)}
+            onChange={handleInputChange}
+            {...inputFocusProps}
+            {...inputKeyboardProps}
+          />
+        </div>
+      ) : (
+        <div
+          ref={outputButtonRef}
+          className={cx({
+            'cursor-default': !allowEdit,
+            'cursor-text': allowEdit,
+          })}
+          {...outputButtonProps}
+        >
+          <output
+            className={THEME[theme].output}
+            style={{
+              left: `${sliderState.getThumbValue(0) * 100}%`,
+            }}
+            {...outputProps}
+          >
+            {sliderState.getThumbValueLabel(0)}
+          </output>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Value;

--- a/app/components/forms/slider/value/index.ts
+++ b/app/components/forms/slider/value/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -7,6 +7,13 @@
     -webkit-font-smoothing: antialiased;
   }
 
+  /* Remove arrows from number inputs */
+  input[type=number]::-webkit-inner-spin-button,
+  input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
   input[type='search']::-webkit-search-decoration,
   input[type='search']::-webkit-search-cancel-button,
   input[type='search']::-webkit-search-results-button,


### PR DESCRIPTION
### Overview

This PR makes it so that the user can input a value for a slider directly, instead of having to drag its handle.  
In order to do so, the user can simply click on the value displayed above the thumb (hovering over it will display the "I-Beam" cursor we usually see when hovering over editable text) and input the desired value. The user can press the `Enter` key or click somewhere else to set the value, or use the `Escape` key to cancel edition. 

### Testing instructions

Verify that:  
- Clicking on a slider's value label allows you to input a value and:   
    - If the value is within range (eg: protected areas threshold 0-100), it is set  
    - If the value is not within the range, it will not be set  
- Pressing `Enter` when adjusting a value sets it  
- Pressing `Escape` closes the adjustment input and reverts the slider to its previous setting  
- When in edit mode, clicking somewhere else in the screen cancels the edition input  

### Feature relevant tickets

[MARXAN-1153](https://vizzuality.atlassian.net/browse/MARXAN-1153)

### Screenshots  

**Normal**  
<img width="719" alt="Screenshot 2021-12-31 at 10 35 40" src="https://user-images.githubusercontent.com/6273795/147818660-d7d0c9fd-baa8-4400-babb-8c916e53e9fe.png">

**Editing**  
<img width="722" alt="Screenshot 2021-12-31 at 10 35 48" src="https://user-images.githubusercontent.com/6273795/147818669-86ebdcba-84aa-49cd-8651-baa9d7a8492a.png">

