### PR TITLE
Removing filters from GET protected-areas

### DIFF
--- a/app/hooks/wdpa/index.ts
+++ b/app/hooks/wdpa/index.ts
@@ -14,32 +14,19 @@ import {
 } from './types';
 
 export function useWDPACategories({
-  adminAreaId,
-  customAreaId,
   scenarioId,
 }: UseWDPACategoriesProps) {
   const [session] = useSession();
 
   const query = useQuery(
-    ['scenarios', adminAreaId, customAreaId],
+    'scenarios',
     async () => WDPA.request({
       method: 'GET',
       url: `/${scenarioId}/protected-areas`,
-      params: {
-        ...(adminAreaId && {
-          'filter[adminAreaId]': adminAreaId,
-        }),
-        ...(customAreaId && {
-          'filter[customAreaId]': customAreaId,
-        }),
-      },
       headers: {
         Authorization: `Bearer ${session.accessToken}`,
       },
     }),
-    {
-      enabled: !!adminAreaId || !!customAreaId,
-    },
   );
 
   const { data } = query;

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -9,7 +9,6 @@ import { useRouter } from 'next/router';
 
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
-import { useProject } from 'hooks/projects';
 import { useScenario } from 'hooks/scenarios';
 import { useWDPACategories, useSaveScenarioProtectedAreas } from 'hooks/wdpa';
 
@@ -34,15 +33,13 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
   onDismiss,
 }: WDPACategoriesProps) => {
   const { query } = useRouter();
-  const { pid, sid } = query;
+  const { sid } = query;
 
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setWDPACategories, setWDPAThreshold } = scenarioSlice.actions;
   const dispatch = useDispatch();
 
   const { wdpaCategories } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
-
-  const { data: projectData } = useProject(pid);
 
   const {
     data: scenarioData,
@@ -56,12 +53,6 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     isFetched: wdpaIsFetched,
     refetch: refetchProtectedAreas,
   } = useWDPACategories({
-    adminAreaId: projectData?.adminAreaLevel2Id
-      || projectData?.adminAreaLevel1I
-      || projectData?.countryId,
-    customAreaId: !projectData?.adminAreaLevel2Id
-      && !projectData?.adminAreaLevel1I
-      && !projectData?.countryId ? projectData?.planningAreaId : null,
     scenarioId: sid,
   });
 

--- a/app/layout/scenarios/edit/wdpa/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/component.tsx
@@ -8,7 +8,6 @@ import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import { motion } from 'framer-motion';
 
-import { useProject } from 'hooks/projects';
 import { useScenario } from 'hooks/scenarios';
 import { useWDPACategories } from 'hooks/wdpa';
 
@@ -27,7 +26,7 @@ export interface ScenariosSidebarEditWDPAProps {
 export const ScenariosSidebarEditWDPA: React.FC<ScenariosSidebarEditWDPAProps> = () => {
   const [step, setStep] = useState(0);
   const { query } = useRouter();
-  const { pid, sid } = query;
+  const { sid } = query;
 
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setTab, setSubTab } = scenarioSlice.actions;
@@ -35,8 +34,6 @@ export const ScenariosSidebarEditWDPA: React.FC<ScenariosSidebarEditWDPAProps> =
   const { tab } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
 
   const dispatch = useDispatch();
-
-  const { data: projectData } = useProject(pid);
 
   const { data: scenarioData } = useScenario(sid);
   const { metadata } = scenarioData || {};
@@ -47,12 +44,6 @@ export const ScenariosSidebarEditWDPA: React.FC<ScenariosSidebarEditWDPAProps> =
   } = scenarioEditingMetadata || {};
 
   const { data: wdpaData } = useWDPACategories({
-    adminAreaId: projectData?.adminAreaLevel2Id
-      || projectData?.adminAreaLevel1I
-      || projectData?.countryId,
-    customAreaId: !projectData?.adminAreaLevel2Id
-      && !projectData?.adminAreaLevel1I
-      && !projectData?.countryId ? projectData?.planningAreaId : null,
     scenarioId: sid,
   });
 

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -11,7 +11,6 @@ import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import { mergeScenarioStatusMetaData } from 'utils/utils-scenarios';
 
-import { useProject } from 'hooks/projects';
 import { useScenario, useSaveScenario } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 import { useWDPACategories, useSaveScenarioProtectedAreas } from 'hooks/wdpa';
@@ -43,11 +42,9 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
 
   const { addToast } = useToasts();
   const { query } = useRouter();
-  const { pid, sid } = query;
+  const { sid } = query;
 
   const { wdpaCategories } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
-
-  const { data: projectData } = useProject(pid);
 
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setWDPAThreshold } = scenarioSlice.actions;
@@ -66,12 +63,6 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
     isFetching: wdpaIsFetching,
     isFetched: wdpaIsFetched,
   } = useWDPACategories({
-    adminAreaId: projectData?.adminAreaLevel2Id
-      || projectData?.adminAreaLevel1I
-      || projectData?.countryId,
-    customAreaId: !projectData?.adminAreaLevel2Id
-      && !projectData?.adminAreaLevel1I
-      && !projectData?.countryId ? projectData?.planningAreaId : null,
     scenarioId: sid,
   });
 

--- a/app/layout/scenarios/show/wdpa/component.tsx
+++ b/app/layout/scenarios/show/wdpa/component.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/router';
 
 import { motion } from 'framer-motion';
 
-import { useProject } from 'hooks/projects';
 import { useScenario } from 'hooks/scenarios';
 import { useWDPACategories } from 'hooks/wdpa';
 
@@ -24,11 +23,10 @@ export interface ScenariosSidebarShowWDPAProps {
 
 export const ScenariosSidebarShowWDPA: React.FC<ScenariosSidebarShowWDPAProps> = () => {
   const { query } = useRouter();
-  const { pid, sid } = query;
+  const { sid } = query;
 
   const { tab } = useSelector((state) => state[`/scenarios/${sid}`]);
 
-  const { data: projectData } = useProject(pid);
   const {
     data: scenarioData,
     isFetching: scenarioIsFetching,
@@ -40,12 +38,6 @@ export const ScenariosSidebarShowWDPA: React.FC<ScenariosSidebarShowWDPAProps> =
     isFetching: wdpaIsFetching,
     isFetched: wdpaIsFetched,
   } = useWDPACategories({
-    adminAreaId: projectData?.adminAreaLevel2Id
-      || projectData?.adminAreaLevel1I
-      || projectData?.countryId,
-    customAreaId: !projectData?.adminAreaLevel2Id
-      && !projectData?.adminAreaLevel1I
-      && !projectData?.countryId ? projectData?.planningAreaId : null,
     scenarioId: sid,
   });
 


### PR DESCRIPTION
### Overview

Removing `adminAreaId` and `customAreaId` filters from `GET` `protected-areas`. 

### Feature relevant tickets

[MARXAN-1095](https://vizzuality.atlassian.net/browse/MARXAN-1095)
