### PR TITLE
Adding scenario status filters on the frontend

### DIFF
--- a/app/components/scenarios/item/component.tsx
+++ b/app/components/scenarios/item/component.tsx
@@ -63,6 +63,7 @@ export interface ItemProps {
   progress?: number;
   lastUpdate: string;
   jobs?: Record<string, any>[];
+  runStatus: 'created' | 'running' | 'done' | 'failure',
   lastUpdateDistance: string;
   className?: string;
   onEdit: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -79,7 +80,8 @@ export const Item: React.FC<ItemProps> = ({
   progress,
   lastUpdateDistance,
   className,
-  jobs = [],
+  jobs,
+  runStatus,
   onEdit,
   onView,
   onCancelRun,
@@ -96,7 +98,6 @@ export const Item: React.FC<ItemProps> = ({
     const geofeatureSplit = jobs.find((j) => j.kind === 'geofeatureSplit');
     const geofeatureStratification = jobs.find((j) => j.kind === 'geofeatureStratification');
     const specification = jobs.find((j) => j.kind === 'specification');
-    const run = jobs.find((j) => j.kind === 'run');
 
     // PROTECTED AREAS
     if (planningAreaProtectedCalculation && planningAreaProtectedCalculation.status === 'running') return 'pa-running';
@@ -119,13 +120,13 @@ export const Item: React.FC<ItemProps> = ({
       || (specification && specification.status === 'failure')
     ) return 'features-failure';
 
-    // RUN
-    if (run && run.status === 'running') return 'run-running';
-    if (run && run.status === 'failure') return 'run-failure';
-    if (run && run.status === 'done') return 'run-done';
+    // RUN STATUS
+    if (runStatus === 'running') return 'run-running';
+    if (runStatus === 'failure') return 'run-failure';
+    if (runStatus === 'done') return 'run-done';
 
     return 'draft';
-  }, [jobs]);
+  }, [jobs, runStatus]);
 
   const onSettings = useCallback(() => {
     setSettings(!settings);

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -271,7 +271,7 @@ export function useSaveScenario({
       queryClient.invalidateQueries(['scenarios', projectId]);
       queryClient.setQueryData(['scenarios', id], data?.data);
 
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -300,7 +300,7 @@ export function useDeleteScenario({
 
   return useMutation(deleteScenario, {
     onSuccess: (data, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -330,7 +330,7 @@ export function useUploadScenarioPU({
 
   return useMutation(uploadScenarioPUShapefile, {
     onSuccess: (data: any, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -361,7 +361,7 @@ export function useUploadPA({
 
   return useMutation(uploadPAShapefile, {
     onSuccess: (data: any, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       console.info('Error', error, variables, context);
@@ -432,7 +432,7 @@ export function useDownloadCostSurface({
       document.body.appendChild(link);
       link.click();
       link.remove();
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -462,7 +462,7 @@ export function useUploadCostSurface({
 
   return useMutation(uploadScenarioCostSurface, {
     onSuccess: (data: any, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -550,7 +550,7 @@ export function useSaveScenarioPU({
 
   return useMutation(saveScenario, {
     onSuccess: (data: any, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
       const { id } = variables;
       queryClient.invalidateQueries(['scenarios-pu', id]);
     },
@@ -584,7 +584,7 @@ export function useDuplicateScenario({
       const { id, projectId } = data;
       queryClient.invalidateQueries(['scenarios', projectId]);
       queryClient.invalidateQueries(['scenarios', id]);
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -613,7 +613,7 @@ export function useRunScenario({
 
   return useMutation(duplicateScenario, {
     onSuccess: (data: any, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!
@@ -642,7 +642,7 @@ export function useCancelRunScenario({
 
   return useMutation(duplicateScenario, {
     onSuccess: (data: any, variables, context) => {
-      console.info('Succces', data, variables, context);
+      console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
       // An error happened!

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -209,8 +209,9 @@ export function useScenarios(pId, options: UseScenariosOptionsProps = {}) {
     // filter it out manually in the frontend. It'll allow us to make the feature work
     // in the frontend for now, albeit in a non-ideal way.
     const filteredData = parsedData.filter((parsedDataItem) => {
-      if (!filters?.status) return true;
-      return (filters?.status as Array<string> || []).includes(parsedDataItem.runStatus);
+      const statusFiltersArr = (filters?.status as Array<string> || []);
+      if (!statusFiltersArr || !statusFiltersArr?.length) return true;
+      return statusFiltersArr.includes(parsedDataItem.runStatus);
     });
 
     return {

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -123,7 +123,7 @@ export function useScenarios(pId, options: UseScenariosOptionsProps = {}) {
     .reduce((acc, k) => {
       // Backend isn't able to deal with this one yet; it'll always return an empty array
       // if we set it. We'll do it manually in the frontend. Not ideal, but allows us to
-      // move forward useable the filters.
+      // move forward with useable filters.
       if (k === 'status') return acc;
 
       return {
@@ -210,7 +210,8 @@ export function useScenarios(pId, options: UseScenariosOptionsProps = {}) {
     // in the frontend for now, albeit in a non-ideal way.
     const filteredData = parsedData.filter((parsedDataItem) => {
       const statusFiltersArr = (filters?.status as Array<string> || []);
-      if (!statusFiltersArr || !statusFiltersArr?.length) return true;
+      // No filters to apply, return everything
+      if (!statusFiltersArr.length) return true;
       return statusFiltersArr.includes(parsedDataItem.runStatus);
     });
 

--- a/app/layout/projects/show/scenarios/component.tsx
+++ b/app/layout/projects/show/scenarios/component.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
+import { flatten } from 'lodash';
 
 import { useProject } from 'hooks/projects';
 import {
@@ -53,24 +54,13 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
   } = useProject(pid);
 
   const {
-    data: rawScenariosData,
-    isFetching: rawScenariosIsFetching,
-    isFetched: rawScenariosIsFetched,
-  } = useScenarios(pid, {
-    filters: {
-      projectId: pid,
-    },
-  });
-
-  const {
-    data: allScenariosData,
-    fetchNextPage: allScenariosfetchNextPage,
+    data: scenariosData,
+    fetchNextPage: scenariosFetchNextPage,
     hasNextPage,
-    isFetching: allScenariosIsFetching,
-    isFetchingNextPage: allScenariosIsFetchingNextPage,
-    isFetched: allScenariosIsFetched,
+    isFetching: scenariosIsFetching,
+    isFetchingNextPage: scenariosIsFetchingNextPage,
+    isFetched: scenariosIsFetched,
   } = useScenarios(pid, {
-
     search,
     filters: {
       projectId: pid,
@@ -81,12 +71,14 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
 
   const scrollRef = useBottomScrollListener(
     () => {
-      if (hasNextPage) allScenariosfetchNextPage();
+      if (hasNextPage) scenariosFetchNextPage();
     },
   );
 
-  const loading = (projectIsFetching && !projectIsFetched)
-    || (rawScenariosIsFetching && !rawScenariosIsFetched);
+  const projectLoading = projectIsFetching && !projectIsFetched;
+  const scenariosLoading = scenariosIsFetching && !scenariosIsFetched;
+  const hasScenarios = !!scenariosData.length;
+  const hasFilters = !!flatten(Object.values(filters)).length;
 
   // DELETE
   const deleteMutation = useDeleteScenario({});
@@ -148,7 +140,7 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
           level: 'success',
         });
 
-        console.info('Scenario duplicated succesfully', s);
+        console.info('Scenario duplicated successfully', s);
       },
       onError: () => {
         addToast('error-duplicate-scenario', (
@@ -191,7 +183,7 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
           level: 'success',
         });
 
-        console.info('Scenario canceled succesfully', s);
+        console.info('Scenario canceled successfully', s);
       },
       onError: () => {
         addToast('error-cancel-scenario', (
@@ -217,130 +209,118 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
   return (
     <AnimatePresence>
       <div key="project-scenarios-sidebar" className="flex flex-col flex-grow col-span-7 overflow-hidden">
-        {!loading && !filters && !rawScenariosData.length && (
-          <motion.div
-            key="project-scenarios-empty"
-            initial={{ y: -10, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: -10, opacity: 0 }}
-            className="flex items-center h-full pl-20 bg-gray-700 bg-right bg-no-repeat bg-contain rounded-4xl"
-            style={{
-              backgroundImage: `url(${bgScenariosDashboard})`,
-            }}
-          >
-            <div>
-              <div className="flex space-x-3">
-                <h2 className="text-lg font-medium font-heading">Scenario dashboard</h2>
-                <InfoButton>
-                  <span className="space-y-2">
-                    <p>
-                      A scenario is an individual planning activity with specific configurations
-                      of conservation areas, features, targets and parameters.
-                    </p>
-                    <p>
-                      You can create as
-                      many scenarios as needed to explore different possibilities.
-                    </p>
-                  </span>
-                </InfoButton>
-              </div>
-              <h3 className="mt-1 text-lg font-medium text-gray-300 font-heading">Get started by creating a scenario</h3>
+        <Loading
+          visible={projectLoading || scenariosLoading}
+          className="absolute top-0 bottom-0 left-0 right-0 z-40 flex items-center justify-center w-full h-full bg-black bg-opacity-90"
+          iconClassName="w-10 h-10 text-primary-500"
+        />
 
-              <Button
-                theme="primary"
-                size="lg"
-                className="mt-10"
-                onClick={() => setModal(true)}
-              >
-                <span className="mr-5">Create scenario</span>
-                <Icon icon={PLUS_SVG} className="w-4 h-4" />
-              </Button>
-            </div>
-          </motion.div>
-        )}
-
-        {!loading && !!rawScenariosData.length && (
-          <motion.div key="projects-scenarios" className="relative flex flex-col flex-grow overflow-hidden">
+        <div key="projects-scenarios" className="relative flex flex-col flex-grow overflow-hidden">
+          {(hasScenarios || search || hasFilters) && (
             <ScenarioToolbar />
+          )}
 
-            <Loading
-              visible={allScenariosIsFetching && !allScenariosIsFetched}
-              className="absolute top-0 bottom-0 left-0 right-0 z-40 flex items-center justify-center w-full h-full bg-black bg-opacity-90"
-              iconClassName="w-10 h-10 text-primary-500"
-            />
+          <div className="relative overflow-hidden" id="scenarios-list">
+            <div ref={scrollRef} className="relative z-0 flex flex-col flex-grow h-full py-6 overflow-x-hidden overflow-y-auto">
+              {!hasScenarios && (search || hasFilters) && (
+                <>No results found</>
+              )}
 
-            <ConfirmationPrompt
-              title={`Are you sure you want to delete "${deleteScenario?.name}"?`}
-              description="The action cannot be reverted."
-              icon={DELETE_WARNING_SVG}
-              open={!!deleteScenario}
-              onAccept={onDelete}
-              onRefuse={() => setDelete(null)}
-              onDismiss={() => setDelete(null)}
-            />
+              {hasScenarios && scenariosData.map((s, i) => {
+                const TAG = i === 0 ? HelpBeacon : Fragment;
 
-            <div className="relative overflow-hidden" id="scenarios-list">
-              <div className="absolute top-0 left-0 z-10 w-full h-6 pointer-events-none bg-gradient-to-b from-black via-black" />
-              <div ref={scrollRef} className="relative z-0 flex flex-col flex-grow h-full py-6 overflow-x-hidden overflow-y-auto">
-                {!!allScenariosData.length
-                  && allScenariosData.map((s, i) => {
-                    const TAG = i === 0 ? HelpBeacon : Fragment;
-
-                    return (
-                      <TAG
-                        key={`${s.id}`}
-                        {...i === 0 && {
-                          id: `project-scenario-${s.id}`,
-                          title: 'Scenario list',
-                          subtitle: 'List and detail overview',
-                          content: (
-                            <div>
-                              Here you can see listed all the scenarios under the same project.
-                              You can access a scenario and edit it at any time, unless there is
-                              a contributor working on the same scenario. In this case, you will see
-                              a warning.
-                            </div>
-                          ),
-                        }}
-                      >
-                        <div
-                          className={cx({
-                            'mt-3': i !== 0,
-                          })}
-                        >
-                          <ScenarioItem
-                            {...s}
-                            onDelete={() => {
-                              setDelete(s);
-                            }}
-                            onDuplicate={() => onDuplicate(s.id, s.name)}
-                            onCancelRun={() => onCancelRun(s.id, s.name)}
-                            SettingsC={<ScenarioSettings sid={s.id} />}
-                          />
-
+                return (
+                  <TAG
+                    key={`${s.id}`}
+                    {...i === 0 && {
+                      id: `project-scenario-${s.id}`,
+                      title: 'Scenario list',
+                      subtitle: 'List and detail overview',
+                      content: (
+                        <div>
+                          Here you can see listed all the scenarios under the same project.
+                          You can access a scenario and edit it at any time, unless there is
+                          a contributor working on the same scenario. In this case, you will
+                          see a warning.
                         </div>
-                      </TAG>
-                    );
-                  })}
+                      ),
+                    }}
+                  >
+                    <div
+                      className={cx({
+                        'mt-3': i !== 0,
+                      })}
+                    >
+                      <ScenarioItem
+                        {...s}
+                        onDelete={() => {
+                          setDelete(s);
+                        }}
+                        onDuplicate={() => onDuplicate(s.id, s.name)}
+                        onCancelRun={() => onCancelRun(s.id, s.name)}
+                        SettingsC={<ScenarioSettings sid={s.id} />}
+                      />
 
-                {!allScenariosData.length && (
-                  <div>
-                    No results found
-                  </div>
-                )}
-              </div>
-              <div className="absolute bottom-0 left-0 z-10 w-full h-6 pointer-events-none bg-gradient-to-t from-black via-black" />
-              <div
-                className={cx({
-                  'opacity-100': allScenariosIsFetchingNextPage,
-                  'absolute left-0 z-20 w-full text-xs text-center uppercase bottom-0 font-heading transition opacity-0 pointer-events-none': true,
-                })}
-              >
-                <div className="py-1 bg-gray-200">Loading more...</div>
-                <div className="w-full h-6 bg-white" />
-              </div>
+                    </div>
+                  </TAG>
+                );
+              })}
             </div>
+            <div className="absolute bottom-0 left-0 z-10 w-full h-6 pointer-events-none bg-gradient-to-t from-black via-black" />
+            <div
+              className={cx({
+                'opacity-100': scenariosIsFetchingNextPage,
+                'absolute left-0 z-20 w-full text-xs text-center uppercase bottom-0 font-heading transition opacity-0 pointer-events-none': true,
+              })}
+            >
+              <div className="py-1 bg-gray-200">Loading more...</div>
+              <div className="w-full h-6 bg-white" />
+            </div>
+          </div>
 
+          {!hasScenarios && !search && !hasFilters && (
+            <motion.div
+              key="project-scenarios-empty"
+              initial={{ y: -10, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -10, opacity: 0 }}
+              className="flex items-center h-full pl-20 bg-gray-700 bg-right bg-no-repeat bg-contain rounded-4xl"
+              style={{
+                backgroundImage: `url(${bgScenariosDashboard})`,
+              }}
+            >
+              <div>
+                <div className="flex space-x-3">
+                  <h2 className="text-lg font-medium font-heading">Scenario dashboard</h2>
+                  <InfoButton>
+                    <span className="space-y-2">
+                      <p>
+                        A scenario is an individual planning activity with specific configurations
+                        of conservation areas, features, targets and parameters.
+                      </p>
+                      <p>
+                        You can create as
+                        many scenarios as needed to explore different possibilities.
+                      </p>
+                    </span>
+                  </InfoButton>
+                </div>
+                <h3 className="mt-1 text-lg font-medium text-gray-300 font-heading">Get started by creating a scenario</h3>
+
+                <Button
+                  theme="primary"
+                  size="lg"
+                  className="mt-10"
+                  onClick={() => setModal(true)}
+                >
+                  <span className="mr-5">Create scenario</span>
+                  <Icon icon={PLUS_SVG} className="w-4 h-4" />
+                </Button>
+              </div>
+            </motion.div>
+          )}
+
+          {(hasScenarios || search || hasFilters) && (
             <button
               type="button"
               className="flex items-center justify-center flex-shrink-0 w-full h-16 px-8 space-x-3 text-sm transition bg-gray-700 rounded-3xl text-primary-500 group hover:bg-gray-800"
@@ -349,18 +329,28 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
               <span>Create scenario</span>
               <Icon icon={PLUS_SVG} className="w-4 h-4 transition transform group-hover:rotate-90" />
             </button>
-          </motion.div>
-        )}
-      </div>
+          )}
+        </div>
 
-      <Modal
-        title="Hello"
-        open={modal}
-        size="wide"
-        onDismiss={() => setModal(false)}
-      >
-        <ScenarioTypes />
-      </Modal>
+        <Modal
+          title="Hello"
+          open={modal}
+          size="wide"
+          onDismiss={() => setModal(false)}
+        >
+          <ScenarioTypes />
+        </Modal>
+
+        <ConfirmationPrompt
+          title={`Are you sure you want to delete "${deleteScenario?.name}"?`}
+          description="The action cannot be reverted."
+          icon={DELETE_WARNING_SVG}
+          open={!!deleteScenario}
+          onAccept={onDelete}
+          onRefuse={() => setDelete(null)}
+          onDismiss={() => setDelete(null)}
+        />
+      </div>
     </AnimatePresence>
   );
 };

--- a/app/layout/projects/show/scenarios/component.tsx
+++ b/app/layout/projects/show/scenarios/component.tsx
@@ -1,11 +1,9 @@
 import React, { Fragment, useCallback, useState } from 'react';
 
 import { useQueryClient } from 'react-query';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { useRouter } from 'next/router';
-
-import { setFilters } from 'store/slices/projects/[id]';
 
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -34,13 +32,11 @@ import bgScenariosDashboard from 'images/bg-scenarios-dashboard.png';
 
 import DELETE_WARNING_SVG from 'svgs/notifications/delete-warning.svg?sprite';
 import PLUS_SVG from 'svgs/ui/plus.svg?sprite';
-import REMOVE_SVG from 'svgs/ui/remove.svg?sprite';
 
 export interface ProjectScenariosProps {
 }
 
 export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
-  const dispatch = useDispatch();
   const queryClient = useQueryClient();
   const { addToast } = useToasts();
 
@@ -63,7 +59,6 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
   } = useScenarios(pid, {
     filters: {
       projectId: pid,
-      ...filters,
     },
   });
 
@@ -259,37 +254,6 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
               >
                 <span className="mr-5">Create scenario</span>
                 <Icon icon={PLUS_SVG} className="w-4 h-4" />
-              </Button>
-            </div>
-          </motion.div>
-        )}
-
-        {!loading && filters && !rawScenariosData.length && (
-          <motion.div
-            key="project-scenarios-empty"
-            initial={{ y: -10, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: -10, opacity: 0 }}
-            className="flex items-center h-full pl-20 bg-gray-700 bg-right bg-no-repeat bg-contain rounded-4xl"
-            style={{
-              backgroundImage: `url(${bgScenariosDashboard})`,
-            }}
-          >
-            <div>
-              <h2 className="text-lg font-medium font-heading">
-                No scenarios found matching the current filters
-              </h2>
-
-              <h3 className="mt-1 text-lg font-medium text-gray-300 font-heading">Remove filters by clicking the button below</h3>
-
-              <Button
-                theme="primary"
-                size="lg"
-                className="mt-10"
-                onClick={() => dispatch(setFilters(null))}
-              >
-                <span className="mr-5">Remove filters</span>
-                <Icon icon={REMOVE_SVG} className="w-4 h-4" />
               </Button>
             </div>
           </motion.div>

--- a/app/layout/projects/show/scenarios/component.tsx
+++ b/app/layout/projects/show/scenarios/component.tsx
@@ -1,9 +1,11 @@
 import React, { Fragment, useCallback, useState } from 'react';
 
 import { useQueryClient } from 'react-query';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useRouter } from 'next/router';
+
+import { setFilters } from 'store/slices/projects/[id]';
 
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -32,11 +34,13 @@ import bgScenariosDashboard from 'images/bg-scenarios-dashboard.png';
 
 import DELETE_WARNING_SVG from 'svgs/notifications/delete-warning.svg?sprite';
 import PLUS_SVG from 'svgs/ui/plus.svg?sprite';
+import REMOVE_SVG from 'svgs/ui/remove.svg?sprite';
 
 export interface ProjectScenariosProps {
 }
 
 export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
+  const dispatch = useDispatch();
   const queryClient = useQueryClient();
   const { addToast } = useToasts();
 
@@ -59,6 +63,7 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
   } = useScenarios(pid, {
     filters: {
       projectId: pid,
+      ...filters,
     },
   });
 
@@ -78,6 +83,7 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
     },
     sort,
   });
+
   const scrollRef = useBottomScrollListener(
     () => {
       if (hasNextPage) allScenariosfetchNextPage();
@@ -216,7 +222,7 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
   return (
     <AnimatePresence>
       <div key="project-scenarios-sidebar" className="flex flex-col flex-grow col-span-7 overflow-hidden">
-        {!loading && !rawScenariosData.length && (
+        {!loading && !filters && !rawScenariosData.length && (
           <motion.div
             key="project-scenarios-empty"
             initial={{ y: -10, opacity: 0 }}
@@ -253,6 +259,37 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
               >
                 <span className="mr-5">Create scenario</span>
                 <Icon icon={PLUS_SVG} className="w-4 h-4" />
+              </Button>
+            </div>
+          </motion.div>
+        )}
+
+        {!loading && filters && !rawScenariosData.length && (
+          <motion.div
+            key="project-scenarios-empty"
+            initial={{ y: -10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -10, opacity: 0 }}
+            className="flex items-center h-full pl-20 bg-gray-700 bg-right bg-no-repeat bg-contain rounded-4xl"
+            style={{
+              backgroundImage: `url(${bgScenariosDashboard})`,
+            }}
+          >
+            <div>
+              <h2 className="text-lg font-medium font-heading">
+                No scenarios found matching the current filters
+              </h2>
+
+              <h3 className="mt-1 text-lg font-medium text-gray-300 font-heading">Remove filters by clicking the button below</h3>
+
+              <Button
+                theme="primary"
+                size="lg"
+                className="mt-10"
+                onClick={() => dispatch(setFilters(null))}
+              >
+                <span className="mr-5">Remove filters</span>
+                <Icon icon={REMOVE_SVG} className="w-4 h-4" />
               </Button>
             </div>
           </motion.div>

--- a/app/layout/projects/show/scenarios/filters/component.tsx
+++ b/app/layout/projects/show/scenarios/filters/component.tsx
@@ -18,7 +18,7 @@ export interface ProjectScenariosFiltersProps {
 const STATUS = [
   { id: 'created', label: 'Created' },
   { id: 'running', label: 'Running' },
-  { id: 'completed', label: 'Completed' },
+  { id: 'done', label: 'Completed' },
   { id: 'failure', label: 'Failed' },
 ];
 

--- a/app/layout/projects/show/scenarios/filters/component.tsx
+++ b/app/layout/projects/show/scenarios/filters/component.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react';
 import { Form as FormRFF, Field as FieldRFF } from 'react-final-form';
 
 import Button from 'components/button';
+import Checkbox from 'components/forms/checkbox';
 import Label from 'components/forms/label';
 import Radio from 'components/forms/radio';
 
@@ -14,11 +15,12 @@ export interface ProjectScenariosFiltersProps {
   onDismiss?: () => void;
 }
 
-// const STATUS = [
-//   { id: 'created', label: 'created' },
-//   { id: 'running', label: 'running' },
-//   { id: 'completed', label: 'completed' },
-// ];
+const STATUS = [
+  { id: 'created', label: 'Created' },
+  { id: 'running', label: 'Running' },
+  { id: 'completed', label: 'Completed' },
+  { id: 'failure', label: 'Failed' },
+];
 
 const SORT = [
   { id: '-lastModifiedAt', label: 'Most recent' },
@@ -66,7 +68,7 @@ export const ProjectScenariosFilters: React.FC<ProjectScenariosFiltersProps> = (
           <h2 className="pl-8 mb-5 text-lg pr-28 font-heading">Filters</h2>
 
           <div className="flex flex-col px-8 space-y-5">
-            {/* <div>
+            <div>
               <h3 className="flex-shrink-0 mb-2 text-sm pr-28 font-heading">Filter by type</h3>
               <div className="flex flex-col space-y-2">
                 {STATUS.map(({ id, label }) => {
@@ -87,7 +89,7 @@ export const ProjectScenariosFilters: React.FC<ProjectScenariosFiltersProps> = (
                   );
                 })}
               </div>
-            </div> */}
+            </div>
 
             <div>
               <h3 className="flex-shrink-0 mb-2 text-sm pr-28 font-heading">Order by</h3>

--- a/app/layout/projects/show/scenarios/toolbar/component.tsx
+++ b/app/layout/projects/show/scenarios/toolbar/component.tsx
@@ -56,9 +56,9 @@ export const ProjectScenariosToolbar: React.FC<ProjectScenariosToolbarProps> = (
   }, [dispatch]);
 
   useEffect(() => {
-    // setSearch to null whenever you unmount this component
     return function unmount() {
       dispatch(setSearch(null));
+      dispatch(setFilters([]));
     };
   }, [dispatch]);
 

--- a/app/layout/projects/show/scenarios/toolbar/component.tsx
+++ b/app/layout/projects/show/scenarios/toolbar/component.tsx
@@ -56,7 +56,7 @@ export const ProjectScenariosToolbar: React.FC<ProjectScenariosToolbarProps> = (
   }, [dispatch]);
 
   useEffect(() => {
-    // setSearch to null wheneverer you unmount this component
+    // setSearch to null whenever you unmount this component
     return function unmount() {
       dispatch(setSearch(null));
     };


### PR DESCRIPTION
### Overview

This PR adds Scenario (`run`) job status filtering.  
Filtering via API is not yet available, so the filtering is done on the frontend.   

**Notes:**  
- Filtering is currently done in the respective hook, so that we have it available seamlessly throughout the app   
  - The commented out modal code was kept virtually unchanged  
- The filters (only the `status` one) are not sent to the backend, as it'd return no results  
- Each scenario's run status is currently pulled from `api/v1/projects/{$projectId}/scenarios/status`, `run` job  
- The original property `status` returned by the backend is not being used, nor overwritten as one would be inclined to do. Couple reasons for this:  
    - Prevent conflicts when the backend implements that property  
    - The `ScenariosList` deals with all sorts of job statuses (not just the `run` one), this way it should be clear that it's not the same one sent by the backend, plus that way there was no need to remain a bunch of variables in that component  
- I have noticed that the backend can return 1 of 4 different statuses: `created`, `running`, `done`, `failure`. I've added filters for all of them. (`created` are scenarios that have been created but were never `run`)  
- Filters/Search/Sorting will be cleared when switching probjects  

**Other notes:**  
- I took the liberty to fix some typos in the code (mostly error messages, they wouldn't ever been seen by an user)  
- I also took the liberty of reorganising/refactoring the Scenarios#show component a little, because I have noticed that:      
   - Two consecutive API calls were being made to the same endpoint, with with `search`/`filters` and the other without (excluding `projectId`).  This would cause double the rendering as well.  
   - Both sets of returning data were a bit confusing, and not needed. If I had to take an educated guess, this would be from an initial stage of the project; possibly when searching was done in the frontend (which is no longer the case)  
    It's not perfect, but I mainly wanted to address the double-calls / double-rendering  

### Testing instructions

1. Create an empty project, with  no scenarios. Verify that:    
    - The pretty screen to create a new scenario is show  
    - The toolbar is not shown (search, filters)  
    - The create scenario button at the very bottom is not shown  
2. Create a few scenarios, ensure that:  
    - Search still works correctly  
    - Filters work correctly  
        - It may be needed to mock `job` statuses returned by the API, as it'll be hard to catch scenarios with a `running` and a `failure` statuses.   
     - Search + Filters together work correctly  
     - When there are no results, the appropriate message is shown  
     - The _"Clear all"_ button in the filters model clears all filters   
     - That when navigating to a new project, filters/search will be cleared  
       (it becomes a problem specially when switching to a project with no scenarios)

### Feature relevant tickets

[MARXAN-685](https://vizzuality.atlassian.net/browse/MARXAN-685)

### Screenshots  
<img width="877" alt="Screenshot 2022-01-10 at 15 11 53" src="https://user-images.githubusercontent.com/6273795/148789340-d287dce2-9ff9-4f39-a105-8bddb106a40d.png">

<img width="631" alt="Screenshot 2022-01-10 at 15 11 39" src="https://user-images.githubusercontent.com/6273795/148789328-4e0eb2ba-e76e-48d9-96d6-cec67a48c8a4.png">

