### PR TITLE
fix(front): adjust PU by uploading[MARXAN-1182]

### DIFF
--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/uploading/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/uploading/component.tsx
@@ -185,6 +185,12 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
 
   // Callbacks
   const onSubmit = useCallback((values) => {
+    const coordinates = [
+      Object.values(values.uploadingValue.features[0][0]).filter((i) => Array.isArray(i)),
+    ];
+    const { properties } = values.uploadingValue.features[0][0];
+    const { type: byGeoJsonType } = values.uploadingValue;
+
     setSubmitting(true);
     // Save current uploaded shape
     scenarioPUMutation.mutate({
@@ -195,7 +201,17 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
           exclude: puExcludedValue,
         },
         byGeoJson: {
-          [values.type]: [values.uploadingValue],
+          [values.type]: [{
+            type: byGeoJsonType,
+            features: [{
+              type: 'Feature',
+              geometry: {
+                type: 'Polygon',
+                coordinates,
+                properties,
+              },
+            }],
+          }],
         },
       },
     }, {


### PR DESCRIPTION
## Fix adjust PU by uploading file

### Overview

This PR comes to solve a problem of failure when adding or removing planning units to a scenario by uploading a file.
The problem was in the way the data was sent, so the solution has been to parse it.

### Testing instructions

- [ ] Go to a Brazil location scenario.
- [ ] Include PU by uploading a file (see attached file on JIRA task)
- [ ] Exclude PU by uploading a file  (see attached file on JIRA task)
- [ ] Be aware PU are include/exclude on map and legend counters.
- [ ] Be aware you can run scenario.

### Feature relevant tickets

[MARXAN-1182](https://vizzuality.atlassian.net/browse/MARXAN-1182)
