### PR TITLE
fix: negative pu cost filtering

### DIFF
--- a/api/apps/geoprocessing/src/modules/surface-cost/adapters/pu-cost-extractor.spec.ts
+++ b/api/apps/geoprocessing/src/modules/surface-cost/adapters/pu-cost-extractor.spec.ts
@@ -3,6 +3,7 @@ import { PromiseType } from 'utility-types';
 import {
   getGeoJson,
   getGeoJsonWithMissingCost,
+  getGeoJsonWithNegativeCost,
   getGeometryMultiPolygon,
 } from '../application/__mocks__/geojson';
 import { PuCostExtractor } from './pu-cost-extractor';
@@ -48,6 +49,14 @@ describe(`when given GeoJson has pu costs`, () => {
   });
 });
 
+describe(`when given GeoJson has some negative pu costs`, () => {
+  it(`throws exception`, () => {
+    expect(() => sut.extract(fixtures.geoFeaturesWithNegativeCost())).toThrow(
+      /invalid cost/,
+    );
+  });
+});
+
 const getFixtures = async () => {
   const sandbox = await Test.createTestingModule({
     providers: [PuCostExtractor],
@@ -57,6 +66,7 @@ const getFixtures = async () => {
     getService: () => sandbox.get(PuCostExtractor),
     geoFeaturesWithoutCost: () => getGeoJsonWithMissingCost(),
     geoFeaturesWithData: () => getGeoJson(['uuid-1', 'uuid-2']),
+    geoFeaturesWithNegativeCost: () => getGeoJsonWithNegativeCost(),
     simpleGeometry: () => getGeometryMultiPolygon(),
   };
 };

--- a/api/apps/geoprocessing/src/modules/surface-cost/adapters/pu-cost-extractor.ts
+++ b/api/apps/geoprocessing/src/modules/surface-cost/adapters/pu-cost-extractor.ts
@@ -23,6 +23,12 @@ export class PuCostExtractor implements PuExtractorPort {
       );
     }
 
+    const validPUCosts = puCosts.every(this.hasACostEqualOrGreaterThanZero);
+
+    if (!validPUCosts) {
+      throw new Error(`Some of the Features has invalid cost values`);
+    }
+
     return puCosts.map((puCost) => ({
       puid: puCost.puid,
       cost: puCost.cost,
@@ -39,5 +45,9 @@ export class PuCostExtractor implements PuExtractorPort {
       isDefined(properties.cost) &&
       isDefined(properties.puid)
     );
+  }
+
+  private hasACostEqualOrGreaterThanZero(puCost: PlanningUnitCost): boolean {
+    return puCost.cost >= 0;
   }
 }

--- a/api/apps/geoprocessing/src/modules/surface-cost/application/__mocks__/geojson.ts
+++ b/api/apps/geoprocessing/src/modules/surface-cost/application/__mocks__/geojson.ts
@@ -43,6 +43,37 @@ export const getGeoJsonWithMissingCost = (): FeatureCollection<
   ],
 });
 
+export const getGeoJsonWithNegativeCost = (): FeatureCollection<
+  MultiPolygon | Polygon,
+  PlanningUnitCost | Record<string, undefined>
+> => ({
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {
+        cost: 200,
+        puid: 'uuid-1',
+      },
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [],
+      },
+    },
+    {
+      properties: {
+        cost: -100,
+        puid: 'uuid-2',
+      },
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [],
+      },
+    },
+  ],
+});
+
 export const getGeometryMultiPolygon = (): MultiPolygon => ({
   type: 'MultiPolygon',
   coordinates: [],


### PR DESCRIPTION
This PR adds a fix for filtering pu cost negative values when updating a scenario cost surface with a shapefile

### Feature relevant tickets

[enforce that cost data provided in cost surface uploads is zero or a positive number](https://vizzuality.atlassian.net/browse/MARXAN-1207)