### PR TITLE
MARXAN-1154-Filter-Deleted-users

### DIFF
--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.spec.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.spec.ts
@@ -77,6 +77,7 @@ const getFixtures = async () => {
             leftJoinAndSelect: jest.fn().mockReturnThis(),
             select: jest.fn().mockReturnThis(),
             where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
             getMany: jest.fn(() => [
               {
                 roleName: ProjectRoles.project_owner,

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
@@ -152,6 +152,7 @@ export class ProjectAclService implements ProjectAccessControl {
       .where({
         projectId,
       })
+      .andWhere('userId.isDeleted is false')
       .select([
         'users_projects.roleName',
         'userId.displayName',

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.ts
@@ -214,7 +214,11 @@ export class ProjectAclService implements ProjectAccessControl {
         .leftJoinAndSelect('users_projects.user', 'userId')
         .select(['users_projects.roleName', 'userId.isDeleted'])
         .getOne();
-
+      /**
+       * If a role was already granted to the user, but the user is marked
+       * as deleted, we don't want to touch their existing role: we consider it,
+       * for the time being, as an archived fact, kept untouched.
+       */
       if (existingUserInProject?.user?.isDeleted) {
         return left(transactionFailed);
       }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -162,6 +162,7 @@ export class ScenarioAclService implements ScenarioAccessControl {
       .where({
         scenarioId,
       })
+      .andWhere('userId.isDeleted is false')
       .select([
         'users_scenarios.roleName',
         'userId.displayName',

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -137,13 +137,18 @@ export class ScenarioAclService implements ScenarioAccessControl {
   }
 
   async hasOtherOwner(userId: string, scenarioId: string): Promise<Permit> {
-    const otherOwnersInScenario = await this.roles.count({
-      where: {
+    const query = this.roles
+      .createQueryBuilder('users_scenarios')
+      .leftJoin('users_scenarios.user', 'userId')
+      .where({
         scenarioId,
         roleName: ScenarioRoles.scenario_owner,
         userId: Not(userId),
-      },
-    });
+      })
+      .andWhere('userId.isDeleted is false');
+
+    const otherOwnersInScenario = await query.getCount();
+
     return otherOwnersInScenario >= 1;
   }
 

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -226,6 +226,12 @@ export class ScenarioAclService implements ScenarioAccessControl {
         .select(['users_scenarios.roleName', 'userId.isDeleted'])
         .getOne();
 
+      /**
+       * If a role was already granted to the user, but the user is marked
+       * as deleted, we don't want to touch their existing role: we consider it,
+       * for the time being, as an archived fact, kept untouched.
+       */
+
       if (existingUserInScenario?.user?.isDeleted) {
         return left(transactionFailed);
       }

--- a/api/apps/api/test/access-control/project-acl/project-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl-get.e2e-spec.ts
@@ -57,3 +57,14 @@ test(`getting project users as owner with a wrong search query`, async () => {
   );
   fixtures.ThenNoUserInformationIsReturned(response);
 });
+
+test(`getting project users should only show those who are not deleted`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenContributorWasAddedToProject(projectId);
+  await fixtures.GivenUserWasAddedToProject(projectId);
+  let response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
+  fixtures.ThenAllUsersBeforeDeletingAnyFromAppAreReturned(response);
+  await fixtures.GivenUserIsDeleted();
+  response = await fixtures.WhenGettingProjectUsersAsOwner(projectId);
+  fixtures.ThenAllUsersExceptDeletedAreReturned(response);
+});

--- a/api/apps/api/test/access-control/project-acl/project-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl-patch.e2e-spec.ts
@@ -106,10 +106,21 @@ test(`adds non-existent userId`, async () => {
   const nonExistentUserIdResponse = await fixtures.WhenAddingNonExistentUserId(
     projectId,
   );
-  fixtures.ThenQueryFailedReturned(nonExistentUserIdResponse);
+  fixtures.ThenQueryFailedIsReturned(nonExistentUserIdResponse);
 });
 
-test(`adds and deletes users alternately`, async () => {
+test(`changes user role after user is soft-deleted from the app`, async () => {
+  const projectId = await fixtures.GivenProjectWasCreated();
+  await fixtures.GivenUserWasAddedToProject(projectId);
+  await fixtures.GivenUserIsDeleted();
+
+  const response = await fixtures.WhenChangingUserRoleFromDeletedUser(
+    projectId,
+  );
+  fixtures.ThenTransactionFailedIsReturned(response);
+});
+
+test(`adds and deletes users from projects alternately`, async () => {
   /* The purpose of this test is to check that all the transactions are
   executed correctly and that no users are deleted/reinstated because
   the transaction wasn't committed before initiating a new one */

--- a/api/apps/api/test/access-control/project-acl/project-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl-patch.e2e-spec.ts
@@ -114,9 +114,7 @@ test(`changes user role after user is soft-deleted from the app`, async () => {
   await fixtures.GivenUserWasAddedToProject(projectId);
   await fixtures.GivenUserIsDeleted();
 
-  const response = await fixtures.WhenChangingUserRoleFromDeletedUser(
-    projectId,
-  );
+  const response = await fixtures.WhenChangingUserRoleForDeletedUser(projectId);
   fixtures.ThenTransactionFailedIsReturned(response);
 });
 

--- a/api/apps/api/test/access-control/project-acl/project-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl-patch.e2e-spec.ts
@@ -27,7 +27,7 @@ test(`add every type of user to a project as project owner`, async () => {
   fixtures.ThenNoContentIsReturned(viewerResponse);
   fixtures.ThenNoContentIsReturned(contributorResponse);
   fixtures.ThenNoContentIsReturned(ownerResponse);
-  fixtures.ThenAllUsersinProjectAfterEveryTypeOfUserHasBeenAddedAreReturned(
+  fixtures.ThenAllUsersInProjectAfterEveryTypeOfUserHasBeenAddedAreReturned(
     allUsersInProjectResponse,
   );
 });

--- a/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
@@ -236,6 +236,15 @@ export const getFixtures = async () => {
           userId: viewerUserId,
           roleName: projectContributorRole,
         }),
+    WhenChangingUserRoleFromDeletedUser: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/projects/${projectId}/users`)
+        .set('Authorization', `Bearer ${ownerUserToken}`)
+        .send({
+          projectId,
+          userId: randomUserInfo.user.id,
+          roleName: projectContributorRole,
+        }),
     WhenAddingIncorrectUserRole: async (projectId: string) =>
       await request(app.getHttpServer())
         .patch(`/api/v1/roles/projects/${projectId}/users`)
@@ -329,10 +338,16 @@ export const getFixtures = async () => {
       expect(error?.message[0]).toEqual('roleName must be a valid enum value');
     },
 
-    ThenQueryFailedReturned: (response: request.Response) => {
+    ThenQueryFailedIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(400);
       const error: any = response.body.errors[0];
       expect(error.title).toEqual(`Error while adding record to the database`);
+    },
+
+    ThenTransactionFailedIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(500);
+      const error: any = response.body.errors[0];
+      expect(error.title).toEqual(`Transaction failed`);
     },
 
     ThenNoContentIsReturned: (response: request.Response) => {

--- a/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
@@ -236,7 +236,7 @@ export const getFixtures = async () => {
           userId: viewerUserId,
           roleName: projectContributorRole,
         }),
-    WhenChangingUserRoleFromDeletedUser: async (projectId: string) =>
+    WhenChangingUserRoleForDeletedUser: async (projectId: string) =>
       await request(app.getHttpServer())
         .patch(`/api/v1/roles/projects/${projectId}/users`)
         .set('Authorization', `Bearer ${ownerUserToken}`)

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl-get.e2e-spec.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl-get.e2e-spec.ts
@@ -57,3 +57,14 @@ test(`getting scenario users as owner with a wrong search query`, async () => {
   );
   fixtures.ThenNoUserInformationIsReturned(response);
 });
+
+test(`getting scenario users should only show those who are not deleted`, async () => {
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+  await fixtures.GivenContributorWasAddedToScenario(scenarioId);
+  await fixtures.GivenUserWasAddedToScenario(scenarioId);
+  let response = await fixtures.WhenGettingScenarioUsersAsOwner(scenarioId);
+  fixtures.ThenAllUsersBeforeDeletingAnyFromAppAreReturned(response);
+  await fixtures.GivenUserIsDeleted();
+  response = await fixtures.WhenGettingScenarioUsersAsOwner(scenarioId);
+  fixtures.ThenAllUsersExceptDeletedAreReturned(response);
+});

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl-patch.e2e-spec.ts
@@ -27,7 +27,7 @@ test(`add every type of user to a scenario as scenario owner`, async () => {
   fixtures.ThenNoContentIsReturned(viewerResponse);
   fixtures.ThenNoContentIsReturned(contributorResponse);
   fixtures.ThenNoContentIsReturned(ownerResponse);
-  fixtures.ThenAllUsersinScenarioAfterEveryTypeOfUserHasBeenAddedAreReturned(
+  fixtures.ThenAllUsersInScenarioAfterEveryTypeOfUserHasBeenAddedAreReturned(
     allUsersInScenarioResponse,
   );
 });

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl-patch.e2e-spec.ts
@@ -98,7 +98,18 @@ test(`adds non-existent userId`, async () => {
   const nonExistentUserIdResponse = await fixtures.WhenAddingNonExistentUserId(
     scenarioId,
   );
-  fixtures.ThenQueryFailedReturned(nonExistentUserIdResponse);
+  fixtures.ThenQueryFailedIsReturned(nonExistentUserIdResponse);
+});
+
+test(`changes user role after user is soft-deleted from the app`, async () => {
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+  await fixtures.GivenUserWasAddedToScenario(scenarioId);
+  await fixtures.GivenUserIsDeleted();
+
+  const response = await fixtures.WhenChangingUserRoleFromDeletedUser(
+    scenarioId,
+  );
+  fixtures.ThenTransactionFailedIsReturned(response);
 });
 
 test(`adds and deletes users alternately`, async () => {

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl-patch.e2e-spec.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl-patch.e2e-spec.ts
@@ -106,7 +106,7 @@ test(`changes user role after user is soft-deleted from the app`, async () => {
   await fixtures.GivenUserWasAddedToScenario(scenarioId);
   await fixtures.GivenUserIsDeleted();
 
-  const response = await fixtures.WhenChangingUserRoleFromDeletedUser(
+  const response = await fixtures.WhenChangingUserRoleForDeletedUser(
     scenarioId,
   );
   fixtures.ThenTransactionFailedIsReturned(response);

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl.fixtures.ts
@@ -233,6 +233,15 @@ export const getFixtures = async () => {
           userId: viewerUserId,
           roleName: scenarioContributorRole,
         }),
+    WhenChangingUserRoleFromDeletedUser: async (scenarioId: string) =>
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/scenarios/${scenarioId}/users`)
+        .set('Authorization', `Bearer ${ownerUserToken}`)
+        .send({
+          scenarioId,
+          userId: randomUserInfo.user.id,
+          roleName: scenarioContributorRole,
+        }),
     WhenAddingIncorrectUserRole: async (scenarioId: string) =>
       await request(app.getHttpServer())
         .patch(`/api/v1/roles/scenarios/${scenarioId}/users`)
@@ -336,10 +345,16 @@ export const getFixtures = async () => {
       expect(error?.message[0]).toEqual('roleName must be a valid enum value');
     },
 
-    ThenQueryFailedReturned: (response: request.Response) => {
+    ThenQueryFailedIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(400);
       const error: any = response.body.errors[0];
       expect(error.title).toEqual(`Error while adding record to the database`);
+    },
+
+    ThenTransactionFailedIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(500);
+      const error: any = response.body.errors[0];
+      expect(error.title).toEqual(`Transaction failed`);
     },
 
     ThenSingleOwnerUserInScenarioIsReturned: (response: request.Response) => {

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl.fixtures.ts
@@ -233,7 +233,7 @@ export const getFixtures = async () => {
           userId: viewerUserId,
           roleName: scenarioContributorRole,
         }),
-    WhenChangingUserRoleFromDeletedUser: async (scenarioId: string) =>
+    WhenChangingUserRoleForDeletedUser: async (scenarioId: string) =>
       await request(app.getHttpServer())
         .patch(`/api/v1/roles/scenarios/${scenarioId}/users`)
         .set('Authorization', `Bearer ${ownerUserToken}`)

--- a/api/apps/api/test/steps/given-user-is-created.ts
+++ b/api/apps/api/test/steps/given-user-is-created.ts
@@ -1,0 +1,35 @@
+import { AccessToken } from '@marxan-api/modules/authentication/authentication.service';
+import { User } from '@marxan-api/modules/users/user.api.entity';
+import { INestApplication } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { hash } from 'bcrypt';
+import * as faker from 'faker';
+import * as request from 'supertest';
+import { Repository } from 'typeorm';
+
+export const GivenUserIsCreated = async (
+  app: INestApplication,
+): Promise<AccessToken> => {
+  const email = faker.internet.email();
+  const password = faker.internet.password();
+  const displayName = faker.name.firstName();
+
+  const user = new User();
+  user.displayName = displayName;
+  user.passwordHash = await hash(password, 10);
+  user.email = email;
+  user.isActive = true;
+
+  const usersRepo: Repository<User> = app.get(getRepositoryToken(User));
+
+  await usersRepo.save(user);
+
+  const { body } = await request(app.getHttpServer())
+    .post('/auth/sign-in')
+    .send({
+      username: email,
+      password,
+    });
+
+  return body;
+};

--- a/api/apps/api/test/steps/given-user-is-deleted.ts
+++ b/api/apps/api/test/steps/given-user-is-deleted.ts
@@ -1,0 +1,11 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+
+export const GivenUserIsDeleted = async (
+  app: INestApplication,
+  accessToken: string,
+): Promise<void> => {
+  await request(app.getHttpServer())
+    .delete('/api/v1/users/me')
+    .set('Authorization', `Bearer ${accessToken}`);
+};


### PR DESCRIPTION
-Filters out deleted users when getting users on project/scenarios
-Prevent changes on user roles to deleted users in projects/scenarios.
-Adds tests for them.


Couple of notes:

The ACL check when deleting a user to check that no project was left without owners is not anywhere to be found due to a cyclical dependency problem that I left in a test branch as requested by @hotzevzl
