### PR TITLE
avoid index size limit when uploading custom planning unit grids from shapefile [MARXAN-1031]

### DIFF
--- a/api/apps/api/src/utils/postgresql.utils.ts
+++ b/api/apps/api/src/utils/postgresql.utils.ts
@@ -3,7 +3,7 @@ import { getManager } from 'typeorm';
 /**
  * Utility functions related to lower-level interaction with PostgreSQL servers.
  *
- * @debt This should be moved to a self-standing
+ * @debt This should be moved to a self-standing project library
  */
 export class PostgreSQLUtils {
   /**

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1641582332000-FixUniquenessOfPuGeoms.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1641582332000-FixUniquenessOfPuGeoms.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { Logger } from '@nestjs/common';
+import { PostgreSQLUtils } from '@marxan-geoprocessing/utils/postgresql.utils';
+
+export class FixUniquenessOfPuGeoms1641582332000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    if (await PostgreSQLUtils.version13Plus()) {
+      await queryRunner.query(`
+          CREATE EXTENSION IF NOT EXISTS pgcrypto;
+        `);
+    } else {
+      Logger.warn(
+        'The PostgreSQL extension `pgcrypto` is needed for the Marxan Geoprocessing service, but it was not possible to activate it. Please activate it manually (see setup documentation).',
+      );
+    }
+
+    /*
+     * The previous implementation of the
+     * `planning_units_geom_the_geom_type_project_id_check` index would not be
+     * ok for `the_geom` data rows past the current limit for btrees (typical
+     * errors: `index row size <NNN> exceeds btree version 4 maximum 2704 for
+     * index "planning_units_geom_from_shapefile_the_geom_type_coalesce_idx")`,
+     * so we are indexing a hash of `the_geom` here as a proxy of the content of
+     * `the_geom` proper.
+     *
+     * md5 should be faster than alternative hashing functions such as sha2xx,
+     * while functionally enough for the purpose: the uniqueness check here is
+     * meant to avoid *routine* duplication of planning units, and we are not
+     * considering this as part of a threat model where a malicious actor would
+     * purposely want to forge collisions.
+     *
+     * No realistic chance of collision is expected through normal use of the
+     * platform, and even if this were to happen, the outcome would be some
+     * wasted storage space for *a specific* planning unit, therefore making
+     * this computationally unattractive even for an hypothetic malicious actor.
+     */
+    await queryRunner.query(`
+      drop index planning_units_geom_the_geom_type_project_id_check;
+
+      alter table planning_units_geom add column the_geom_hash bytea generated always as (digest(the_geom::bytea, 'md5')) stored;
+
+      create unique index planning_units_geom_the_geom_type_project_id_check
+        on planning_units_geom(the_geom_hash, type, coalesce(project_id, '00000000-0000-0000-0000-000000000000'));
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      drop index planning_units_geom_the_geom_type_project_id_check;
+
+      alter table planning_units_geom drop column the_geom_hash;
+
+      create unique index planning_units_geom_the_geom_type_project_id_check
+        on planning_units_geom(the_geom, type, coalesce(project_id, '00000000-0000-0000-0000-000000000000'));
+    `);
+
+    if (await PostgreSQLUtils.version13Plus()) {
+      await queryRunner.query(`
+          DROP EXTENSION IF EXISTS pgcrypto;
+        `);
+      } else {
+        Logger.warn(
+          'The PostgreSQL extension `pgcrypto` is not needed anymore for the Marxan Geoprocessing service, but it was not possible to drop it. Please drop it manually (see setup documentation).',
+        );
+    }
+  }
+}

--- a/api/apps/geoprocessing/src/modules/planning-area/planning-units-grid/planning-units-grid.processor.ts
+++ b/api/apps/geoprocessing/src/modules/planning-area/planning-units-grid/planning-units-grid.processor.ts
@@ -43,7 +43,7 @@ export class PlanningUnitsGridProcessor {
             FROM (
                    SELECT json_array_elements($1::json -> 'features') AS features
                  ) AS f
-            ON CONFLICT (the_geom, type, COALESCE(project_id, '00000000-0000-0000-0000-000000000000')) DO UPDATE SET type = 'from_shapefile'::shape_type
+            ON CONFLICT (the_geom_hash, type, COALESCE(project_id, '00000000-0000-0000-0000-000000000000')) DO UPDATE SET type = 'from_shapefile'::shape_type
             RETURNING "id", "project_id"
           `,
           [geoJson, ShapeType.FromShapefile, fakeProjectId],

--- a/api/apps/geoprocessing/src/modules/planning-units/planning-units.job.ts
+++ b/api/apps/geoprocessing/src/modules/planning-units/planning-units.job.ts
@@ -103,7 +103,7 @@ const createPlanningUnitGridFromJobSpec = async (
                         select st_transform(geom, 4326) as the_geom,
                         '${job.data.planningUnitGridShape}' as type,
                         ${job.data.planningUnitAreakm2} as size from (${subquery}) grid
-                        ON CONFLICT (the_geom, type, COALESCE(project_id, '00000000-0000-0000-0000-000000000000')) DO NOTHING;`);
+                        ON CONFLICT (the_geom_hash, type, COALESCE(project_id, '00000000-0000-0000-0000-000000000000')) DO NOTHING;`);
       return queryResult;
     } catch (err) {
       logger.error(err);

--- a/api/apps/geoprocessing/src/utils/postgresql.utils.ts
+++ b/api/apps/geoprocessing/src/utils/postgresql.utils.ts
@@ -3,7 +3,7 @@ import { getManager } from 'typeorm';
 /**
  * Utility functions related to lower-level interaction with PostgreSQL servers.
  *
- * @debt This should be moved to a self-standing
+ * @debt This should be moved to a self-standing project library
  */
 export class PostgreSQLUtils {
   /**


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1031

Please see shapefile attached to the Jira task for validating the functionality of this PR.

In practice, any PU grid shapefile with non-regularly-shaped (e.g. square, hexagon) PUs should allow to reproduce the issue without this PR, and should be processed correctly (if within other criteria such as maximum file size, valid geometries, etc.) with this PR.