### PR TITLE
fix: surface cost events handler failed method

### DIFF
--- a/api/apps/api/src/modules/scenarios/cost-surface/infra/surface-cost.events-handler.ts
+++ b/api/apps/api/src/modules/scenarios/cost-surface/infra/surface-cost.events-handler.ts
@@ -64,14 +64,10 @@ export class SurfaceCostEventsHandler implements EventFactory<JobInput, true> {
   async failed(eventData: EventData<JobInput, true>): Promise<void> {
     const jobInput = await eventData.data;
 
-    if (this.isInitialCostJobInput(jobInput)) {
+    const isInitialCostJobInput =
+      (jobInput as InitialCostJobInput).puGridShape !== undefined;
+    if (isInitialCostJobInput) {
       await this.commandBus.execute(new DeleteScenario(jobInput.scenarioId));
     }
-  }
-
-  private isInitialCostJobInput(
-    jobInput: JobInput,
-  ): jobInput is InitialCostJobInput {
-    return (jobInput as InitialCostJobInput).puGridShape !== undefined;
   }
 }


### PR DESCRIPTION
This PR fixes `failed` method of `SurfaceCostEventsHandler`. Since the failed event listener reference is added directly (not as a callback) to `QueueEventsAdapter` instance, `this` reference in `SurfaceCostEventsHandler.failed` method was pointing to `QueueEventsAdapter` instead of `SurfaceCostEventsHandler`.

### Feature relevant tickets

[failure when marking a cost surface job as failed](https://vizzuality.atlassian.net/browse/MARXAN-1280)

