### PR TITLE
Feature/frontend/marxan 1048

### DIFF
--- a/app/components/features/target-spf-item/component.tsx
+++ b/app/components/features/target-spf-item/component.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
+
 import cx from 'classnames';
+
 import Button from 'components/button';
-import Slider from 'components/forms/slider';
-import Label from 'components/forms/label';
 import Input from 'components/forms/input';
+import Label from 'components/forms/label';
+import Slider from 'components/forms/slider';
 
 import { TargetSPFItemProps, Type } from './types';
 
@@ -23,6 +25,8 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
 }: TargetSPFItemProps) => {
   const [targetValue, setTargetValue] = useState((target || defaultTarget) / 100);
   const [FPFValue, setFPFValue] = useState(fpf || defaultFPF);
+  const [inputFPFValue, setInputFPFValue] = useState(String(FPFValue));
+
   const sliderLabelRef = useRef(null);
 
   useEffect(() => {
@@ -33,12 +37,18 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
     if (typeof fpf !== 'undefined') setFPFValue(fpf);
   }, [fpf]);
 
+  useEffect(() => {
+    setInputFPFValue(String(FPFValue));
+  }, [FPFValue]);
+
   return (
     <div
       key={id}
       className={cx({
-        'bg-gray-700 text-white text-xs pl-5 py-2 relative border-transparent': true,
+        'text-white text-xs pl-5 py-2 mb-2 relative border-transparent': true,
         [className]: !!className,
+        'bg-gray-700': !isAllTargets,
+        'bg-gray-500 border rounded-lg': isAllTargets,
       })}
     >
       <div
@@ -83,18 +93,29 @@ export const TargetSPFItem: React.FC<TargetSPFItemProps> = ({
             <span>100%</span>
           </div>
         </div>
-        <div className="flex flex-col justify-between w-24 px-4 border-l">
+        <div className="flex flex-col justify-between w-24 px-4 border-l border-gray-500">
           <span>{isAllTargets ? 'ALL SPF' : 'SPF'}</span>
           <div className="w-10 mb-6">
             <Input
-              className="px-0 py-1"
+              className="px-0 py-1 rounded"
               theme="dark"
               mode="dashed"
               type="number"
-              value={FPFValue}
+              value={inputFPFValue}
               onChange={({ target: { value: inputValue } }) => {
-                setFPFValue(Number(inputValue));
-                if (onChangeFPF) onChangeFPF(Number(inputValue));
+                setInputFPFValue(inputValue);
+              }}
+              onBlur={() => {
+                // If user leaves the input empty, we'll revert to the original targetValue
+                if (!inputFPFValue) {
+                  setInputFPFValue(String(FPFValue));
+                  return;
+                }
+                // Prevent changing all targets if user didn't actually change it
+                // (despite clicking on the input)
+                if (FPFValue === Number(inputFPFValue)) return;
+                setFPFValue(Number(inputFPFValue));
+                if (onChangeFPF) onChangeFPF(Number(inputFPFValue));
               }}
             />
           </div>

--- a/app/components/forms/input/component.tsx
+++ b/app/components/forms/input/component.tsx
@@ -1,6 +1,9 @@
 import React, { InputHTMLAttributes } from 'react';
-import Icon from 'components/icon';
+
+import { useFocus } from '@react-aria/interactions';
 import cx from 'classnames';
+
+import Icon from 'components/icon';
 
 const THEME = {
   dark: {
@@ -43,6 +46,9 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     id: string;
     viewBox: string;
   };
+  onFocus?: () => void;
+  onBlur?: () => void;
+  onFocusChange?: (isFocused: boolean) => void;
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -52,9 +58,18 @@ export const Input: React.FC<InputProps> = ({
   disabled = false,
   icon,
   className,
+  onFocus,
+  onBlur,
+  onFocusChange,
   ...props
 }: InputProps) => {
   const st = disabled ? 'disabled' : status;
+
+  const { focusProps: inputFocusProps } = useFocus({
+    onFocus,
+    onBlur,
+    onFocusChange,
+  });
 
   return (
     <div className="relative">
@@ -79,6 +94,7 @@ export const Input: React.FC<InputProps> = ({
           'pl-10': icon,
           [className]: !!className,
         })}
+        {...inputFocusProps}
       />
     </div>
   );


### PR DESCRIPTION
### Overview

This PR makes it so it's clearer when the user is setting Target and SPF in all features instead of individual ones 

**Other changes:**  
- Updated the SPF left border color to better match the designs  
- Added a little bit of margin between features' items to better match the designs  
- Fixed an issue where _SPF_  input wouldn't allow the user to delete the input's content when editing  
- SPF inputs will update "on blur"
    to match the behaviour when editing the slider's label value.
- If the user clicks the "All features" SPF input but doesn't actually changes it, SPF in other features will not be changed .   
    to match the behaviour when editing the slider's label value.
- If the user clears an input (_"All targets"_ or _"SPF"_) then clicks outside, the input will revert to its previous value  
    to match the behaviour when editing the slider's label value.
- `Input Component` can now take `onFocus`, `onBlur`, `onFocusChange` callbacks  
    Provided by `@react-aria/interactions`  

### Designs

[Figma](https://www.figma.com/proto/hq0BZNB9fzyFSbEUgQIHdK/Marxan-Visual_V02?page-id=6694%3A10654&node-id=6722%3A13776&viewport=314%2C48%2C0.53&scaling=min-zoom&starting-point-node-id=6722%3A13776&show-proto-sidebar=1)

### Testing instructions

Open a project, create a scenario, and go with the flow. When on the _"Features 2/2"_ screen, verify that:  
- Set target and SPF in all features has a different background to better differentiate it from others  
- Clicking the _All targets'_ _SPF_ input, then outside (without changing the value), does not update the features  
- Clearing an  input then clicking outside will revert it to its previous value  
- Setting _SPF_ in individual features works  
- Setting  _SPF_ in all features works  as expected
- Setting _SPF_ in all features updates the features on blur (and not while typing)    

### Feature relevant tickets

[MARXAN-1048](https://vizzuality.atlassian.net/browse/MARXAN-1048)

### Screenshots  

<img width="721" alt="Screenshot 2022-01-19 at 13 17 05" src="https://user-images.githubusercontent.com/6273795/150139398-967ed7a7-4a12-4e1a-8fad-9e48f77f0a53.png">

