### PR TITLE
[MARXAN-1195] Fixing adjusting planning units triggering a dispatch/render loop

### DIFF
--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/clicking/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/clicking/component.tsx
@@ -94,7 +94,6 @@ export const AnalysisAdjustClicking: React.FC<AnalysisAdjustClickingProps> = ({
     }, {
       onSuccess: ({ data: { meta } }) => {
         dispatch(setJob(new Date(meta.isoDate).getTime()));
-        setSubmitting(false);
         onSelected(null);
         dispatch(setClicking(false));
 
@@ -110,7 +109,6 @@ export const AnalysisAdjustClicking: React.FC<AnalysisAdjustClickingProps> = ({
         });
       },
       onError: () => {
-        setSubmitting(false);
         addToast('adjust-planning-units-error', (
           <>
             <h2 className="font-medium">Error!</h2>
@@ -121,6 +119,9 @@ export const AnalysisAdjustClicking: React.FC<AnalysisAdjustClickingProps> = ({
         ), {
           level: 'error',
         });
+      },
+      onSettled: () => {
+        setSubmitting(false);
       },
     });
   }, [sid,

--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/drawing/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/drawing/component.tsx
@@ -99,7 +99,6 @@ export const AnalysisAdjustDrawing: React.FC<AnalysisAdjustDrawingProps> = ({
       onSuccess: ({ data: { meta } }) => {
         // Let's wait unitl we can track fast async jobs
         dispatch(setJob(new Date(meta.isoDate).getTime()));
-        setSubmitting(false);
         onSelected(null);
         dispatch(setDrawing(null));
         dispatch(setDrawingValue(null));
@@ -116,7 +115,6 @@ export const AnalysisAdjustDrawing: React.FC<AnalysisAdjustDrawingProps> = ({
         });
       },
       onError: () => {
-        setSubmitting(false);
         addToast('adjust-planning-units-error', (
           <>
             <h2 className="font-medium">Error!</h2>
@@ -127,6 +125,9 @@ export const AnalysisAdjustDrawing: React.FC<AnalysisAdjustDrawingProps> = ({
         ), {
           level: 'error',
         });
+      },
+      onSettled: () => {
+        setSubmitting(false);
       },
     });
   }, [

--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/uploading/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/buttons/uploading/component.tsx
@@ -97,7 +97,6 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
 
     uploadScenarioPUMutation.mutate({ id: `${sid}`, data }, {
       onSuccess: ({ data: { data: g } }) => {
-        setLoading(false);
         setSuccessFile({ id: g.id, name: f.name });
 
         addToast('success-upload-shapefile', (
@@ -125,7 +124,6 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
       onError: ({ response }) => {
         const { errors } = response.data;
 
-        setLoading(false);
         setSuccessFile(null);
 
         addToast('error-upload-shapefile', (
@@ -140,6 +138,9 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
         ), {
           level: 'error',
         });
+      },
+      onSettled: () => {
+        setLoading(false);
       },
     });
   };
@@ -217,7 +218,6 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
     }, {
       onSuccess: ({ data: { meta } }) => {
         dispatch(setJob(new Date(meta.isoDate).getTime()));
-        setSubmitting(false);
         onSelected(null);
         dispatch(setUploading(false));
         dispatch(setUploadingValue(null));
@@ -235,7 +235,6 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
         });
       },
       onError: () => {
-        setSubmitting(false);
         addToast('adjust-planning-units-error', (
           <>
             <h2 className="font-medium">Error!</h2>
@@ -246,6 +245,9 @@ export const AnalysisAdjustUploading: React.FC<AnalysisAdjustUploadingProps> = (
         ), {
           level: 'error',
         });
+      },
+      onSettled: () => {
+        setSubmitting(false);
       },
     });
   }, [

--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import { motion } from 'framer-motion';
+import { xor } from 'lodash';
 
 import { useScenarioPU, useSaveScenarioPU } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
@@ -33,10 +34,12 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
 }: ScenariosSidebarAnalysisSectionsProps) => {
   const [clearing, setClearing] = useState(false);
 
+  const dispatch = useDispatch();
   const { query } = useRouter();
   const { sid } = query;
 
   const scenarioSlice = getScenarioEditSlice(sid);
+
   const {
     setJob,
     setPUAction,
@@ -45,8 +48,15 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
     setTmpPuIncludedValue,
     setTmpPuExcludedValue,
   } = scenarioSlice.actions;
-  const dispatch = useDispatch();
-  const { puAction } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
+
+  const {
+    clicking,
+    puAction,
+    puIncludedValue,
+    puExcludedValue,
+    puTmpIncludedValue,
+    puTmpExcludedValue,
+  } = useSelector((state) => state[`/scenarios/${sid}/edit`]);
 
   const { addToast } = useToasts();
 
@@ -56,10 +66,30 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
   useEffect(() => {
     if (PUData && PUisFetched) {
       const { included, excluded } = PUData;
-      dispatch(setPuIncludedValue(included));
-      dispatch(setPuExcludedValue(excluded));
-      dispatch(setTmpPuIncludedValue(included));
-      dispatch(setTmpPuExcludedValue(excluded));
+
+      // If PUData.included is different from puIncluded
+      if (xor(included, puIncludedValue).length > 0) {
+        dispatch(setPuIncludedValue(included));
+      }
+
+      // If PUData.excluded is different from puExcluded
+      if (xor(excluded, puExcludedValue).length > 0) {
+        dispatch(setPuExcludedValue(excluded));
+      }
+
+      // If the user is clicking on the map, we don't want to touch the
+      // temporary PU included/excluded values as they're being handled.
+      if (clicking) return;
+
+      // If PUData.included is different from tmp puIncluded
+      if (xor(included, puTmpIncludedValue).length > 0) {
+        dispatch(setTmpPuIncludedValue(included));
+      }
+
+      // If PUData.excluded is different from tmp puExcluded
+      if (xor(excluded, puTmpExcludedValue).length > 0) {
+        dispatch(setTmpPuExcludedValue(excluded));
+      }
     }
   }, [PUData]); //eslint-disable-line
 

--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
@@ -123,7 +123,6 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
         ), {
           level: 'success',
         });
-        setClearing(false);
       },
       onError: () => {
         addToast('clear-planning-units-error', (
@@ -136,6 +135,8 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
         ), {
           level: 'error',
         });
+      },
+      onSettled: () => {
         setClearing(false);
       },
     });

--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
@@ -91,7 +91,20 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
         dispatch(setTmpPuExcludedValue(excluded));
       }
     }
-  }, [PUData]); //eslint-disable-line
+  }, [
+    PUData,
+    PUisFetched,
+    clicking,
+    dispatch,
+    puExcludedValue,
+    puIncludedValue,
+    puTmpExcludedValue,
+    puTmpIncludedValue,
+    setPuExcludedValue,
+    setPuIncludedValue,
+    setTmpPuExcludedValue,
+    setTmpPuIncludedValue,
+  ]);
 
   const onChangeTab = useCallback((t) => {
     dispatch(setPUAction(t));

--- a/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
+++ b/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
@@ -101,6 +101,10 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
     const { includedDefault, excludedDefault } = PUData;
     setClearing(true);
 
+    // Clear all temp PU values
+    dispatch(setTmpPuIncludedValue(includedDefault));
+    dispatch(setTmpPuExcludedValue(excludedDefault));
+
     // Save current clicked pu ids
     scenarioPUMutation.mutate({
       id: `${sid}`,
@@ -140,7 +144,16 @@ export const ScenariosSidebarAnalysisSections: React.FC<ScenariosSidebarAnalysis
         setClearing(false);
       },
     });
-  }, [sid, PUData, scenarioPUMutation, addToast, dispatch, setJob]);
+  }, [
+    PUData,
+    dispatch,
+    scenarioPUMutation,
+    sid,
+    setJob,
+    setTmpPuIncludedValue,
+    setTmpPuExcludedValue,
+    addToast,
+  ]);
 
   return (
     <motion.div


### PR DESCRIPTION
### Overview

This PR mainly addresses an issue with the [ScenariosSidebarAnalysisSections](https://github.com/Vizzuality/marxan-cloud/blob/develop/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx) component. It uses an `useEffect` hook to update all `puIncludedValue`, `puExcludedValue`, `puTmpIncludedValue`, `puTmpExcludedValue`, with `PUData` (which comes from the API) which ends up running on every render.  

However, a dispatch for any of those _will_ trigger a re-render; this is particularly problematic when the user chooses to _"Select planning units"_, the respective `AnalysisAdjustClicking` component (along with any click) will be setting `puTmpIncludedValue`, `puTmpExcludedValue` causing a loop. 

&nbsp;

The main solution implemented was to check whether the user is using that method, and prevent setting `puTmpIncludedValue`, `puTmpExcludedValue`, which will already be set, which in turn stops the loop.

In order to prevent similar issues down the line, I took the liberty to compare `PUData`'s `include`/`exclude` to the existing arrays in the store, so that we don't update the store unnecessarily (triggering re-renders throughout the app), (using lodash's [xor](https://lodash.com/docs/4.17.15#xor) to check whether the arrays are equivalent, even if the order of their elements is different).  

&nbsp;  

Additionally, I noticed that the _"Clear"_ button doesn't work as one would expect. It does do its expected job of clearing PU included/excluded values, when the user isn't in the middle of selecting planning units, but it won't clear the temporary ones "in progress", so I made sure to clear those as well, so that the map is truly reset to consistent values as those coming from the API. 


&nbsp; 


### Testing instructions

This bug requires testing the code locally. 

Add a `console.log('RENDER');` to either (well, ideally both): 
```
/app/layout/scenarios/edit/analysis/adjust-planning-units/component.tsx
/app/layout/scenarios/edit/analysis/component.tsx
```

Then: 
- Open a Project   
- Click _"Edit"_ on a Scenario  
- Click the _"Analysis"_ tab  
- Click the _"Adjust planning units"_  section  
- Adjust planning units using all three methods, for both _"Include areas"_ and _"Exclude areas"_  
- Verify that:  
    - [x] Adjusting the planning units works correctly on all scenarios/methods, both when including and excluding areas   
    - [x] There is no `RENDER` loop in the console  
        There'll be multiple renders, but it should never enter a loop. It'll be obvious if it happens. 

### Feature relevant tickets

- [MARXAN-1195](https://vizzuality.atlassian.net/browse/MARXAN-1195)
- [MARXAN-1067](https://vizzuality.atlassian.net/browse/MARXAN-1067) (Possibly the ultimate fix for this one as well)  
