### PR TITLE
fix: typeorm export repository transaction method

### DIFF
--- a/api/apps/api/src/modules/clone/export/adapters/typeorm-export.repository.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/typeorm-export.repository.ts
@@ -4,6 +4,7 @@ import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 import { ExportRepository } from '../application/export-repository.port';
 import { Export, ExportId } from '../domain';
+import { ExportComponentEntity } from './entities/export-components.api.entity';
 import { ExportEntity } from './entities/exports.api.entity';
 
 @Injectable()
@@ -13,15 +14,35 @@ export class TypeormExportRepository implements ExportRepository {
   constructor(
     @InjectRepository(ExportEntity)
     private readonly exportRepo: Repository<ExportEntity>,
+    @InjectRepository(ExportComponentEntity)
+    private readonly exportComponentRepo: Repository<ExportComponentEntity>,
     @InjectEntityManager(DbConnections.default)
     private readonly entityManager: EntityManager,
   ) {}
 
   async find(exportId: ExportId): Promise<Export | undefined> {
+    const lock = this.inTransaction
+      ? { mode: 'pessimistic_write' as const }
+      : undefined;
     const exportEntity = await this.exportRepo.findOne(exportId.value, {
-      relations: ['components', 'components.uris'],
+      lock,
     });
     if (!exportEntity) return undefined;
+
+    /**
+     * Extracting export components from it's own repo is needed
+     * in order to be able to lock the reads when the operation is
+     * executed within a transaction
+     *
+     * https://www.postgresql.org/message-id/21634.1160151923@sss.pgh.pa.us
+     * https://stackoverflow.com/questions/46282087/hibernate-postgresql-select-for-update-with-outer-join-issue
+     */
+    const exportComponents = await this.exportComponentRepo.find({
+      where: { exportId: exportEntity.id },
+      relations: ['uris'],
+    });
+
+    exportEntity.components = exportComponents;
 
     return exportEntity.toAggregate();
   }
@@ -36,6 +57,7 @@ export class TypeormExportRepository implements ExportRepository {
     return this.entityManager.transaction((transactionEntityManager) => {
       const transactionalRepository = new TypeormExportRepository(
         transactionEntityManager.getRepository(ExportEntity),
+        transactionEntityManager.getRepository(ExportComponentEntity),
         transactionEntityManager,
       );
       transactionalRepository.inTransaction = true;


### PR DESCRIPTION
This PR fixes transaction "mode" of `typeorm-export.respository`