### PR TITLE
Feat/marxan 1224 export scenario metadata

### DIFF
--- a/api/apps/api/src/migrations/api/1643298778270-AddExportScenarioEvents.ts
+++ b/api/apps/api/src/migrations/api/1643298778270-AddExportScenarioEvents.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddExportScenarioEvents1643298778270
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO api_event_kinds (id) values
+      ('scenario.export.submitted/v1/alpha'),
+      ('scenario.export.finished/v1/alpha'),
+      ('scenario.export.failed/v1/alpha'),
+      ('scenario.export.piece.submitted/v1/alpha'),
+      ('scenario.export.piece.finished/v1/alpha'),
+      ('scenario.export.piece.failed/v1/alpha');
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id = 'scenario.export.submitted/v1/alpha';`,
+    );
+
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id = 'scenario.export.finished/v1/alpha';`,
+    );
+
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id = 'scenario.export.failed/v1/alpha';`,
+    );
+
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id = 'scenario.export.piece.submitted/v1/alpha';`,
+    );
+
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id = 'scenario.export.piece.finished/v1/alpha';`,
+    );
+
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id = 'scenario.export.piece.failed/v1/alpha';`,
+    );
+  }
+}

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
@@ -10,4 +10,5 @@ export abstract class ScenarioAccessControl {
     userId: string,
     projectId: string,
   ): Promise<Permit>;
+  abstract canCloneScenario(userId: string, projectId: string): Promise<Permit>;
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -40,6 +40,10 @@ export class ScenarioAclService implements ScenarioAccessControl {
     ScenarioRoles.scenario_owner,
   ];
   private readonly canDeleteScenarioRoles = [ScenarioRoles.scenario_owner];
+  private readonly canCloneScenarioRoles = [
+    ProjectRoles.project_owner,
+    ProjectRoles.project_contributor,
+  ];
 
   private async getRolesWithinScenarioForUser(
     userId: string,
@@ -119,6 +123,13 @@ export class ScenarioAclService implements ScenarioAccessControl {
     return this.doesUserHaveRole(
       await this.getRolesWithinScenarioForUser(userId, scenarioId),
       this.canViewScenarioRoles,
+    );
+  }
+
+  async canCloneScenario(userId: string, projectId: string): Promise<Permit> {
+    return this.doesUserHaveRoleInProject(
+      await this.getRolesWithinProjectForUser(userId, projectId),
+      this.canCloneScenarioRoles,
     );
   }
 

--- a/api/apps/api/src/modules/clone/export/application/export-application.module.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-application.module.ts
@@ -6,6 +6,7 @@ import { CompletePieceHandler } from './complete-piece.handler';
 import { FinalizeArchiveHandler } from './finalize-archive.handler';
 import { AllPiecesReadySaga } from './all-pieces-ready.saga';
 import { GetArchiveHandler } from './get-archive.handler';
+import { ExportScenarioHandler } from './export-scenario.handler';
 
 @Module({})
 export class ExportApplicationModule {
@@ -18,6 +19,7 @@ export class ExportApplicationModule {
         AllPiecesReadySaga,
         // use cases
         ExportProjectHandler,
+        ExportScenarioHandler,
         CompletePieceHandler,
         FinalizeArchiveHandler,
         GetArchiveHandler,

--- a/api/apps/api/src/modules/clone/export/application/export-scenario.command.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-scenario.command.ts
@@ -1,0 +1,12 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+import { ResourceId } from '@marxan/cloning/domain';
+import { ExportId } from '../domain';
+
+export { ExportId };
+export { ResourceId };
+
+export class ExportScenario extends Command<ExportId> {
+  constructor(public readonly id: ResourceId) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/clone/export/application/export-scenario.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-scenario.handler.ts
@@ -1,0 +1,38 @@
+import {
+  CommandHandler,
+  EventPublisher,
+  IInferredCommandHandler,
+} from '@nestjs/cqrs';
+
+import { ResourceKind } from '@marxan/cloning/domain';
+import { Export, ExportComponentSnapshot, ExportId } from '../domain';
+
+import { ExportScenario } from './export-scenario.command';
+import { ResourcePieces } from './resource-pieces.port';
+import { ExportRepository } from './export-repository.port';
+
+@CommandHandler(ExportScenario)
+export class ExportScenarioHandler
+  implements IInferredCommandHandler<ExportScenario> {
+  constructor(
+    private readonly resourcePieces: ResourcePieces,
+    private readonly exportRepository: ExportRepository,
+    private readonly eventPublisher: EventPublisher,
+  ) {}
+
+  async execute({ id }: ExportScenario): Promise<ExportId> {
+    const kind = ResourceKind.Scenario;
+    const pieces: ExportComponentSnapshot[] = await this.resourcePieces.resolveFor(
+      id,
+      kind,
+    );
+    const exportRequest = this.eventPublisher.mergeObjectContext(
+      Export.newOne(id, kind, pieces),
+    );
+    await this.exportRepository.save(exportRequest);
+
+    exportRequest.commit();
+
+    return exportRequest.id;
+  }
+}

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
@@ -147,7 +147,7 @@ export class FakeQueueEvents {
     failed: [],
   };
 
-  private constructor(eventFactory: EventFactory<JobInput, JobOutput>) {
+  private constructor(private eventFactory: EventFactory<JobInput, JobOutput>) {
     this.on('completed', eventFactory.createCompletedEvent);
     this.on('failed', eventFactory.createFailedEvent);
   }
@@ -163,7 +163,7 @@ export class FakeQueueEvents {
   }
 
   on(type: JobEvent, callback: JobEventListener) {
-    this.#listeners[type].push(callback);
+    this.#listeners[type].push(callback.bind(this.eventFactory));
   }
 
   triggerJobEvent(

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
@@ -23,11 +23,22 @@ import {
 import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
 import { ResourceId } from '../../export';
 import { ApiEventsService } from '../../../api-events';
+import { ResourceKind } from '@marxan/cloning/domain';
 
 @Injectable()
 export class ExportPieceEventsHandler
   implements EventFactory<JobInput, JobOutput> {
   private queueEvents: QueueEventsAdapter<JobInput, JobOutput>;
+
+  private failEventsMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__piece__failed__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__piece__failed__v1__alpha,
+  };
+
+  private successEventsMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__piece__finished__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__piece__finished__v1__alpha,
+  };
 
   constructor(
     @Inject(exportPieceEventsFactoryToken)
@@ -45,7 +56,7 @@ export class ExportPieceEventsHandler
   ): Promise<CreateApiEventDTO> {
     const data = await eventData.data;
     const output = await eventData.result;
-    const kind = API_EVENT_KINDS.project__export__piece__finished__v1__alpha;
+    const kind = this.successEventsMapper[data.resourceKind];
 
     return {
       topic: data.componentId,
@@ -67,7 +78,7 @@ export class ExportPieceEventsHandler
       exportId,
       componentId,
     } = await eventData.data;
-    const kind = API_EVENT_KINDS.project__export__piece__failed__v1__alpha;
+    const kind = this.failEventsMapper[resourceKind];
 
     return {
       topic: componentId,

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
@@ -9,6 +9,11 @@ import { MarkExportAsFailed } from './mark-export-as-failed.command';
 @CommandHandler(MarkExportAsFailed)
 export class MarkExportAsFailedHandler
   implements IInferredCommandHandler<MarkExportAsFailed> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__failed__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__failed__v1__alpha,
+  };
+
   constructor(private readonly apiEvents: ApiEventsService) {}
 
   async execute({
@@ -16,15 +21,7 @@ export class MarkExportAsFailedHandler
     resourceId,
     exportId,
   }: MarkExportAsFailed): Promise<void> {
-    const kind =
-      resourceKind === ResourceKind.Project
-        ? API_EVENT_KINDS.project__export__failed__v1__alpha
-        : null;
-
-    if (!kind) {
-      // TODO update with Scenario once supported.
-      return;
-    }
+    const kind = this.eventMapper[resourceKind];
 
     await this.apiEvents.createIfNotExists({
       kind,

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.handler.ts
@@ -9,6 +9,11 @@ import { MarkExportAsFinished } from './mark-export-as-finished.command';
 @CommandHandler(MarkExportAsFinished)
 export class MarkExportAsFinishedHandler
   implements IInferredCommandHandler<MarkExportAsFinished> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__finished__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__finished__v1__alpha,
+  };
+
   constructor(private readonly apiEvents: ApiEventsService) {}
 
   async execute({
@@ -16,15 +21,7 @@ export class MarkExportAsFinishedHandler
     resourceId,
     exportId,
   }: MarkExportAsFinished): Promise<void> {
-    const kind =
-      resourceKind === ResourceKind.Project
-        ? API_EVENT_KINDS.project__export__finished__v1__alpha
-        : null;
-
-    if (!kind) {
-      // TODO update with Scenario once supported.
-      return;
-    }
+    const kind = this.eventMapper[resourceKind];
 
     await this.apiEvents.createIfNotExists({
       kind,

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-submitted.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-submitted.handler.ts
@@ -7,6 +7,11 @@ import { MarkExportAsSubmitted } from './mark-export-as-submitted.command';
 @CommandHandler(MarkExportAsSubmitted)
 export class MarkExportAsSubmittedHandler
   implements IInferredCommandHandler<MarkExportAsSubmitted> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__submitted__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__submitted__v1__alpha,
+  };
+
   constructor(private readonly apiEvents: ApiEventsService) {}
 
   async execute({
@@ -14,15 +19,7 @@ export class MarkExportAsSubmittedHandler
     resourceId,
     resourceKind,
   }: MarkExportAsSubmitted): Promise<void> {
-    const kind =
-      resourceKind === ResourceKind.Project
-        ? API_EVENT_KINDS.project__export__submitted__v1__alpha
-        : null;
-
-    if (!kind) {
-      // TODO update with Scenario once supported.
-      return;
-    }
+    const kind = this.eventMapper[resourceKind];
 
     await this.apiEvents.createIfNotExists({
       kind,

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-pieces-as-failed.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-pieces-as-failed.handler.ts
@@ -7,6 +7,11 @@ import { MarkExportPiecesAsFailed } from '@marxan-api/modules/clone/infra/export
 @CommandHandler(MarkExportPiecesAsFailed)
 export class MarkExportPiecesAsFailedHandler
   implements IInferredCommandHandler<MarkExportPiecesAsFailed> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__piece__failed__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__piece__failed__v1__alpha,
+  };
+
   constructor(private readonly apiEvents: ApiEventsService) {}
 
   async execute({
@@ -15,15 +20,7 @@ export class MarkExportPiecesAsFailedHandler
     resourceKind,
     componentsId,
   }: MarkExportPiecesAsFailed): Promise<void> {
-    const kind =
-      resourceKind === ResourceKind.Project
-        ? API_EVENT_KINDS.project__export__piece__failed__v1__alpha
-        : null;
-
-    if (!kind) {
-      // TODO update with Scenario once supported.
-      return;
-    }
+    const kind = this.eventMapper[resourceKind];
 
     await Promise.all(
       componentsId.map((componentId) =>

--- a/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.ts
@@ -13,10 +13,16 @@ import { SchedulePieceExport } from './schedule-piece-export.command';
 import { exportPieceQueueToken } from './export-queue.provider';
 import { API_EVENT_KINDS } from '@marxan/api-events';
 import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
+import { ResourceKind } from '@marxan/cloning/domain';
 
 @CommandHandler(SchedulePieceExport)
 export class SchedulePieceExportHandler
   implements IInferredCommandHandler<SchedulePieceExport> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__export__piece__submitted__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__export__piece__submitted__v1__alpha,
+  };
+
   constructor(
     private readonly apiEvents: ApiEventsService,
     @Inject(exportPieceQueueToken) private readonly queue: Queue<JobInput>,
@@ -53,8 +59,10 @@ export class SchedulePieceExportHandler
       return;
     }
 
+    const kind = this.eventMapper[resourceKind];
+
     await this.apiEvents.createIfNotExists({
-      kind: API_EVENT_KINDS.project__export__piece__submitted__v1__alpha,
+      kind,
       topic: componentId.value,
       data: {
         piece,

--- a/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.spec.ts
+++ b/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.spec.ts
@@ -16,10 +16,6 @@ describe('MarxanBlockGuard', () => {
     fixtures = await getFixtures();
   });
 
-  afterEach(async () => {
-    await fixtures?.cleanup();
-  });
-
   it(`throws an exception if the given project has an ongoing export`, async () => {
     const projectId = fixtures.GivenProjectWasCreated();
 
@@ -67,9 +63,6 @@ const getFixtures = async () => {
   const blockGuard = sandbox.get(BlockGuard);
 
   return {
-    cleanup: () => {
-      projectChecker.clear();
-    },
     GivenProjectWasCreated: () => {
       const id = v4();
       fakeProjectsService.findOne.mockResolvedValue({ id } as Project);

--- a/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.spec.ts
+++ b/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.spec.ts
@@ -16,6 +16,10 @@ describe('MarxanBlockGuard', () => {
     fixtures = await getFixtures();
   });
 
+  afterEach(async () => {
+    await fixtures?.cleanup();
+  });
+
   it(`throws an exception if the given project has an ongoing export`, async () => {
     const projectId = fixtures.GivenProjectWasCreated();
 
@@ -63,6 +67,9 @@ const getFixtures = async () => {
   const blockGuard = sandbox.get(BlockGuard);
 
   return {
+    cleanup: () => {
+      projectChecker.clear();
+    },
     GivenProjectWasCreated: () => {
       const id = v4();
       fakeProjectsService.findOne.mockResolvedValue({ id } as Project);

--- a/api/apps/api/src/modules/projects/job-status/job-status.view.api.entity.ts
+++ b/api/apps/api/src/modules/projects/job-status/job-status.view.api.entity.ts
@@ -146,4 +146,13 @@ const eventToJobStatusMapping: Record<ValuesType<ScenarioEvents>, JobStatus> = {
     JobStatus.running,
   [API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1]: JobStatus.failure,
   [API_EVENT_KINDS.scenario__calibration__finished_v1_alpha1]: JobStatus.done,
+  [API_EVENT_KINDS.scenario__export__failed__v1__alpha]: JobStatus.failure,
+  [API_EVENT_KINDS.scenario__export__finished__v1__alpha]: JobStatus.done,
+  [API_EVENT_KINDS.scenario__export__submitted__v1__alpha]: JobStatus.running,
+  [API_EVENT_KINDS.scenario__export__piece__failed__v1__alpha]:
+    JobStatus.failure,
+  [API_EVENT_KINDS.scenario__export__piece__finished__v1__alpha]:
+    JobStatus.done,
+  [API_EVENT_KINDS.scenario__export__piece__submitted__v1__alpha]:
+    JobStatus.running,
 };

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -81,6 +81,8 @@ import { ScenariosPlanningUnitGeoEntity } from '@marxan/scenarios-planning-unit'
 import { PaginationMeta } from '@marxan-api/utils/app-base.service';
 import { ScenarioFeaturesData } from '@marxan/features';
 import { ScenariosOutputResultsApiEntity } from '@marxan/marxan-output';
+import { ResourceId } from '../clone';
+import { ExportScenario } from '../clone/export/application/export-scenario.command';
 
 /** @debt move to own module */
 const EmptyGeoFeaturesSpecification: GeoFeatureSetSpecification = {
@@ -489,6 +491,20 @@ export class ScenariosService {
       }
     }
     return right(void 0);
+  }
+
+  async requestExport(
+    scenarioId: string,
+    userId: string,
+  ): Promise<Either<typeof forbiddenError, string>> {
+    // Block guard
+    // ACL slot
+
+    const result = await this.commandBus.execute(
+      new ExportScenario(new ResourceId(scenarioId)),
+    );
+
+    return right(result.value);
   }
 
   private async assertScenario(scenarioId: string) {

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -497,8 +497,16 @@ export class ScenariosService {
     scenarioId: string,
     userId: string,
   ): Promise<Either<typeof forbiddenError, string>> {
-    // Block guard
-    // ACL slot
+    // TODO Block guard
+    const scenario = await this.assertScenario(scenarioId);
+    const userCanCloneScenario = await this.scenarioAclService.canCloneScenario(
+      userId,
+      scenario.projectId,
+    );
+
+    if (!userCanCloneScenario) {
+      return left(forbiddenError);
+    }
 
     const result = await this.commandBus.execute(
       new ExportScenario(new ResourceId(scenarioId)),

--- a/api/apps/api/test/business-critical/marxan-run/fixtures.ts
+++ b/api/apps/api/test/business-critical/marxan-run/fixtures.ts
@@ -41,10 +41,9 @@ export const getFixtures = async () => {
       );
     },
     GivenCostSurfaceTemplateFilled: async () => {
-      const template = await request(app.getHttpServer())
+      await request(app.getHttpServer())
         .get(`/api/v1/scenarios/${scenario}/cost-surface/shapefile-template`)
         .set('Authorization', `Bearer ${authToken}`);
-      console.log(template.body);
     },
     WhenMarxanExecutionIsRequested: async () => {
       // TODO currently not implemented yet: 501

--- a/api/apps/api/test/project-jobs-status/job-status.service.integration.e2e-spec.ts
+++ b/api/apps/api/test/project-jobs-status/job-status.service.integration.e2e-spec.ts
@@ -14,6 +14,7 @@ import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
 import { GivenProjectExists } from '../steps/given-project';
 import { GivenScenarioExists } from '../steps/given-scenario-exists';
 import { OrganizationsTestUtils } from '../utils/organizations.test.utils';
+import { ProjectsTestUtils } from '../utils/projects.test.utils';
 
 let fixtures: PromiseType<ReturnType<typeof getFixtures>>;
 
@@ -77,7 +78,7 @@ async function getFixtures() {
 
   const eventsRepository = application.get(ApiEventsService);
   const addedOrganizations: string[] = [];
-
+  const addedProjects: string[] = [];
   const addedEvents: ApiEvent[] = [];
 
   const statusRepository: Repository<ScenarioJobStatus> = application.get(
@@ -132,6 +133,7 @@ async function getFixtures() {
         const event = await eventsRepository.create(eventDto);
         addedEvents.push(event);
       }
+      addedProjects.push(projectId);
       addedOrganizations.push(organizationId);
       return {
         projectId,
@@ -150,10 +152,16 @@ async function getFixtures() {
         topic: projectId,
       });
       addedOrganizations.push(organizationId);
+      addedProjects.push(projectId);
       addedEvents.push(event);
     },
     async cleanup() {
       await eventsRepository.repo.remove(addedEvents);
+      await Promise.all(
+        addedProjects.map((projectId) =>
+          ProjectsTestUtils.deleteProject(application, token, projectId),
+        ),
+      );
       await Promise.all(
         addedOrganizations.map((organizationId) =>
           OrganizationsTestUtils.deleteOrganization(

--- a/api/apps/api/test/project/update-project.fixtures.ts
+++ b/api/apps/api/test/project/update-project.fixtures.ts
@@ -25,6 +25,8 @@ export const getFixtures = async () => {
 
   return {
     cleanup: async () => {
+      projectChecker.clear();
+
       await ProjectsTestUtils.deleteProject(app, token, projectId);
       await OrganizationsTestUtils.deleteOrganization(
         app,

--- a/api/apps/api/test/scenarios/start-scenario-calibration.fixtures.ts
+++ b/api/apps/api/test/scenarios/start-scenario-calibration.fixtures.ts
@@ -69,6 +69,7 @@ export const getFixtures = async () => {
 
   return {
     cleanup: async () => {
+      projectChecker.clear();
       await ProjectsTestUtils.deleteProject(app, ownerToken, projectId);
       await ScenariosTestUtils.deleteScenario(app, ownerToken, scenarioId);
       await OrganizationsTestUtils.deleteOrganization(

--- a/api/apps/api/test/scenarios/update-scenario.e2e-spec.ts
+++ b/api/apps/api/test/scenarios/update-scenario.e2e-spec.ts
@@ -67,6 +67,7 @@ async function getFixtures() {
 
   return {
     cleanup: async () => {
+      projectChecker.clear();
       await ProjectsTestUtils.deleteProject(app, token, projectId);
       await ScenariosTestUtils.deleteScenario(app, token, scenarioId);
       await OrganizationsTestUtils.deleteOrganization(

--- a/api/libs/api-events/src/api-event-kinds.enum.ts
+++ b/api/libs/api-events/src/api-event-kinds.enum.ts
@@ -58,6 +58,12 @@ export enum API_EVENT_KINDS {
   project__export__piece__submitted__v1__alpha = 'project.export.piece.submitted/v1/alpha',
   project__export__piece__finished__v1__alpha = 'project.export.piece.finished/v1/alpha',
   project__export__piece__failed__v1__alpha = 'project.export.piece.failed/v1/alpha',
+  scenario__export__submitted__v1__alpha = 'scenario.export.submitted/v1/alpha',
+  scenario__export__finished__v1__alpha = 'scenario.export.finished/v1/alpha',
+  scenario__export__failed__v1__alpha = 'scenario.export.failed/v1/alpha',
+  scenario__export__piece__submitted__v1__alpha = 'scenario.export.piece.submitted/v1/alpha',
+  scenario__export__piece__finished__v1__alpha = 'scenario.export.piece.finished/v1/alpha',
+  scenario__export__piece__failed__v1__alpha = 'scenario.export.piece.failed/v1/alpha',
 }
 
 export type ProjectEvents = Pick<


### PR DESCRIPTION
- Added `requestExport` method to `ScenariosService`
- Added `ExportScenario` command and its handler
- Added ACL for `requestExport` method
- Added proper scenario export `api events` handling

### Feature relevant tickets

[Export scenario metadata](https://vizzuality.atlassian.net/browse/MARXAN-813)