### PR TITLE
fix(front): update features list after uploading new one[MARXAN-1189]

### DIFF
--- a/app/layout/scenarios/edit/features/add/list/component.tsx
+++ b/app/layout/scenarios/edit/features/add/list/component.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
+
+import { useSelector } from 'react-redux';
 
 import { useRouter } from 'next/router';
 
@@ -26,7 +28,9 @@ export const ScenariosFeaturesAddList: React.FC<ScenariosFeaturesAddListProps> =
   onToggleSelected,
 }: ScenariosFeaturesAddListProps) => {
   const { query } = useRouter();
-  const { pid } = query;
+  const { pid, sid } = query;
+
+  const { cache } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
 
   const {
     data: allFeaturesData,
@@ -35,6 +39,7 @@ export const ScenariosFeaturesAddList: React.FC<ScenariosFeaturesAddListProps> =
     isFetching: allFeaturesIsFetching,
     isFetchingNextPage: allFeaturesIsFetchingNextPage,
     isFetched: allFeaturesIsFetched,
+    refetch: allFeaturesDataRefetch,
   } = useAllFeatures(pid, {
     search,
     filters,
@@ -46,6 +51,12 @@ export const ScenariosFeaturesAddList: React.FC<ScenariosFeaturesAddListProps> =
       if (hasNextPage) allFeaturesfetchNextPage();
     },
   );
+
+  useEffect(() => {
+    return () => {
+      allFeaturesDataRefetch();
+    };
+  }, [cache, allFeaturesDataRefetch]);
 
   // Callbacks
   const handleToggleSelected = useCallback((id) => {

--- a/app/layout/scenarios/edit/features/add/uploader/component.tsx
+++ b/app/layout/scenarios/edit/features/add/uploader/component.tsx
@@ -5,8 +5,11 @@ import React, {
 import { FEATURES_UPLOADER_MAX_SIZE } from 'constants/file-uploader-size-limits';
 import { useDropzone } from 'react-dropzone';
 import { Form as FormRFF, Field as FieldRFF } from 'react-final-form';
+import { useDispatch } from 'react-redux';
 
 import { useRouter } from 'next/router';
+
+import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import cx from 'classnames';
 import { motion } from 'framer-motion';
@@ -39,9 +42,13 @@ export const ScenariosFeaturesAddUploader: React.FC<ScenariosFeaturesAddUploader
   const [successFile, setSuccessFile] = useState(null);
 
   const { query } = useRouter();
-  const { pid } = query;
+  const { pid, sid } = query;
 
   const { addToast } = useToasts();
+
+  const dispatch = useDispatch();
+  const scenarioSlice = getScenarioEditSlice(sid);
+  const { setCache } = scenarioSlice.actions;
 
   const uploadFeaturesShapefileMutation = useUploadFeaturesShapefile({
     requestConfig: {
@@ -109,8 +116,8 @@ export const ScenariosFeaturesAddUploader: React.FC<ScenariosFeaturesAddUploader
       onSuccess: ({ data: { data: g, id: shapefileId } }) => {
         setLoading(false);
         setSuccessFile({ ...successFile });
+        dispatch(setCache(Date.now()));
         onClose();
-
         addToast('success-upload-feature-shapefile', (
           <>
             <h2 className="font-medium">Success!</h2>
@@ -142,7 +149,15 @@ export const ScenariosFeaturesAddUploader: React.FC<ScenariosFeaturesAddUploader
         });
       },
     });
-  }, [pid, addToast, onClose, uploadFeaturesShapefileMutation]);
+  }, [
+    pid,
+    addToast,
+    onClose,
+    uploadFeaturesShapefileMutation,
+    successFile,
+    dispatch,
+    setCache,
+  ]);
 
   const {
     getRootProps,


### PR DESCRIPTION
## Update features list after uploading new one

### Overview

This PR contains the fix of an error related to updating all the features in the modal to add new features. It was detected that when uploading a new feature, the change was not reflected in the list unless the user closed the modal and reopened it.

### Testing instructions

- [ ] Add a new feature by uploading. (See attached file on JIRA task). 
- [ ] Classify it as bioregional.
- [ ] Check if features list is automatically updated on upload modal.

### Feature relevant tickets

[MARXAN-1189](https://vizzuality.atlassian.net/browse/MARXAN-1189)