### PR TITLE
avoid fetching `theGeom` by default from db

### DIFF
--- a/api/apps/api/src/modules/countries/country.geo.entity.ts
+++ b/api/apps/api/src/modules/countries/country.geo.entity.ts
@@ -54,7 +54,10 @@ export class Country {
    * type.
    */
   @ApiProperty()
-  @Column('geometry', { name: 'the_geom' })
+  @Column('geometry', {
+    select: false,
+    name: 'the_geom',
+  })
   theGeom!: Geometry;
 
   /**

--- a/api/apps/api/test/countries.e2e-spec.ts
+++ b/api/apps/api/test/countries.e2e-spec.ts
@@ -130,7 +130,6 @@ describe('CountriesModule (e2e)', () => {
           maxPuAreaSize: 1252305,
           minPuAreaSize: 136,
           name0: 'Angola',
-          theGeom: expect.any(Object),
         },
         id: 'AGO',
         type: 'countries',


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1197

The missing column configuration to exclude `theGeom` from selects by default via QueryBuilder was causing operations such as plain lists of country names and ids to take way longer than they should.

The `select: false` setting was applied to the `AdminArea` entity but had not been set on the `Country` entity: this change fixes this. Raw db query goes from >1sec to <10ms with this PR (then we have node/nest overhead, but still...)
