### PR TITLE
MARXAN-1087-endpoint-acquire-scenarios-lock

### DIFF
--- a/api/apps/api/src/modules/scenarios/locks/__mocks__/scenario-access-control.mock.ts
+++ b/api/apps/api/src/modules/scenarios/locks/__mocks__/scenario-access-control.mock.ts
@@ -1,0 +1,21 @@
+import { Permit } from '@marxan-api/modules/access-control/access-control.types';
+import { ScenarioAccessControl } from '@marxan-api/modules/access-control/scenarios-acl/scenario-access-control';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ScenarioAccessControlMock implements ScenarioAccessControl {
+  mock: jest.Mock<boolean> = jest.fn(() => true);
+
+  async canCreateScenario(userId: string, projectId: string): Promise<Permit> {
+    return this.mock(userId, projectId);
+  }
+  async canEditScenario(userId: string, projectId: string): Promise<Permit> {
+    return this.mock(userId, projectId);
+  }
+  async canViewScenario(userId: string, projectId: string): Promise<Permit> {
+    return this.mock(userId, projectId);
+  }
+  async canDeleteScenario(userId: string, projectId: string): Promise<Permit> {
+    return this.mock(userId, projectId);
+  }
+}

--- a/api/apps/api/src/modules/scenarios/locks/__mocks__/scenario-access-control.mock.ts
+++ b/api/apps/api/src/modules/scenarios/locks/__mocks__/scenario-access-control.mock.ts
@@ -18,4 +18,7 @@ export class ScenarioAccessControlMock implements ScenarioAccessControl {
   async canDeleteScenario(userId: string, projectId: string): Promise<Permit> {
     return this.mock(userId, projectId);
   }
+  async canCloneScenario(userId: string, scenarioId: string): Promise<Permit> {
+    return this.mock(userId, scenarioId);
+  }
 }

--- a/api/apps/api/src/modules/scenarios/locks/dto/scenario.lock.dto.ts
+++ b/api/apps/api/src/modules/scenarios/locks/dto/scenario.lock.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDate, IsUUID } from 'class-validator';
+
+export class ScenarioLockDto {
+  @IsUUID()
+  @ApiProperty()
+  userId!: string;
+
+  @IsUUID()
+  @ApiProperty()
+  scenarioId!: string;
+
+  @IsDate()
+  @ApiPropertyOptional()
+  createdAt?: Date;
+}
+
+export class ScenarioLockResult {
+  @ApiProperty()
+  data!: ScenarioLockDto;
+}

--- a/api/apps/api/src/modules/scenarios/locks/entity/scenario.lock.api.entity.ts
+++ b/api/apps/api/src/modules/scenarios/locks/entity/scenario.lock.api.entity.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity(`scenario_locks`)
@@ -22,9 +21,4 @@ export class ScenarioLockEntity {
     default: 'now()',
   })
   createdAt!: Date;
-}
-
-export class ScenarioLockResult {
-  @ApiProperty()
-  data!: ScenarioLockEntity;
 }

--- a/api/apps/api/src/modules/scenarios/locks/lock.service.ts
+++ b/api/apps/api/src/modules/scenarios/locks/lock.service.ts
@@ -3,9 +3,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Either, left, right } from 'fp-ts/lib/Either';
 
-import { ScenarioLockEntity } from '@marxan-api/modules/scenarios/locks/scenario.lock.api.entity';
+import { ScenarioLockEntity } from '@marxan-api/modules/scenarios/locks/entity/scenario.lock.api.entity';
 import { forbiddenError } from '@marxan-api/modules/access-control';
 import { ScenarioAccessControl } from '@marxan-api/modules/access-control/scenarios-acl/scenario-access-control';
+import { ScenarioLockDto } from './dto/scenario.lock.dto';
 
 export const unknownError = Symbol(`unknown error`);
 export const lockedScenario = Symbol(`scenario is already locked`);
@@ -23,9 +24,7 @@ export class LockService {
   async acquireLock(
     scenarioId: string,
     userId: string,
-  ): Promise<
-    Either<AcquireFailure | typeof forbiddenError, ScenarioLockEntity>
-  > {
+  ): Promise<Either<AcquireFailure | typeof forbiddenError, ScenarioLockDto>> {
     if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
       return left(forbiddenError);
     }

--- a/api/apps/api/src/modules/scenarios/locks/lock.service.ts
+++ b/api/apps/api/src/modules/scenarios/locks/lock.service.ts
@@ -3,7 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Either, left, right } from 'fp-ts/lib/Either';
 
-import { ScenarioLockEntity } from '@marxan-api/modules/scenarios/locks/scenario.lock.entity';
+import { ScenarioLockEntity } from '@marxan-api/modules/scenarios/locks/scenario.lock.api.entity';
+import { forbiddenError } from '@marxan-api/modules/access-control';
+import { ScenarioAccessControl } from '@marxan-api/modules/access-control/scenarios-acl/scenario-access-control';
 
 export const unknownError = Symbol(`unknown error`);
 export const lockedScenario = Symbol(`scenario is already locked`);
@@ -15,24 +17,31 @@ export class LockService {
   constructor(
     @InjectRepository(ScenarioLockEntity)
     private readonly locksRepo: Repository<ScenarioLockEntity>,
+    private readonly scenarioAclService: ScenarioAccessControl,
   ) {}
 
   async acquireLock(
     scenarioId: string,
     userId: string,
-  ): Promise<Either<AcquireFailure, void>> {
+  ): Promise<
+    Either<AcquireFailure | typeof forbiddenError, ScenarioLockEntity>
+  > {
+    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
+      return left(forbiddenError);
+    }
     return this.locksRepo.manager.transaction(async (entityManager) => {
       if (await this.isLocked(scenarioId)) {
         return left(lockedScenario);
       }
 
-      await entityManager.save({
-        scenarioId,
-        userId,
-        createdAt: new Date(),
-      });
+      const lock = new ScenarioLockEntity();
+      lock.scenarioId = scenarioId;
+      lock.userId = userId;
+      lock.createdAt = new Date();
 
-      return right(void 0);
+      const result = await entityManager.save(lock);
+
+      return right(result);
     });
   }
 
@@ -42,5 +51,9 @@ export class LockService {
 
   async isLocked(scenarioId: string): Promise<boolean> {
     return (await this.locksRepo.count({ where: { scenarioId } })) > 0;
+  }
+
+  async isLockedByUser(scenarioId: string, userId: string): Promise<boolean> {
+    return !(await this.locksRepo.find({ where: { scenarioId, userId } }));
   }
 }

--- a/api/apps/api/src/modules/scenarios/locks/scenario.lock.api.entity.ts
+++ b/api/apps/api/src/modules/scenarios/locks/scenario.lock.api.entity.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity(`scenario_locks`)
@@ -21,4 +22,9 @@ export class ScenarioLockEntity {
     default: 'now()',
   })
   createdAt!: Date;
+}
+
+export class ScenarioLockResult {
+  @ApiProperty()
+  data!: ScenarioLockEntity;
 }

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -126,7 +126,7 @@ import {
   lockedScenario,
   unknownError,
 } from './locks/lock.service';
-import { ScenarioLockResult } from './locks/scenario.lock.api.entity';
+import { ScenarioLockResult } from './locks/dto/scenario.lock.dto';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -278,7 +278,7 @@ export class ScenariosController {
         case forbiddenError:
           throw new ForbiddenException();
         case notFound:
-          throw new NotFoundException(`Scenario ${id} could not be found`);
+          throw new NotFoundException(`Scenario ${id} could not be found.`);
         default:
           const _exhaustiveCheck: never = result.left;
           throw _exhaustiveCheck;
@@ -1117,7 +1117,7 @@ export class ScenariosController {
           throw new ForbiddenException();
         case lockedScenario:
           throw new BadRequestException(
-            `Scenario ${id} is already being edited`,
+            `Scenario ${id} is already being edited.`,
           );
         case unknownError:
           throw new InternalServerErrorException();

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -121,6 +121,12 @@ import {
 import { notFound as protectedAreaProjectNotFound } from '@marxan/projects';
 import { invalidProtectedAreaId } from './protected-area/selection/selection-update.service';
 import { ScenarioAccessControl } from '../access-control/scenarios-acl/scenario-access-control';
+import {
+  LockService,
+  lockedScenario,
+  unknownError,
+} from './locks/lock.service';
+import { ScenarioLockResult } from './locks/scenario.lock.api.entity';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -148,6 +154,7 @@ export class ScenariosController {
     private readonly zipFilesSerializer: ZipFilesSerializer,
     private readonly planningUnitsSerializer: ScenarioPlanningUnitSerializer,
     private readonly scenarioAclService: ScenarioAccessControl,
+    private readonly lockService: LockService,
   ) {}
 
   @ApiOperation({
@@ -1090,5 +1097,35 @@ export class ScenariosController {
     if (isLeft(result)) {
       throw new ForbiddenException();
     }
+  }
+
+  @ApiOperation({
+    description: `Start Scenario Editing session.`,
+    summary: `Creates a Lock entity with related scenario
+     and user data to prevent other users from editing at the same time.`,
+  })
+  @Post(`:id/lock`)
+  async startScenarioEditingSession(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<ScenarioLockResult> {
+    const result = await this.lockService.acquireLock(id, req.user.id);
+
+    if (isLeft(result)) {
+      switch (result.left) {
+        case forbiddenError:
+          throw new ForbiddenException();
+        case lockedScenario:
+          throw new BadRequestException(
+            `Scenario ${id} is already being edited`,
+          );
+        case unknownError:
+          throw new InternalServerErrorException();
+        default:
+          const _exhaustiveCheck: never = result.left;
+          throw _exhaustiveCheck;
+      }
+    }
+    return { data: result.right };
   }
 }

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -36,6 +36,7 @@ import { ScenarioPlanningUnitSerializer } from './dto/scenario-planning-unit.ser
 import { ScenarioPlanningUnitsService } from './planning-units/scenario-planning-units.service';
 import { ScenarioPlanningUnitsLinkerService } from './planning-units/scenario-planning-units-linker-service';
 import { AdminAreasModule } from '../admin-areas/admin-areas.module';
+import { LockService } from './locks/lock.service';
 
 import { SpecificationModule } from './specification';
 import { ScenarioFeaturesGapDataSerializer } from './dto/scenario-feature-gap-data.serializer';
@@ -50,6 +51,7 @@ import { ProjectCheckerModule } from '@marxan-api/modules/projects/project-check
 import { AccessControlModule } from '@marxan-api/modules/access-control';
 import { UsersScenariosApiEntity } from '@marxan-api/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity';
 import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block-guard.module';
+import { ScenarioLockEntity } from './locks/scenario.lock.api.entity';
 
 @Module({
   imports: [
@@ -87,6 +89,7 @@ import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block
     BlmValuesModule,
     BlmCalibrationModule,
     AccessControlModule,
+    TypeOrmModule.forFeature([ScenarioLockEntity]),
   ],
   providers: [
     ScenariosService,
@@ -104,6 +107,7 @@ import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block
     ZipFilesSerializer,
     ScenarioPlanningUnitSerializer,
     CostRangeService,
+    LockService,
   ],
   controllers: [ScenariosController],
   exports: [ScenariosCrudService, ScenariosService],

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -51,7 +51,7 @@ import { ProjectCheckerModule } from '@marxan-api/modules/projects/project-check
 import { AccessControlModule } from '@marxan-api/modules/access-control';
 import { UsersScenariosApiEntity } from '@marxan-api/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity';
 import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block-guard.module';
-import { ScenarioLockEntity } from './locks/scenario.lock.api.entity';
+import { ScenarioLockEntity } from './locks/entity/scenario.lock.api.entity';
 
 @Module({
   imports: [

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -123,6 +123,37 @@ describe('ScenariosModule (e2e)', () => {
     fixtures.ThenOkIsReturned(response);
   });
 
+  it('Viewer fails to acquire a lock for a scenario', async () => {
+    await fixtures.GivenScenarioWasCreated();
+    await fixtures.GivenViewerWasAddedToScenario();
+    const response = await fixtures.WhenAcquiringLockForScenarioAsViewer();
+    fixtures.ThenForbiddenIsReturned(response);
+  });
+
+  it('Contributor acquires a lock for a scenario', async () => {
+    await fixtures.GivenScenarioWasCreated();
+    await fixtures.GivenContributorWasAddedToScenario();
+    const response = await fixtures.WhenAcquiringLockForScenarioAsContributor();
+    fixtures.ThenScenarioLockInfoIsReturned(response);
+  });
+
+  it('Owner acquires a lock for a scenario', async () => {
+    await fixtures.GivenScenarioWasCreated();
+    const response = await fixtures.WhenAcquiringLockForScenarioAsOwner();
+    fixtures.ThenScenarioLockInfoIsReturned(response);
+  });
+
+  it('Fails to acquire a lock for a scenario as there was one already', async () => {
+    await fixtures.GivenScenarioWasCreated();
+    await fixtures.GivenContributorWasAddedToScenario();
+
+    let response = await fixtures.WhenAcquiringLockForScenarioAsOwner();
+    fixtures.ThenScenarioLockInfoIsReturned(response);
+
+    response = await fixtures.WhenAcquiringLockForScenarioAsContributor();
+    fixtures.ThenScenarioIsLockedIsReturned(response);
+  });
+
   it('should not allow to create scenario with invalid marxan properties', async () => {
     const response = await fixtures.WhenCreatingScenarioWithInvalidMarxanProperties();
     fixtures.ThenInvalidEnumValueMessageIsReturned(response);
@@ -325,6 +356,19 @@ async function getFixtures() {
           },
         }),
 
+    WhenAcquiringLockForScenarioAsOwner: async () =>
+      await request(app.getHttpServer())
+        .post(`/api/v1/scenarios/${scenarioId}/lock`)
+        .set('Authorization', `Bearer ${ownerToken}`),
+    WhenAcquiringLockForScenarioAsContributor: async () =>
+      await request(app.getHttpServer())
+        .post(`/api/v1/scenarios/${scenarioId}/lock`)
+        .set('Authorization', `Bearer ${contributorToken}`),
+    WhenAcquiringLockForScenarioAsViewer: async () =>
+      await request(app.getHttpServer())
+        .post(`/api/v1/scenarios/${scenarioId}/lock`)
+        .set('Authorization', `Bearer ${viewerToken}`),
+
     ThenForbiddenIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(403);
     },
@@ -335,6 +379,14 @@ async function getFixtures() {
 
     ThenOkIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(200);
+    },
+
+    ThenScenarioIsLockedIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(400);
+      const error: any = response.body.errors[0];
+      expect(error.title).toEqual(
+        `Scenario ${scenarioId} is already being edited`,
+      );
     },
 
     ThenScenarioIsCreatedAndNoJobHasBeenSubmitted: (
@@ -451,6 +503,11 @@ async function getFixtures() {
         response.body.errors[0].meta.rawError.response.message[0].constraints
           .isEnum,
       ).toMatchInlineSnapshot(`"HEURTYPE must be a valid enum value"`);
+    },
+
+    ThenScenarioLockInfoIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(201);
+      expect(response.body.data.scenarioId).toEqual(scenarioId);
     },
   };
 }

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -385,7 +385,7 @@ async function getFixtures() {
       expect(response.status).toEqual(400);
       const error: any = response.body.errors[0];
       expect(error.title).toEqual(
-        `Scenario ${scenarioId} is already being edited`,
+        `Scenario ${scenarioId} is already being edited.`,
       );
     },
 


### PR DESCRIPTION
-Adds lock creation endpoint for scenarios.
-Adds tests for lock creation with different roles on a scenario.
-Minor fixes and improvements.