### PR TITLE
[MARXAN-1191] Fixing sliders' issues (cut off labels, floating point errors)

### DIFF
--- a/app/components/forms/slider/value/component.tsx
+++ b/app/components/forms/slider/value/component.tsx
@@ -56,7 +56,8 @@ export const Value: React.FC<ValueProps> = ({
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
   // Percentages come in a range from 0.0 to 1, so we have to multiply by 100 to display them
-  const displayValue = (formatOptions.style === 'percent') ? value * 100 : value;
+  // Due to floating point precision issues, we need to trunc percentages' display values
+  const displayValue = (formatOptions.style === 'percent') ? Math.round(value * 100) : value;
 
   // CANCELLING AND SAVING EDITS
 

--- a/app/layout/scenarios/edit/wdpa/threshold/component.tsx
+++ b/app/layout/scenarios/edit/wdpa/threshold/component.tsx
@@ -272,21 +272,23 @@ export const WDPAThreshold: React.FC<WDPAThresholdCategories> = ({
                           be covered by a protected area to be considered “protected”.
                         </p>
 
-                        <Slider
-                          labelRef={labelRef}
-                          theme="dark"
-                          defaultValue={values.wdpaThreshold}
-                          formatOptions={{
-                            style: 'percent',
-                          }}
-                          maxValue={1}
-                          minValue={0.01}
-                          step={0.01}
-                          onChange={(s) => {
-                            flprops.input.onChange(s);
-                            dispatch(setWDPAThreshold(s));
-                          }}
-                        />
+                        <div className="px-5">
+                          <Slider
+                            labelRef={labelRef}
+                            theme="dark"
+                            defaultValue={values.wdpaThreshold}
+                            formatOptions={{
+                              style: 'percent',
+                            }}
+                            maxValue={1}
+                            minValue={0.01}
+                            step={0.01}
+                            onChange={(s) => {
+                              flprops.input.onChange(s);
+                              dispatch(setWDPAThreshold(s));
+                            }}
+                          />
+                        </div>
                       </Field>
                     )}
                   </FieldRFF>


### PR DESCRIPTION
### Overview

This PR addresses a couple of issues with the (percentage) Sliders:  

1. Sliders' labels being cut off when the slider is set at either `0%` or `100%`  
    Unfortunately this is due to how the scrolling of the the component's contents (when the contents don't fit vertically) works. This requires an `overflow-hidden` in the parent components, which is effectively why these labels get hidden.

    We could rework this, but this would require us setting correct paddings in all the sections manually (instead of letting the `Pill` component standardise them. 

    Alternatively, we can make the sliders shorter width-wise just enough to let the labels fit, which was the step taken here. I noticed that in the _Features_ section the sliders are inset so this doesn't stray from the designs much. 

2. Sliders' percentages have floating point precision errors.  
    We know the percentage will always be an integer, so we can just round them. 

### Testing instructions

Navigate to the _"Protected Areas"_ tab of a project, section `2/2`, and verify that:  
- [ ] When setting sliders to either `0%` or `100%`, the label above the thumb doesn't get cut off 
- [ ] Trying multiple values (40-60 range is usually where I get the bug triggered), click on the label and verify that the number is always an integer  

### Feature relevant tickets

[MARXAN-1187](https://vizzuality.atlassian.net/browse/MARXAN-1187)
[MARXAN-1191](https://vizzuality.atlassian.net/browse/MARXAN-1191)

### Screenshots  
<img width="732" alt="Screenshot 2022-01-13 at 16 33 56" src="https://user-images.githubusercontent.com/6273795/149370505-7d0687e7-6832-4b03-88a3-a67867e97202.png">
<img width="744" alt="Screenshot 2022-01-13 at 16 33 50" src="https://user-images.githubusercontent.com/6273795/149370514-c30da7ec-f88c-4ff9-9ae4-1054fc2bafb0.png">
<img width="753" alt="Screenshot 2022-01-13 at 16 35 39" src="https://user-images.githubusercontent.com/6273795/149370771-e5fc68f0-1e0a-42e4-8927-f1a685972d1f.png">

