### PR TITLE
temporary workaround for error when loading bioregional features

### DIFF
--- a/app/hooks/features/index.ts
+++ b/app/hooks/features/index.ts
@@ -103,13 +103,25 @@ export function useAllFeatures(projectId, options: UseFeaturesOptionsProps = {})
         let splitFeaturesOptions = [];
 
         if (tag === 'bioregional') {
-          splitOptions = Object.keys(properties).map((k) => {
+          /**
+           * @todo Checking whether `properties` is defined here is just a
+           * workaround to avoid an error when processing `bioregional`
+           * features, which would prevent progressing through the stop of
+           * configuring features for a scenario until this code is reviewed.
+           * Without much knowledge of the flow for feature data, I see that
+           * short-circuiting the `map()` below and therefore setting
+           * `splitOptions = []` still results in properties being shown in the
+           * dropdowns used for splitting features, but since `properties` is
+           * always undefined (from what I can see), we may need to adapt the
+           * API payload or how we process it here.
+           */
+          splitOptions = properties ? Object.keys(properties).map((k) => {
             return {
               key: k,
               label: k,
               values: properties[k].map((v) => ({ id: v, name: v })),
             };
-          });
+          }): [];
 
           splitFeaturesOptions = splitSelected ? splitOptions
             .find((s) => s.key === splitSelected).values


### PR DESCRIPTION
Checking whether `properties` is defined here is just a workaround to avoid an error when processing `bioregional` features, which would prevent progressing through the stop of configuring features for a scenario until this code is reviewed.

Without much knowledge of the flow for feature data, I see that short-circuiting the `map()` below and therefore setting `splitOptions = []` still results in properties being shown in the dropdowns used for splitting features, but since `properties` is always undefined (from what I can see), we may need to adapt the API payload or how we process it here.

On the other hand: I started experiencing this error after loading the latest data dump (which now includes bioregional data) locally, however the app without the change in this PR and using m49 as backend (where we now have bioregional data) does work without triggering this error, so I am even more confused. But leaving this PR here for consideration as there may be something else we need to adapt (and I need this change in my local branches in any case or I can't work with the app).