### PR TITLE
[MARXAN-1048] Improve "Set target and SPF in all features"

### DIFF
--- a/app/components/features/target-spf-item/component.tsx
+++ b/app/components/features/target-spf-item/component.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
+
 import cx from 'classnames';
+
 import Button from 'components/button';
-import Slider from 'components/forms/slider';
-import Label from 'components/forms/label';
 import Input from 'components/forms/input';
+import Label from 'components/forms/label';
+import Slider from 'components/forms/slider';
 
 import { TargetSPFItemProps, Type } from './types';
 
@@ -22,6 +24,8 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
   onChangeFPF,
 }: TargetSPFItemProps) => {
   const [targetValue, setTargetValue] = useState((target || defaultTarget) / 100);
+  const [inputTargetValue, setInputTargetValue] = useState(targetValue);
+  const [targetInputFocused, setTargetInputFocused] = useState(false);
   const [FPFValue, setFPFValue] = useState(fpf || defaultFPF);
   const sliderLabelRef = useRef(null);
 
@@ -32,6 +36,11 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
   useEffect(() => {
     if (typeof fpf !== 'undefined') setFPFValue(fpf);
   }, [fpf]);
+
+  useEffect(() => {
+    const percentValue = Math.round(targetValue * 100);
+    setInputTargetValue(percentValue);
+  }, [targetValue]);
 
   return (
     <div
@@ -50,54 +59,84 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
         })}
       />
       <div className="flex items-start justify-between pb-2 pr-2">
-        <span className="pr-5 text-sm font-medium font-heading">{isAllTargets ? 'Set target and SPF in all features' : name}</span>
-        {!isAllTargets && (
-          <Button
-            className="flex-shrink-0 text-xs"
-            theme="secondary"
-            size="xs"
-            onClick={() => onRemove && onRemove(id)}
-          >
-            Remove
-          </Button>
-        )}
-      </div>
-      <div className="flex">
-        <div className="relative flex-col w-full pr-4">
-          <Label ref={sliderLabelRef} className="mb-1 uppercase">
-            <span>{isAllTargets ? 'ALL TARGETS' : 'TARGET'}</span>
-          </Label>
-          <Slider
-            labelRef={sliderLabelRef}
-            minValue={0}
-            maxValue={1}
-            value={targetValue}
-            step={0.01}
-            onChange={(sliderValue) => {
-              setTargetValue(sliderValue);
-              if (onChangeTarget) onChangeTarget(+(sliderValue * 100).toFixed(0));
-            }}
-          />
-          <div className="flex justify-between w-full text-gray-400">
-            <span>0%</span>
-            <span>100%</span>
+        <div className="flex flex-col flex-grow">
+          <div className="w-full pr-5 text-sm font-medium font-heading">
+            {isAllTargets ? 'Set target and SPF in all features' : name}
           </div>
-        </div>
-        <div className="flex flex-col justify-between w-24 px-4 border-l">
-          <span>{isAllTargets ? 'ALL SPF' : 'SPF'}</span>
-          <div className="w-10 mb-6">
-            <Input
-              className="px-0 py-1"
-              theme="dark"
-              mode="dashed"
-              type="number"
-              value={FPFValue}
-              onChange={({ target: { value: inputValue } }) => {
-                setFPFValue(Number(inputValue));
-                if (onChangeFPF) onChangeFPF(Number(inputValue));
+          <div className="flex justify-between items-center mt-4">
+            <div className="flex items-center">
+              <Label ref={sliderLabelRef} className="uppercase w-16">
+                {isAllTargets ? 'ALL TARGETS' : 'TARGET'}
+              </Label>
+              <Input
+                className="w-16 text-center text-sm"
+                theme="dark"
+                type={targetInputFocused ? 'number' : 'text'}
+                min={0}
+                max={100}
+                step={1}
+                value={targetInputFocused ? inputTargetValue : `${inputTargetValue}%`}
+                onFocusChange={setTargetInputFocused}
+                onChange={((event) => {
+                  const percentValue = parseInt(event.target.value, 10);
+                  if (percentValue < 0 || percentValue > 100) return;
+                  setInputTargetValue(percentValue);
+                })}
+                onBlur={() => {
+                  // Prevent changing all targets if user didn't actually change it
+                  // (despite clicking on the input)
+                  if (Math.round(targetValue * 100) === inputTargetValue) return;
+                  setTargetValue(inputTargetValue / 100);
+                  if (onChangeTarget) onChangeTarget(inputTargetValue);
+                }}
+              />
+            </div>
+            <div className="flex items-center">
+              <span>{isAllTargets ? 'ALL SPF' : 'SPF'}</span>
+              <Input
+                className="w-16 ml-3 text-center text-sm"
+                theme="dark"
+                type="number"
+                value={FPFValue}
+                onChange={({ target: { value: inputValue } }) => {
+                  setFPFValue(Number(inputValue));
+                  if (onChangeFPF) onChangeFPF(Number(inputValue));
+                }}
+              />
+            </div>
+          </div>
+          <div className="relative flex flex-col">
+            <Slider
+              labelRef={sliderLabelRef}
+              minValue={0}
+              maxValue={1}
+              value={targetValue}
+              step={0.01}
+              showValue={false}
+              onChange={(sliderValue) => {
+                const percentValue = +(sliderValue * 100).toFixed(0);
+                setTargetValue(sliderValue);
+                setInputTargetValue(percentValue);
+                if (onChangeTarget) onChangeTarget(percentValue);
               }}
             />
+            <div className="flex justify-between -mt-3 text-gray-400">
+              <span>0%</span>
+              <span>100%</span>
+            </div>
           </div>
+        </div>
+        <div className="flex justify-end w-28">
+          {!isAllTargets && (
+            <Button
+              className="flex-shrink-0 text-xs"
+              theme="secondary"
+              size="xs"
+              onClick={() => onRemove && onRemove(id)}
+            >
+              Remove
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/app/components/features/target-spf-item/component.tsx
+++ b/app/components/features/target-spf-item/component.tsx
@@ -24,9 +24,12 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
   onChangeFPF,
 }: TargetSPFItemProps) => {
   const [targetValue, setTargetValue] = useState((target || defaultTarget) / 100);
-  const [inputTargetValue, setInputTargetValue] = useState(targetValue);
+  const [inputTargetValue, setInputTargetValue] = useState(String(targetValue));
   const [targetInputFocused, setTargetInputFocused] = useState(false);
+
   const [FPFValue, setFPFValue] = useState(fpf || defaultFPF);
+  const [inputFPFValue, setInputFPFValue] = useState(String(FPFValue));
+
   const sliderLabelRef = useRef(null);
 
   useEffect(() => {
@@ -39,8 +42,12 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
 
   useEffect(() => {
     const percentValue = Math.round(targetValue * 100);
-    setInputTargetValue(percentValue);
+    setInputTargetValue(String(percentValue));
   }, [targetValue]);
+
+  useEffect(() => {
+    setInputFPFValue(String(FPFValue));
+  }, [FPFValue]);
 
   return (
     <div
@@ -75,18 +82,23 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
                 min={0}
                 max={100}
                 step={1}
-                value={targetInputFocused ? inputTargetValue : `${inputTargetValue}%`}
+                value={`${inputTargetValue}${targetInputFocused ? '' : '%'}`}
                 onFocusChange={setTargetInputFocused}
                 onChange={((event) => {
                   const percentValue = parseInt(event.target.value, 10);
                   if (percentValue < 0 || percentValue > 100) return;
-                  setInputTargetValue(percentValue);
+                  setInputTargetValue(String(percentValue));
                 })}
                 onBlur={() => {
+                  // If user leaves the input empty, we'll revert to the original targetValue
+                  if (Number.isNaN(Number(inputTargetValue))) {
+                    setInputTargetValue(String(Math.round(targetValue * 100)));
+                    return;
+                  }
                   // Prevent changing all targets if user didn't actually change it
                   // (despite clicking on the input)
-                  if (Math.round(targetValue * 100) === inputTargetValue) return;
-                  setTargetValue(inputTargetValue / 100);
+                  if (Math.round(targetValue * 100) === Number(inputTargetValue)) return;
+                  setTargetValue(Number(inputTargetValue) / 100);
                   if (onChangeTarget) onChangeTarget(inputTargetValue);
                 }}
               />
@@ -97,10 +109,21 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
                 className="w-16 ml-3 text-center text-sm"
                 theme="dark"
                 type="number"
-                value={FPFValue}
+                value={inputFPFValue}
                 onChange={({ target: { value: inputValue } }) => {
-                  setFPFValue(Number(inputValue));
-                  if (onChangeFPF) onChangeFPF(Number(inputValue));
+                  setInputFPFValue(inputValue);
+                }}
+                onBlur={() => {
+                  // If user leaves the input empty, we'll revert to the original targetValue
+                  if (!inputFPFValue) {
+                    setInputFPFValue(String(FPFValue));
+                    return;
+                  }
+                  // Prevent changing all targets if user didn't actually change it
+                  // (despite clicking on the input)
+                  if (FPFValue === Number(inputFPFValue)) return;
+                  setFPFValue(Number(inputFPFValue));
+                  if (onChangeFPF) onChangeFPF(Number(inputFPFValue));
                 }}
               />
             </div>
@@ -116,7 +139,7 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
               onChange={(sliderValue) => {
                 const percentValue = +(sliderValue * 100).toFixed(0);
                 setTargetValue(sliderValue);
-                setInputTargetValue(percentValue);
+                setInputTargetValue(String(percentValue));
                 if (onChangeTarget) onChangeTarget(percentValue);
               }}
             />

--- a/app/components/forms/input/component.tsx
+++ b/app/components/forms/input/component.tsx
@@ -1,11 +1,14 @@
 import React, { InputHTMLAttributes } from 'react';
-import Icon from 'components/icon';
+
+import { useFocus } from '@react-aria/interactions';
 import cx from 'classnames';
+
+import Icon from 'components/icon';
 
 const THEME = {
   dark: {
     base:
-      'w-full leading-tight text-white bg-gray-800 bg-opacity-0 focus:outline-none focus:bg-gray-700',
+      'leading-tight text-white bg-gray-800 bg-opacity-0 focus:outline-none focus:bg-gray-700',
     status: {
       none: 'border-gray-500',
       valid: 'border-gray-500',
@@ -20,7 +23,7 @@ const THEME = {
   },
   light: {
     base:
-      'w-full leading-tight text-gray-800 bg-white focus:outline-none focus:bg-gray-100',
+      'leading-tight text-gray-800 bg-white focus:outline-none focus:bg-gray-100',
     status: {
       none: 'border-gray-800',
       valid: 'border-gray-800',
@@ -43,6 +46,9 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     id: string;
     viewBox: string;
   };
+  onFocus?: () => void;
+  onBlur?: () => void;
+  onFocusChange?: (isFocused: boolean) => void;
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -52,9 +58,18 @@ export const Input: React.FC<InputProps> = ({
   disabled = false,
   icon,
   className,
+  onFocus,
+  onBlur,
+  onFocusChange,
   ...props
 }: InputProps) => {
   const st = disabled ? 'disabled' : status;
+
+  const { focusProps: inputFocusProps } = useFocus({
+    onFocus,
+    onBlur,
+    onFocusChange,
+  });
 
   return (
     <div className="relative">
@@ -77,8 +92,10 @@ export const Input: React.FC<InputProps> = ({
           [THEME[theme].status[st]]: true,
           [THEME[theme].mode[mode]]: true,
           'pl-10': icon,
+          'w-full': !className,
           [className]: !!className,
         })}
+        {...inputFocusProps}
       />
     </div>
   );

--- a/app/components/forms/slider/component.tsx
+++ b/app/components/forms/slider/component.tsx
@@ -11,17 +11,17 @@ import Value from './value';
 
 const THEME = {
   dark: {
-    base: 'relative w-full h-12 pt-8 touch-action-none',
+    base: 'relative w-full h-12 touch-action-none',
     filledTrack: 'absolute left-0 h-1.5 bg-white rounded',
     track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
   },
   light: {
-    base: 'relative w-full h-12 pt-8 touch-action-none',
+    base: 'relative w-full h-12 touch-action-none',
     filledTrack: 'absolute left-0 h-1.5 bg-gray-800 rounded',
     track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
   },
   'dark-small': {
-    base: 'relative w-full h-12 pt-8 touch-action-none',
+    base: 'relative w-full h-12 touch-action-none',
     filledTrack: 'absolute left-0 h-1.5 bg-black rounded',
     track: 'w-full h-1.5 bg-gray-300 rounded opacity-20',
   },
@@ -46,9 +46,13 @@ export interface SliderProps {
    */
   disabled?: boolean;
   /**
-   * Whether to allow the user to click the output and edit it directly. Defaults to `true`
+   * Whether to allow the user to click the output and edit it directly
    */
   allowEdit?: boolean,
+  /**
+   * Where or not to display the slider value above the thumb
+   */
+  showValue?: boolean,
   /**
    * Format of the value
    */
@@ -95,6 +99,7 @@ export const Slider: React.FC<SliderProps> = ({
   theme = 'dark',
   status: rawState = 'none',
   allowEdit = true,
+  showValue = true,
   disabled = false,
   formatOptions = { style: 'percent' },
   labelRef,
@@ -170,6 +175,7 @@ export const Slider: React.FC<SliderProps> = ({
       {...groupProps}
       className={cx({
         [THEME[theme].base]: true,
+        'pt-8': showValue,
         'opacity-30': status === 'disabled',
       })}
     >
@@ -192,22 +198,25 @@ export const Slider: React.FC<SliderProps> = ({
           sliderState={sliderState}
           trackRef={trackRef}
           isDisabled={disabled}
+          showValue={showValue}
         />
       </div>
-      <Value
-        minValue={minValue}
-        maxValue={maxValue}
-        step={step}
-        allowEdit={allowEdit}
-        isDisabled={disabled}
-        theme={theme}
-        sliderState={sliderState}
-        outputProps={outputProps}
-        formatOptions={formatOptions}
-        style={{
-          left: `${sliderState.getThumbPercent(0) * 100}%`,
-        }}
-      />
+      { showValue && (
+        <Value
+          minValue={minValue}
+          maxValue={maxValue}
+          step={step}
+          allowEdit={allowEdit}
+          isDisabled={disabled}
+          theme={theme}
+          sliderState={sliderState}
+          outputProps={outputProps}
+          formatOptions={formatOptions}
+          style={{
+            left: `${sliderState.getThumbPercent(0) * 100}%`,
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/app/components/forms/slider/thumb/component.tsx
+++ b/app/components/forms/slider/thumb/component.tsx
@@ -10,7 +10,7 @@ import cx from 'classnames';
 const THEME = {
   dark: {
     thumb:
-      'absolute top-0 w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
+      'absolute w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
     status: {
       default: 'border-white',
       dragging: 'border-white opacity-80',
@@ -22,7 +22,7 @@ const THEME = {
   },
   light: {
     thumb:
-      'absolute top-0 w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
+      'absolute w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
     status: {
       default: 'border-white',
       dragging: 'border-white opacity-80',
@@ -34,7 +34,7 @@ const THEME = {
   },
   'dark-small': {
     thumb:
-      'cursor-pointer absolute top-0 w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
+      'cursor-pointer absolute w-4 h-4 transform -translate-x-1/2 rounded-full bg-gray-700 border-2',
     status: {
       default: 'border-white',
       dragging: 'border-white opacity-80',
@@ -52,6 +52,7 @@ export interface ThumbProps {
   sliderState: SliderState;
   trackRef: React.MutableRefObject<HTMLElement | null>;
   isDisabled: boolean;
+  showValue: boolean;
   id?: string;
 }
 
@@ -61,6 +62,7 @@ export const Thumb: React.FC<ThumbProps> = ({
   sliderState,
   trackRef,
   isDisabled,
+  showValue,
   id = undefined,
   ...rest
 }: ThumbProps) => {
@@ -102,6 +104,8 @@ export const Thumb: React.FC<ThumbProps> = ({
       className={cx({
         [THEME[theme].thumb]: true,
         [THEME[theme].status[status]]: true,
+        'top-0': showValue,
+        'top-4': !showValue,
       })}
       style={{
         left: `${sliderState.getThumbPercent(0) * 100}%`,


### PR DESCRIPTION
### Overview

This PR implements the design changes from the Figma link below.  

**Notes:**  
- `TargetSPFItem` Component:  
    - Redesigned to better match the designs  
    - Fixed issue where _SPF_  input wouldn't allow the user to delete the input's content when editing  
    - Added _Target_ inputs, with `min`, `max` and `step` to match the Slider  
    - Changing the input value will adjust the slider as expected, and vice versa  
    - Inputs will update "on blur"  
    - If the user clicks the _"All targets"_ input, then clicks out but didn't change the value, the features will not update   
    - If the user clears an input (_"All targets"_ or _"SPF"_) then clicks outside, the input will revert to its previous value  
- `Input` Component:  
    - Can now take `onFocus`, `onBlur`, `onFocusChange` callbacks  
      Provided by `@react-aria/interactions`  
    - We can now set its width via `className`
- `Slider` Component:    
    - Added option to display sliders without the value above the thumb  

### Designs

[Figma](https://www.figma.com/proto/Ayr0EqxEGSo6B1ydJ7Bkfb/Marxan-Visual_V03?page-id=2991%3A66&node-id=2991%3A2900&viewport=333%2C48%2C1&scaling=min-zoom&starting-point-node-id=2991%3A68&show-proto-sidebar=1)

### Testing instructions

Open a project, create a scenario, and go with the flow. When on the _"Features 2/2"_ screen, verify that:  
- Clicking the _All targets_ input, then outside (without changing the value), does not update the features  
- Clicking the _All targets_ _SPF_, then outside (without changing the value), does not update the features
- Setting _All Targets_ and _SPF_ in all features works  as expected
- Setting _All Targets_ and _SPF_ in all features updates the features on blur  
- Setting _All Targets_ using the input updates the slider, and vice versa  
- Setting _Target_ and _SPF_ in individual features works  
- Setting a target value of less than 0 or higher than 100 does not work   
- Clearing an input then clicking outside will revert it to its previous value  

### Feature relevant tickets

[MARXAN-1048](https://vizzuality.atlassian.net/browse/MARXAN-1048)

### Screenshots
<img width="723" alt="Screenshot 2022-01-19 at 11 52 15" src="https://user-images.githubusercontent.com/6273795/150124722-e8e025db-fe84-4b0f-87eb-3de9555dbfd8.png">
<img width="1680" alt="Screenshot 2022-01-19 at 11 52 26" src="https://user-images.githubusercontent.com/6273795/150124734-00006e50-18bc-4023-a73d-122ee4d60ddf.png">

