### PR TITLE
MARXAN-1179 All Users can view other users in private projects

### DIFF
--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
@@ -142,7 +142,7 @@ export class ProjectAclService implements ProjectAccessControl {
     userId: string,
     nameSearch?: string,
   ): Promise<Either<Denied, UserRoleInProjectDto[]>> {
-    if (!(await this.isOwner(userId, projectId))) {
+    if (!(await this.canViewProject(userId, projectId))) {
       return left(false);
     }
 

--- a/api/apps/api/test/access-control/project-acl/project-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl-get.e2e-spec.ts
@@ -28,7 +28,7 @@ test(`getting project users as viewer`, async () => {
   const projectId = await fixtures.GivenProjectWasCreated();
   await fixtures.GivenViewerWasAddedToProject(projectId);
   const response = await fixtures.WhenGettingProjectUsersAsViewer(projectId);
-  fixtures.ThenForbiddenIsReturned(response);
+  fixtures.ThenOwnerUserAndNewUserAddedToProjectAreReturned(response);
 });
 
 test(`getting project users as contributor`, async () => {
@@ -37,7 +37,7 @@ test(`getting project users as contributor`, async () => {
   const response = await fixtures.WhenGettingProjectUsersAsContributor(
     projectId,
   );
-  fixtures.ThenForbiddenIsReturned(response);
+  fixtures.ThenOwnerUserAndNewUserAddedToProjectAreReturned(response);
 });
 
 test(`getting project users as owner with a search query`, async () => {

--- a/api/apps/api/test/access-control/project-acl/project-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl-get.e2e-spec.ts
@@ -28,7 +28,7 @@ test(`getting project users as viewer`, async () => {
   const projectId = await fixtures.GivenProjectWasCreated();
   await fixtures.GivenViewerWasAddedToProject(projectId);
   const response = await fixtures.WhenGettingProjectUsersAsViewer(projectId);
-  fixtures.ThenOwnerUserAndNewUserAddedToProjectAreReturned(response);
+  fixtures.ThenOwnerAndViewerInProjectAreReturned(response);
 });
 
 test(`getting project users as contributor`, async () => {
@@ -37,7 +37,7 @@ test(`getting project users as contributor`, async () => {
   const response = await fixtures.WhenGettingProjectUsersAsContributor(
     projectId,
   );
-  fixtures.ThenOwnerUserAndNewUserAddedToProjectAreReturned(response);
+  fixtures.ThenOwnerAndContributorInProjectAreReturned(response);
 });
 
 test(`getting project users as owner with a search query`, async () => {

--- a/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
@@ -352,11 +352,34 @@ export const getFixtures = async () => {
       expect(newUserCreated.roleName).toEqual(projectOwnerRole);
     },
 
-    ThenOwnerUserAndNewUserAddedToProjectAreReturned: (
+    ThenOwnerAndViewerInProjectAreReturned: (response: request.Response) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(2);
+
+      const projectRoleNames: string[] = response.body.data.map(
+        (p: any) => p.roleName,
+      );
+
+      expect(projectRoleNames.sort()).toEqual([
+        projectOwnerRole,
+        projectViewerRole,
+      ]);
+    },
+
+    ThenOwnerAndContributorInProjectAreReturned: (
       response: request.Response,
     ) => {
       expect(response.status).toEqual(200);
       expect(response.body.data).toHaveLength(2);
+
+      const projectRoleNames: string[] = response.body.data.map(
+        (p: any) => p.roleName,
+      );
+
+      expect(projectRoleNames.sort()).toEqual([
+        projectContributorRole,
+        projectOwnerRole,
+      ]);
     },
 
     ThenAllUsersinProjectAfterEveryTypeOfUserHasBeenAddedAreReturned: (

--- a/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
@@ -352,6 +352,13 @@ export const getFixtures = async () => {
       expect(newUserCreated.roleName).toEqual(projectOwnerRole);
     },
 
+    ThenOwnerUserAndNewUserAddedToProjectAreReturned: (
+      response: request.Response,
+    ) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(2);
+    },
+
     ThenAllUsersinProjectAfterEveryTypeOfUserHasBeenAddedAreReturned: (
       response: request.Response,
     ) => {


### PR DESCRIPTION
- Replaced the method of finding users in projects so all roles can at least see each other. 
- Adapted tests. 