### PR TITLE
Changing text displayed while features are being processed

### DIFF
--- a/app/layout/scenarios/edit/status/component.tsx
+++ b/app/layout/scenarios/edit/status/component.tsx
@@ -106,7 +106,7 @@ export const ScenarioStatus: React.FC<ScenarioStatusProps> = () => {
             <p className="text-xs tracking-wide text-center font-heading">
               This task may take some time.
               <br />
-              Meanwhile, you can go to the project and do some other stuff.
+              You can wait here or go back to your project dashboard.
             </p>
             <div className="flex justify-center space-x-2">
               {/* <Button


### PR DESCRIPTION
### Overview

This PR updates the message displayed to the user while features are being processed. 

### Testing instructions

Ensure that when the loading screen appears after editing features, the text is correctly updated. This may require the Network speed to be limited with the DevTools ("Slow 3G" works well for me to test this).  

### Feature relevant tickets

[MARXAN-1045](https://vizzuality.atlassian.net/browse/MARXAN-1045)

### Screenshot  

<img width="1792" alt="Screenshot 2022-01-17 at 17 22 59" src="https://user-images.githubusercontent.com/6273795/149813984-e4f3b24d-f7de-44c2-8afe-c587ab8a4482.png">

