### PR TITLE
feat(front): persist BLM range[MARXAN-1259]

### DIFF
--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -678,6 +678,28 @@ export function useScenarioCalibrationResults(scenarioId) {
   }, [query, data?.data]);
 }
 
+export function useScenarioCalibrationRange(scenarioId) {
+  const [session] = useSession();
+
+  const query = useQuery(['scenario-calibration-range', scenarioId], async () => SCENARIOS.request({
+    method: 'GET',
+    url: `/${scenarioId}/blm/range`,
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+    },
+    transformResponse: (data) => JSON.parse(data),
+  }));
+
+  const { data } = query;
+
+  return useMemo(() => {
+    return {
+      ...query,
+      data: data?.data?.range,
+    };
+  }, [query, data?.data]);
+}
+
 export function useSaveScenarioCalibrationRange({
   requestConfig = {
     method: 'POST',

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -651,6 +651,8 @@ export function useCancelRunScenario({
     },
   });
 }
+
+// BLM
 export function useScenarioCalibrationResults(scenarioId) {
   const [session] = useSession();
 
@@ -666,7 +668,8 @@ export function useScenarioCalibrationResults(scenarioId) {
   const { data } = query;
 
   return useMemo(() => {
-    const parsedData = Array.isArray(data?.data) ? data?.data : [];
+    const parsedData = Array.isArray(data?.data)
+      ? data?.data.sort((a, b) => (a.cost > b.cost ? 1 : -1)) : [];
 
     return {
       ...query,
@@ -675,7 +678,6 @@ export function useScenarioCalibrationResults(scenarioId) {
   }, [query, data?.data]);
 }
 
-// BLM
 export function useSaveScenarioCalibrationRange({
   requestConfig = {
     method: 'POST',

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -724,6 +724,7 @@ export function useSaveScenarioCalibrationRange({
       console.info('Succcess', data, variables, context);
       const { id: scenarioId } = variables;
       queryClient.invalidateQueries(['scenario-calibration', scenarioId]);
+      queryClient.invalidateQueries(['scenario-calibration-range', scenarioId]);
     },
     onError: (error, variables, context) => {
       console.info('Error', error, variables, context);

--- a/app/layout/scenarios/edit/analysis/blm-calibration/component.tsx
+++ b/app/layout/scenarios/edit/analysis/blm-calibration/component.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/router';
 import { format } from 'd3';
 import { motion } from 'framer-motion';
 
-import { useSaveScenarioCalibrationRange } from 'hooks/scenarios';
+import { useSaveScenarioCalibrationRange, useScenarioCalibrationRange } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 
 import BlmSettingsGraph from 'layout/scenarios/edit/analysis/blm-calibration/blm-settings-graph';
@@ -35,6 +35,8 @@ export const ScenariosBLMCalibration: React.FC<ScenariosBLMCalibrationProps> = (
   const { addToast } = useToasts();
 
   const saveScenarioCalibrationRange = useSaveScenarioCalibrationRange({});
+
+  const { data: calibrationRange } = useScenarioCalibrationRange(sid);
 
   const minBlmValue = 0;
   const maxBlmValue = 10000000;
@@ -73,6 +75,11 @@ export const ScenariosBLMCalibration: React.FC<ScenariosBLMCalibrationProps> = (
     });
   }, [addToast, saveScenarioCalibrationRange, sid]);
 
+  const INITIAL_VALUES = {
+    blmCalibrationFrom: calibrationRange ? calibrationRange[0] : null,
+    blmCalibrationTo: calibrationRange ? calibrationRange[1] : null,
+  };
+
   return (
     <motion.div
       key="cost-surface"
@@ -106,7 +113,10 @@ export const ScenariosBLMCalibration: React.FC<ScenariosBLMCalibrationProps> = (
           </InfoButton>
         </div>
         <div className="flex flex-col w-full min-h-0 space-y-10 text-sm">
-          <FormRFF onSubmit={onSaveBlmRange}>
+          <FormRFF
+            initialValues={INITIAL_VALUES}
+            onSubmit={onSaveBlmRange}
+          >
             {({ handleSubmit }) => (
               <form
                 className="flex flex-col w-full mt-5 text-gray-500"


### PR DESCRIPTION
## Persist BLM range and set ordered values on graph

### Designs

[Figma](https://www.figma.com/file/DpHfvKRBNQylK71c0nq2FD/Marxan-Visual_Internal?node-id=6727%3A12961)

### Testing instructions

- [ ] Go to BLM section of a non calibration scenario and check range inputs are empty.
- [ ] Introduce BLM range on a scenario 
- [ ] Calibrate and check graph is ok
- [ ] Exit the section, browse through the scenario, return to the BLM section and check that range and BLM selected previously are on its respective inputs.

### Feature relevant tickets

[MARXAN-1259](https://vizzuality.atlassian.net/browse/MARXAN-1259)

