### PR TITLE
Fixing bad padding when project has no scenarios yet

### DIFF
--- a/app/layout/projects/show/scenarios/component.tsx
+++ b/app/layout/projects/show/scenarios/component.tsx
@@ -221,52 +221,58 @@ export const ProjectScenarios: React.FC<ProjectScenariosProps> = () => {
           )}
 
           <div className="relative overflow-hidden" id="scenarios-list">
-            <div ref={scrollRef} className="relative z-0 flex flex-col flex-grow h-full py-6 overflow-x-hidden overflow-y-auto">
-              {!hasScenarios && (search || hasFilters) && (
+            {!hasScenarios && (search || hasFilters) && (
+              <div className="py-6">
                 <>No results found</>
-              )}
+              </div>
+            )}
 
-              {hasScenarios && scenariosData.map((s, i) => {
-                const TAG = i === 0 ? HelpBeacon : Fragment;
+            {hasScenarios && (
+              <div ref={scrollRef} className="relative z-0 flex flex-col flex-grow h-full py-6 overflow-x-hidden overflow-y-auto">
+                {scenariosData.map((s, i) => {
+                  const TAG = i === 0 ? HelpBeacon : Fragment;
 
-                return (
-                  <TAG
-                    key={`${s.id}`}
-                    {...i === 0 && {
-                      id: `project-scenario-${s.id}`,
-                      title: 'Scenario list',
-                      subtitle: 'List and detail overview',
-                      content: (
-                        <div>
-                          Here you can see listed all the scenarios under the same project.
-                          You can access a scenario and edit it at any time, unless there is
-                          a contributor working on the same scenario. In this case, you will
-                          see a warning.
-                        </div>
-                      ),
-                    }}
-                  >
-                    <div
-                      className={cx({
-                        'mt-3': i !== 0,
-                      })}
+                  return (
+                    <TAG
+                      key={`${s.id}`}
+                      {...i === 0 && {
+                        id: `project-scenario-${s.id}`,
+                        title: 'Scenario list',
+                        subtitle: 'List and detail overview',
+                        content: (
+                          <div>
+                            Here you can see listed all the scenarios under the same project.
+                            You can access a scenario and edit it at any time, unless there is
+                            a contributor working on the same scenario. In this case, you will
+                            see a warning.
+                          </div>
+                        ),
+                      }}
                     >
-                      <ScenarioItem
-                        {...s}
-                        onDelete={() => {
-                          setDelete(s);
-                        }}
-                        onDuplicate={() => onDuplicate(s.id, s.name)}
-                        onCancelRun={() => onCancelRun(s.id, s.name)}
-                        SettingsC={<ScenarioSettings sid={s.id} />}
-                      />
+                      <div
+                        className={cx({
+                          'mt-3': i !== 0,
+                        })}
+                      >
+                        <ScenarioItem
+                          {...s}
+                          onDelete={() => {
+                            setDelete(s);
+                          }}
+                          onDuplicate={() => onDuplicate(s.id, s.name)}
+                          onCancelRun={() => onCancelRun(s.id, s.name)}
+                          SettingsC={<ScenarioSettings sid={s.id} />}
+                        />
 
-                    </div>
-                  </TAG>
-                );
-              })}
-            </div>
+                      </div>
+                    </TAG>
+                  );
+                })}
+              </div>
+            )}
+
             <div className="absolute bottom-0 left-0 z-10 w-full h-6 pointer-events-none bg-gradient-to-t from-black via-black" />
+
             <div
               className={cx({
                 'opacity-100': scenariosIsFetchingNextPage,


### PR DESCRIPTION
### Overview

This PR fixes a bug introduced in https://github.com/Vizzuality/marxan-cloud/pull/740, which caused excessive padding in the Project view, when the project has no Scenarios. See screenshots below for more details. 

### Feature relevant tickets

[MARXAN-1193](https://vizzuality.atlassian.net/browse/MARXAN-1193)

### Screenshots 

**Before:**  
<img width="1478" alt="Screenshot 2022-01-14 at 10 25 04" src="https://user-images.githubusercontent.com/6273795/149519804-d40067a9-7014-4104-956d-c8769789daa8.png">

**After:**  
<img width="1484" alt="Screenshot 2022-01-14 at 13 05 42" src="https://user-images.githubusercontent.com/6273795/149519927-0bf1645e-ee94-478b-9f00-1601adfbf73a.png">

