### PR TITLE
[MARXAN-1190] Fixing bad dispatch calls in the WDPACategories and ScenariosFeaturesList forms

### DIFF
--- a/app/layout/scenarios/edit/features/list/component.tsx
+++ b/app/layout/scenarios/edit/features/list/component.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback, useMemo, useState,
+} from 'react';
 
 import { Form as FormRFF, FormSpy as FormSpyRFF, Field as FieldRFF } from 'react-final-form';
 import { useQueryClient } from 'react-query';
@@ -267,8 +269,12 @@ export const ScenariosFeaturesList: React.FC<ScenariosFeaturesListProps> = ({
       {({ handleSubmit, values }) => (
         <form onSubmit={handleSubmit} autoComplete="off" className="relative flex flex-col flex-grow overflow-hidden">
           <FormSpyRFF
-            subscription={{ dirty: true }}
-            onChange={() => dispatch(setFeatures(values.features))}
+            subscription={{ dirty: true, touched: true }}
+            onChange={(state) => {
+              if (state.touched.features) {
+                dispatch(setFeatures(values.features));
+              }
+            }}
           />
 
           <Loading

--- a/app/layout/scenarios/edit/wdpa/categories/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/categories/component.tsx
@@ -132,6 +132,14 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
     }
   }, [scenarioData.wdpaThreshold]); //eslint-disable-line
 
+  useEffect(() => {
+    dispatch(setWDPACategories(INITIAL_VALUES));
+    // We need to setWDPACategories' initial values on first render only.
+    // The way to pull this off is to add no dependencies to useEffect, but
+    // eslint will complain about it. So we disable this check.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Loading
   if ((scenarioIsFetching && !scenarioIsFetched) || (wdpaIsFetching && !wdpaIsFetched)) {
     return (
@@ -189,12 +197,17 @@ export const WDPACategories: React.FC<WDPACategoriesProps> = ({
             autoComplete="off"
             className="relative flex flex-col flex-grow w-full overflow-hidden"
           >
-            <FormSpyRFF onChange={(state) => {
-              dispatch(setWDPACategories(state.values));
-              if (state.touched.uploadedProtectedArea) {
-                refetchProtectedAreas();
-              }
-            }}
+            <FormSpyRFF
+              subscription={{ dirty: true, touched: true }}
+              onChange={(state) => {
+                if (state.touched.wdpaIucnCategories) {
+                  dispatch(setWDPACategories(values));
+                }
+
+                if (state.touched.uploadedProtectedArea) {
+                  refetchProtectedAreas();
+                }
+              }}
             />
 
             <div className="relative flex flex-col flex-grow overflow-hidden">


### PR DESCRIPTION
### Overview

Those two components' forms's dispatch actions updating the store, causing other components to re-render, before the user even touching any input. 

- `WDPACategories` Component
    `setWDPACategories` ended up being the culprit here. Instead of making the call inside the `render` method, we can simply use an `useEffect` hook to set the initial values on the very first render (hence the empty dependencies list). The store will then only be updated when the actual list of values changes, no matter how many times the component re-renders. 

- `ScenariosFeaturesList`   
    Similar issue here, except the culprit was `setFeatures`. Setting the initial values is not needed (and will break the app). 

### Testing instructions

Create a scenario and go through the flow with the browser console open. Ensure that:  
- [ ] `WDPACategories` doesn't throw this particular error while in the _"Protected areas"_ tab  
- [ ] `ScenariosFeaturesList` doesn't throw this particular error while in the _"Features"_ tab  
- [ ] The app's behaviour has not changed  

### Feature relevant tickets

[MARXAN-1190](https://vizzuality.atlassian.net/browse/MARXAN-1190)

### Console
![Screenshot 2022-01-13 at 12 44 45](https://user-images.githubusercontent.com/6273795/149350311-3637d790-9ae9-457d-a145-2be39ddcb568.png)

![Screenshot 2022-01-13 at 12 59 53](https://user-images.githubusercontent.com/6273795/149350293-90c42695-30a3-47fa-be6d-e38929716a0f.png)

