### PR TITLE
avoid fetching geo columns when not needed [MARXAN-1111]

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -172,6 +172,7 @@ export class GeoFeaturesService extends AppBaseService<
     if (projectId && info?.params?.bbox) {
       const geoFeaturesWithinProjectBbox = await this.geoFeaturesGeometriesRepository
         .createQueryBuilder('geoFeatureGeometries')
+        .select('"geoFeatureGeometries"."feature_id"', 'featureId')
         .distinctOn(['"geoFeatureGeometries"."feature_id"'])
         .where(
           `st_intersects(
@@ -185,7 +186,7 @@ export class GeoFeaturesService extends AppBaseService<
             ymax: info.params.bbox[2],
           },
         )
-        .getMany()
+        .getRawMany()
         .then((result) => result.map((i) => i.featureId))
         .catch((error) => {
           throw new Error(error);


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1111

The previous implementation would not restrict the set of columns queried, resulting in potentially very large response payloads from db as well as correspondingly high memory usage while parsing the result set to, essentially, only select ids.

The present change limits the select to the id column we need.