### PR TITLE
MARXAN-1261 Requested changes for scenario locks endpoints

### DIFF
--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/__mocks__/scenario-access-control.mock.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/__mocks__/scenario-access-control.mock.ts
@@ -75,7 +75,7 @@ export class ScenarioAccessControlMock implements ScenarioAccessControl {
   async findLock(
     userId: string,
     scenarioId: string,
-  ): Promise<Either<typeof forbiddenError, null | ScenarioLockResultSingular>> {
+  ): Promise<Either<typeof forbiddenError, ScenarioLockResultSingular>> {
     if (this.mock(userId, scenarioId)) {
       return left(forbiddenError);
     }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/__mocks__/scenario-access-control.mock.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/__mocks__/scenario-access-control.mock.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { Either, left, right } from 'fp-ts/lib/Either';
 import {
   ScenarioLockDto,
-  ScenarioLockResultPlural,
+  ScenarioLockResultSingular,
 } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
 import {
   AcquireFailure,
@@ -72,14 +72,14 @@ export class ScenarioAccessControlMock implements ScenarioAccessControl {
     }
     return right(this.mock(userId, scenarioId));
   }
-  async findAllLocks(
+  async findLock(
     userId: string,
     scenarioId: string,
-  ): Promise<Either<typeof forbiddenError, ScenarioLockResultPlural>> {
+  ): Promise<Either<typeof forbiddenError, null | ScenarioLockResultSingular>> {
     if (this.mock(userId, scenarioId)) {
       return left(forbiddenError);
     }
 
-    return right({ data: [{ userId, scenarioId, createdAt: new Date() }] });
+    return right({ data: { userId, scenarioId, createdAt: new Date() } });
   }
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto.ts
@@ -17,7 +17,7 @@ export class ScenarioLockDto {
 
 export class ScenarioLockResultSingular {
   @ApiProperty()
-  data!: ScenarioLockDto;
+  data!: ScenarioLockDto | null;
 }
 export class ScenarioLockResultPlural {
   @ApiProperty()

--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/lock.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/lock.service.ts
@@ -7,6 +7,7 @@ import { ScenarioLockEntity } from '@marxan-api/modules/access-control/scenarios
 import {
   ScenarioLockDto,
   ScenarioLockResultPlural,
+  ScenarioLockResultSingular,
 } from './dto/scenario.lock.dto';
 
 export const unknownError = Symbol(`unknown error`);
@@ -62,6 +63,18 @@ export class LockService {
     const allLocksByProject = await query.getMany();
 
     return { data: allLocksByProject };
+  }
+
+  async getLock(
+    scenarioId: string,
+  ): Promise<null | ScenarioLockResultSingular> {
+    const result = await this.locksRepo.findOne({ scenarioId });
+
+    if (!result) {
+      return null;
+    }
+
+    return { data: result };
   }
 
   async releaseLock(scenarioId: string): Promise<void> {

--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/lock.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/lock.service.ts
@@ -65,13 +65,11 @@ export class LockService {
     return { data: allLocksByProject };
   }
 
-  async getLock(
-    scenarioId: string,
-  ): Promise<null | ScenarioLockResultSingular> {
+  async getLock(scenarioId: string): Promise<ScenarioLockResultSingular> {
     const result = await this.locksRepo.findOne({ scenarioId });
 
     if (!result) {
-      return null;
+      return { data: null };
     }
 
     return { data: result };

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
@@ -3,7 +3,7 @@ import { Either } from 'fp-ts/lib/Either';
 import { forbiddenError } from '..';
 import {
   ScenarioLockDto,
-  ScenarioLockResultPlural,
+  ScenarioLockResultSingular,
 } from './locks/dto/scenario.lock.dto';
 import {
   AcquireFailure,
@@ -42,9 +42,8 @@ export abstract class ScenarioAccessControl {
       boolean
     >
   >;
-  abstract findAllLocks(
+  abstract findLock(
     userId: string,
     scenarioId: string,
-    projectId: string,
-  ): Promise<Either<typeof forbiddenError, ScenarioLockResultPlural>>;
+  ): Promise<Either<typeof forbiddenError, null | ScenarioLockResultSingular>>;
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
@@ -45,5 +45,5 @@ export abstract class ScenarioAccessControl {
   abstract findLock(
     userId: string,
     scenarioId: string,
-  ): Promise<Either<typeof forbiddenError, null | ScenarioLockResultSingular>>;
+  ): Promise<Either<typeof forbiddenError, ScenarioLockResultSingular>>;
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -32,6 +32,7 @@ import {
 import {
   ScenarioLockDto,
   ScenarioLockResultPlural,
+  ScenarioLockResultSingular,
 } from './locks/dto/scenario.lock.dto';
 
 @Injectable()
@@ -255,15 +256,14 @@ export class ScenarioAclService implements ScenarioAccessControl {
     );
   }
 
-  async findAllLocks(
+  async findLock(
     userId: string,
     scenarioId: string,
-    projectId: string,
-  ): Promise<Either<typeof forbiddenError, ScenarioLockResultPlural>> {
+  ): Promise<Either<typeof forbiddenError, null | ScenarioLockResultSingular>> {
     if (!(await this.canViewScenario(userId, scenarioId))) {
       return left(forbiddenError);
     }
-    return right(await this.lockService.getAllLocksByProject(projectId));
+    return right(await this.lockService.getLock(scenarioId));
   }
 
   async findUsersInScenario(

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -12,7 +12,7 @@ import {
 } from '@marxan-api/modules/access-control/scenarios-acl/dto/user-role-scenario.dto';
 import { UsersScenariosApiEntity } from '@marxan-api/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity';
 import { ScenarioAccessControl } from '@marxan-api/modules/access-control/scenarios-acl/scenario-access-control';
-import { Either, isLeft, left, right } from 'fp-ts/lib/Either';
+import { Either, left, right } from 'fp-ts/lib/Either';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { assertDefined } from '@marxan/utils';
 import {
@@ -31,7 +31,6 @@ import {
 } from './locks/lock.service';
 import {
   ScenarioLockDto,
-  ScenarioLockResultPlural,
   ScenarioLockResultSingular,
 } from './locks/dto/scenario.lock.dto';
 
@@ -259,7 +258,7 @@ export class ScenarioAclService implements ScenarioAccessControl {
   async findLock(
     userId: string,
     scenarioId: string,
-  ): Promise<Either<typeof forbiddenError, null | ScenarioLockResultSingular>> {
+  ): Promise<Either<typeof forbiddenError, ScenarioLockResultSingular>> {
     if (!(await this.canViewScenario(userId, scenarioId))) {
       return left(forbiddenError);
     }

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1189,15 +1189,15 @@ export class ScenariosController {
 
   @ApiOperation({
     description: `End Scenario Editing session.`,
-    summary: `Releases the lock created on a scenario so other
+    summary: `Deletes the lock created on a scenario so other
     users can start editing the scenario.`,
   })
   @ApiNoContentResponse({
     status: 204,
-    description: 'Lock was released correctly',
+    description: 'Lock was deleted correctly',
   })
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Patch(`:id/release-lock`)
+  @Delete(`:id/lock`)
   async endScenarioEditingSession(
     @Param('id', ParseUUIDPipe) id: string,
     @Req() req: RequestWithAuthenticatedUser,
@@ -1227,13 +1227,13 @@ export class ScenariosController {
 
   @Get(':scenarioId/editing-locks')
   @ApiOperation({
-    summary: "Get all locks for scenarios of this scenario's parent project",
+    summary: 'Get lock for scenario if it exists. Otherwise, it returns null',
   })
   async findLocksForScenariosWithinParentProject(
     @Param('scenarioId', ParseUUIDPipe) scenarioId: string,
     @Req() req: RequestWithAuthenticatedUser,
-  ): Promise<ScenarioLockResultPlural> {
-    const result = await this.service.findAllLocks(scenarioId, req.user.id);
+  ): Promise<null | ScenarioLockResultSingular> {
+    const result = await this.service.findLock(scenarioId, req.user.id);
 
     if (isLeft(result)) {
       switch (result.left) {

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1194,7 +1194,7 @@ export class ScenariosController {
   })
   @ApiNoContentResponse({
     status: 204,
-    description: 'Lock was deleted correctly',
+    description: 'Lock was released correctly',
   })
   @HttpCode(HttpStatus.NO_CONTENT)
   @Delete(`:id/lock`)
@@ -1232,7 +1232,7 @@ export class ScenariosController {
   async findLocksForScenariosWithinParentProject(
     @Param('scenarioId', ParseUUIDPipe) scenarioId: string,
     @Req() req: RequestWithAuthenticatedUser,
-  ): Promise<null | ScenarioLockResultSingular> {
+  ): Promise<ScenarioLockResultSingular> {
     const result = await this.service.findLock(scenarioId, req.user.id);
 
     if (isLeft(result)) {

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -101,7 +101,7 @@ import {
   LockService,
   noLockInPlace,
 } from '@marxan-api/modules/access-control/scenarios-acl/locks/lock.service';
-import { ScenarioLockResultPlural } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
+import { ScenarioLockResultSingular } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
 
 /** @debt move to own module */
 const EmptyGeoFeaturesSpecification: GeoFeatureSetSpecification = {
@@ -985,23 +985,15 @@ export class ScenariosService {
     );
   }
 
-  async findAllLocks(
+  async findLock(
     scenarioId: string,
     userId: string,
   ): Promise<
-    Either<typeof forbiddenError | GetScenarioFailure, ScenarioLockResultPlural>
+    Either<
+      typeof forbiddenError | GetScenarioFailure,
+      null | ScenarioLockResultSingular
+    >
   > {
-    const scenario = await this.getById(scenarioId, {
-      authenticatedUser: { id: userId },
-    });
-    if (isLeft(scenario)) {
-      return scenario;
-    }
-    const projectId = scenario.right.projectId;
-    return await this.scenarioAclService.findAllLocks(
-      userId,
-      scenarioId,
-      projectId,
-    );
+    return await this.scenarioAclService.findLock(userId, scenarioId);
   }
 }

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -991,7 +991,7 @@ export class ScenariosService {
   ): Promise<
     Either<
       typeof forbiddenError | GetScenarioFailure,
-      null | ScenarioLockResultSingular
+      ScenarioLockResultSingular
     >
   > {
     return await this.scenarioAclService.findLock(userId, scenarioId);

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -225,6 +225,22 @@ test(`getting all locks of scenarios as scenario viewer`, async () => {
   );
 });
 
+test.only(`getting the lock of a scenario if there is no lock in place`, async () => {
+  const ownerToken = await fixtures.GivenUserIsLoggedIn('owner');
+  const scenarioIdObj = await fixtures.GivenTwoScenariosWereCreated();
+
+  const firstScenarioResponse = await fixtures.WhenGettingLockFromScenario(
+    scenarioIdObj.firstScenarioId,
+    ownerToken,
+  );
+  fixtures.ThenNoScenarioLockIsReturned(firstScenarioResponse);
+  const secondScenarioResponse = await fixtures.WhenGettingLockFromScenario(
+    scenarioIdObj.secondScenarioId,
+    ownerToken,
+  );
+  fixtures.ThenNoScenarioLockIsReturned(secondScenarioResponse);
+});
+
 test('Viewer fails to acquire lock for a scenario', async () => {
   await fixtures.GivenScenarioWasCreated();
   await fixtures.GivenViewerWasAddedToScenario();

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -20,7 +20,7 @@ test(`getting all locks of scenarios from projects as project owner`, async () =
     scenarioIdObj.firstScenarioId,
     token,
   );
-  await fixtures.ThenScenarioLockInfoIsReturned(
+  await fixtures.ThenScenarioLockInfoAfterCreationIsReturned(
     firstLock,
     scenarioIdObj.firstScenarioId,
   );
@@ -28,7 +28,7 @@ test(`getting all locks of scenarios from projects as project owner`, async () =
     scenarioIdObj.secondScenarioId,
     token,
   );
-  await fixtures.ThenScenarioLockInfoIsReturned(
+  await fixtures.ThenScenarioLockInfoAfterCreationIsReturned(
     secondLock,
     scenarioIdObj.secondScenarioId,
   );
@@ -117,24 +117,22 @@ test(`getting all locks of scenarios as scenario owner`, async () => {
     token,
   );
 
-  const firstScenarioResponse = await fixtures.WhenGettingAllLocksFromScenarioId(
+  const firstScenarioResponse = await fixtures.WhenGettingLockFromScenario(
     scenarioIdObj.firstScenarioId,
     token,
   );
-  fixtures.ThenAllLocksAreReturned(
+  fixtures.ThenScenarioLockInfoIsReturned(
     firstScenarioResponse,
     userId,
     scenarioIdObj.firstScenarioId,
-    scenarioIdObj.secondScenarioId,
   );
-  const secondScenarioResponse = await fixtures.WhenGettingAllLocksFromScenarioId(
+  const secondScenarioResponse = await fixtures.WhenGettingLockFromScenario(
     scenarioIdObj.secondScenarioId,
     token,
   );
-  fixtures.ThenAllLocksAreReturned(
+  fixtures.ThenScenarioLockInfoIsReturned(
     secondScenarioResponse,
     userId,
-    scenarioIdObj.firstScenarioId,
     scenarioIdObj.secondScenarioId,
   );
 });
@@ -163,24 +161,22 @@ test(`getting all locks of scenarios as scenario contributor`, async () => {
     ownerToken,
   );
 
-  const firstScenarioResponse = await fixtures.WhenGettingAllLocksFromScenarioId(
+  const firstScenarioResponse = await fixtures.WhenGettingLockFromScenario(
     scenarioIdObj.firstScenarioId,
     contributorToken,
   );
-  fixtures.ThenAllLocksAreReturned(
+  fixtures.ThenScenarioLockInfoIsReturned(
     firstScenarioResponse,
     ownerUserId,
     scenarioIdObj.firstScenarioId,
-    scenarioIdObj.secondScenarioId,
   );
-  const secondScenarioResponse = await fixtures.WhenGettingAllLocksFromScenarioId(
+  const secondScenarioResponse = await fixtures.WhenGettingLockFromScenario(
     scenarioIdObj.secondScenarioId,
     contributorToken,
   );
-  fixtures.ThenAllLocksAreReturned(
+  fixtures.ThenScenarioLockInfoIsReturned(
     secondScenarioResponse,
     ownerUserId,
-    scenarioIdObj.firstScenarioId,
     scenarioIdObj.secondScenarioId,
   );
 });
@@ -209,24 +205,22 @@ test(`getting all locks of scenarios as scenario viewer`, async () => {
     ownerToken,
   );
 
-  const firstScenarioResponse = await fixtures.WhenGettingAllLocksFromScenarioId(
+  const firstScenarioResponse = await fixtures.WhenGettingLockFromScenario(
     scenarioIdObj.firstScenarioId,
     viewerToken,
   );
-  fixtures.ThenAllLocksAreReturned(
+  fixtures.ThenScenarioLockInfoIsReturned(
     firstScenarioResponse,
     ownerUserId,
     scenarioIdObj.firstScenarioId,
-    scenarioIdObj.secondScenarioId,
   );
-  const secondScenarioResponse = await fixtures.WhenGettingAllLocksFromScenarioId(
+  const secondScenarioResponse = await fixtures.WhenGettingLockFromScenario(
     scenarioIdObj.secondScenarioId,
     viewerToken,
   );
-  fixtures.ThenAllLocksAreReturned(
+  fixtures.ThenScenarioLockInfoIsReturned(
     secondScenarioResponse,
     ownerUserId,
-    scenarioIdObj.firstScenarioId,
     scenarioIdObj.secondScenarioId,
   );
 });

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
@@ -310,5 +310,9 @@ export async function getFixtures() {
       expect(response.body.data.scenarioId).toEqual(scenarioId);
       expect(response.body.data.userId).toEqual(userId);
     },
+    ThenNoScenarioLockIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toEqual(null);
+    },
   };
 }

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
@@ -209,7 +209,7 @@ export async function getFixtures() {
         .set('Authorization', `Bearer ${contributorToken}`),
     WhenReleasingLockForScenario: async (token: string) =>
       await request(app.getHttpServer())
-        .patch(`/api/v1/scenarios/${scenarioId}/release-lock`)
+        .delete(`/api/v1/scenarios/${scenarioId}/lock`)
         .set('Authorization', `Bearer ${token}`),
     WhenGettingAllLocksFromProjectId: async (
       projectId: string,
@@ -218,10 +218,7 @@ export async function getFixtures() {
       await request(app.getHttpServer())
         .get(`/api/v1/projects/${projectId}/editing-locks`)
         .set('Authorization', `Bearer ${token}`),
-    WhenGettingAllLocksFromScenarioId: async (
-      scenarioId: string,
-      token: string,
-    ) =>
+    WhenGettingLockFromScenario: async (scenarioId: string, token: string) =>
       await request(app.getHttpServer())
         .get(`/api/v1/scenarios/${scenarioId}/editing-locks`)
         .set('Authorization', `Bearer ${token}`),
@@ -296,13 +293,22 @@ export async function getFixtures() {
       expect(firstScenario.userId).toEqual(userId);
       expect(secondScenario.userId).toEqual(userId);
     },
-    ThenScenarioLockInfoIsReturned: (
+    ThenScenarioLockInfoAfterCreationIsReturned: (
       response: request.Response,
       scenarioId: string,
     ) => {
       expect(response.status).toEqual(201);
       expect(response.body.data.scenarioId).toEqual(scenarioId);
       expect(response.body.data.userId).toEqual(ownerUserId);
+    },
+    ThenScenarioLockInfoIsReturned: (
+      response: request.Response,
+      userId: string,
+      scenarioId: string,
+    ) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data.scenarioId).toEqual(scenarioId);
+      expect(response.body.data.userId).toEqual(userId);
     },
   };
 }


### PR DESCRIPTION
-Changes `PATCH /scenarios/:scenarioId/release-lock` into `DELETE /scenarios/:scenarioId/lock`.
-Changes `GET /scenarios/:scenarioId/editing-locks` payload. No more an array of every scenario lock of the parent project of the scenario. It returns either the current lock in place (`{userId, scenarioId, createdAt}`) or null if unlocked.
-Adapt e2e tests to endpoint changes.