### PR TITLE
Feat/marxan 875 ensure import flow is connected

### DIFF
--- a/api/apps/api/src/migrations/api/1644845096640-AddImportEvents.ts
+++ b/api/apps/api/src/migrations/api/1644845096640-AddImportEvents.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddExportProjectEvents1644845096640 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO api_event_kinds (id) values
+        ('project.import.submitted/v1/alpha'),
+        ('project.import.finished/v1/alpha'),
+        ('project.import.failed/v1/alpha'),
+        ('project.import.piece.submitted/v1/alpha'),
+        ('project.import.piece.finished/v1/alpha'),
+        ('project.import.piece.failed/v1/alpha'),
+        ('scenario.import.submitted/v1/alpha'),
+        ('scenario.import.finished/v1/alpha'),
+        ('scenario.import.failed/v1/alpha'),
+        ('scenario.import.piece.submitted/v1/alpha'),
+        ('scenario.import.piece.finished/v1/alpha'),
+        ('scenario.import.piece.failed/v1/alpha');
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM api_event_kinds WHERE id IN (
+        'project.import.submitted/v1/alpha',
+        'project.import.finished/v1/alpha',
+        'project.import.failed/v1/alpha',
+        'project.import.piece.submitted/v1/alpha',
+        'project.import.piece.finished/v1/alpha',
+        'project.import.piece.failed/v1/alpha',
+        'scenario.import.submitted/v1/alpha',
+        'scenario.import.finished/v1/alpha',
+        'scenario.import.failed/v1/alpha',
+        'scenario.import.piece.submitted/v1/alpha',
+        'scenario.import.piece.finished/v1/alpha',
+        'scenario.import.piece.failed/v1/alpha'
+      );`,
+    );
+  }
+}

--- a/api/apps/api/src/modules/clone/export/adapters/entities/export-component-locations.api.entity.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/entities/export-component-locations.api.entity.ts
@@ -1,7 +1,9 @@
+import {
+  ComponentLocation,
+  ComponentLocationSnapshot,
+} from '@marxan/cloning/domain';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
-import { ComponentLocation } from '../../application/complete-piece.command';
 import { ExportComponentEntity } from './export-components.api.entity';
-import { ComponentLocationSnapshot } from '@marxan/cloning/domain/component-location.snapshot';
 
 @Entity('export_component_locations')
 export class ExportComponentLocationEntity {

--- a/api/apps/api/src/modules/clone/export/application/complete-export-piece.command.ts
+++ b/api/apps/api/src/modules/clone/export/application/complete-export-piece.command.ts
@@ -2,9 +2,7 @@ import { Command } from '@nestjs-architects/typed-cqrs';
 import { ComponentId, ComponentLocation } from '@marxan/cloning/domain';
 import { ExportId } from '../domain';
 
-export { ComponentId, ComponentLocation, ExportId };
-
-export class CompletePiece extends Command<void> {
+export class CompleteExportPiece extends Command<void> {
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,

--- a/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.ts
@@ -1,41 +1,40 @@
+import { ExportPieceFailed } from '@marxan-api/modules/clone/export/application/export-piece-failed.event';
+import { Logger } from '@nestjs/common';
 import {
   CommandHandler,
   EventBus,
   EventPublisher,
   IInferredCommandHandler,
 } from '@nestjs/cqrs';
-import { Logger } from '@nestjs/common';
-
-import { CompletePiece } from './complete-piece.command';
-import { ExportRepository } from './export-repository.port';
 import { isLeft } from 'fp-ts/Either';
-import { ExportPieceFailed } from '@marxan-api/modules/clone/export/application/export-piece-failed.event';
 import { Export } from '../domain';
+import { CompleteExportPiece } from './complete-export-piece.command';
+import { ExportRepository } from './export-repository.port';
 
-@CommandHandler(CompletePiece)
-export class CompletePieceHandler
-  implements IInferredCommandHandler<CompletePiece> {
+@CommandHandler(CompleteExportPiece)
+export class CompleteExportPieceHandler
+  implements IInferredCommandHandler<CompleteExportPiece> {
   constructor(
     private readonly exportRepository: ExportRepository,
     private readonly eventPublisher: EventPublisher,
     private readonly eventBus: EventBus,
     private readonly logger: Logger,
   ) {
-    this.logger.setContext(CompletePieceHandler.name);
+    this.logger.setContext(CompleteExportPieceHandler.name);
   }
 
   async execute({
     exportId,
     componentLocation,
     componentId,
-  }: CompletePiece): Promise<void> {
+  }: CompleteExportPiece): Promise<void> {
     let exportInstance: Export | undefined;
     await this.exportRepository
       .transaction(async (repo) => {
         exportInstance = await repo.find(exportId);
 
         if (!exportInstance) {
-          const errorMessage = `${CompletePieceHandler.name} could not find export ${exportId.value} to complete piece: ${componentId.value}`;
+          const errorMessage = `${CompleteExportPieceHandler.name} could not find export ${exportId.value} to complete piece: ${componentId.value}`;
           this.logger.error(errorMessage);
           throw new Error(errorMessage);
         }

--- a/api/apps/api/src/modules/clone/export/application/export-application.module.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-application.module.ts
@@ -1,4 +1,10 @@
-import { DynamicModule, Logger, Module, ModuleMetadata } from '@nestjs/common';
+import {
+  DynamicModule,
+  Logger,
+  Module,
+  ModuleMetadata,
+  Scope,
+} from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { AllPiecesReadySaga } from './all-pieces-ready.saga';
 import { CompleteExportPieceHandler } from './complete-export-piece.handler';
@@ -22,7 +28,11 @@ export class ExportApplicationModule {
         CompleteExportPieceHandler,
         FinalizeArchiveHandler,
         GetArchiveHandler,
-        Logger,
+        {
+          provide: Logger,
+          useClass: Logger,
+          scope: Scope.TRANSIENT,
+        },
       ],
       exports: [],
     };

--- a/api/apps/api/src/modules/clone/export/application/export-application.module.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-application.module.ts
@@ -1,12 +1,11 @@
 import { DynamicModule, Logger, Module, ModuleMetadata } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
-
-import { ExportProjectHandler } from './export-project.handler';
-import { CompletePieceHandler } from './complete-piece.handler';
-import { FinalizeArchiveHandler } from './finalize-archive.handler';
 import { AllPiecesReadySaga } from './all-pieces-ready.saga';
-import { GetArchiveHandler } from './get-archive.handler';
+import { CompleteExportPieceHandler } from './complete-export-piece.handler';
+import { ExportProjectHandler } from './export-project.handler';
 import { ExportScenarioHandler } from './export-scenario.handler';
+import { FinalizeArchiveHandler } from './finalize-archive.handler';
+import { GetArchiveHandler } from './get-archive.handler';
 
 @Module({})
 export class ExportApplicationModule {
@@ -20,7 +19,7 @@ export class ExportApplicationModule {
         // use cases
         ExportProjectHandler,
         ExportScenarioHandler,
-        CompletePieceHandler,
+        CompleteExportPieceHandler,
         FinalizeArchiveHandler,
         GetArchiveHandler,
         Logger,

--- a/api/apps/api/src/modules/clone/export/application/export-piece-failed.event.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-piece-failed.event.ts
@@ -8,6 +8,7 @@ import { ExportId } from '@marxan-api/modules/clone';
 import { IEvent } from '@nestjs/cqrs';
 
 export class ExportPieceFailed implements IEvent {
+  // TODO Check if all parameters are needed
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,

--- a/api/apps/api/src/modules/clone/export/application/export-project.command.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.command.ts
@@ -2,9 +2,6 @@ import { Command } from '@nestjs-architects/typed-cqrs';
 import { ResourceId } from '@marxan/cloning/domain';
 import { ExportId } from '../domain';
 
-export { ExportId };
-export { ResourceId };
-
 export class ExportProject extends Command<ExportId> {
   constructor(public readonly id: ResourceId) {
     super();

--- a/api/apps/api/src/modules/clone/export/application/export-scenario.command.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-scenario.command.ts
@@ -2,9 +2,6 @@ import { Command } from '@nestjs-architects/typed-cqrs';
 import { ResourceId } from '@marxan/cloning/domain';
 import { ExportId } from '../domain';
 
-export { ExportId };
-export { ResourceId };
-
 export class ExportScenario extends Command<ExportId> {
   constructor(public readonly id: ResourceId) {
     super();

--- a/api/apps/api/src/modules/clone/export/index.ts
+++ b/api/apps/api/src/modules/clone/export/index.ts
@@ -1,8 +1,4 @@
 export { ExportModule } from './export.module';
-export {
-  ExportProject,
-  ResourceId,
-  ExportId,
-} from './application/export-project.command';
-
+export { ExportProject } from './application/export-project.command';
+export { ExportId } from './domain/export/export.id';
 export { GetExportArchive } from './application/get-archive.query';

--- a/api/apps/api/src/modules/clone/import/application/import-archive.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-archive.spec.ts
@@ -185,7 +185,7 @@ const getFixtures = async () => {
         events.filter((event) => event instanceof ImportRequested),
       ).toEqual([
         {
-          id: expect.any(ImportId),
+          importId: expect.any(ImportId),
           resourceId,
           resourceKind: `project`,
         },
@@ -196,7 +196,7 @@ const getFixtures = async () => {
         events.filter((event) => event instanceof PieceImportRequested),
       ).toMatchObject([
         {
-          id: new ComponentId(`import component unique id`),
+          componentId: new ComponentId(`import component unique id`),
           resourceId: projectId,
           piece: `project-metadata`,
           uris: [
@@ -213,7 +213,7 @@ const getFixtures = async () => {
         events.filter((event) => event instanceof PieceImportRequested),
       ).toMatchObject([
         {
-          id: new ComponentId(`import component unique id`),
+          componentId: new ComponentId(`import component unique id`),
           resourceId: projectId,
           piece: `project-metadata`,
           uris: [
@@ -224,7 +224,7 @@ const getFixtures = async () => {
           ],
         },
         {
-          id: new ComponentId(`some other piece`),
+          componentId: new ComponentId(`some other piece`),
           resourceId: projectId,
           piece: `planning-area-gadm`,
           uris: [

--- a/api/apps/api/src/modules/clone/import/application/import-archive.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-archive.ts
@@ -37,6 +37,6 @@ export class ImportArchive {
 
     importRequest.commit();
 
-    return right(importRequest.id.value);
+    return right(importRequest.importId.value);
   }
 }

--- a/api/apps/api/src/modules/clone/import/application/import-piece-failed.event.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-piece-failed.event.ts
@@ -1,4 +1,4 @@
-import { ComponentId, ResourceId, ResourceKind } from '@marxan/cloning/domain';
+import { ComponentId } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
 import { ImportId } from '../domain';
 
@@ -6,7 +6,5 @@ export class ImportPieceFailed implements IEvent {
   constructor(
     public readonly importId: ImportId,
     public readonly componentId: ComponentId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
   ) {}
 }

--- a/api/apps/api/src/modules/clone/import/application/import-piece-failed.event.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-piece-failed.event.ts
@@ -1,0 +1,12 @@
+import { ComponentId, ResourceId, ResourceKind } from '@marxan/cloning/domain';
+import { IEvent } from '@nestjs/cqrs';
+import { ImportId } from '../domain';
+
+export class ImportPieceFailed implements IEvent {
+  constructor(
+    public readonly importId: ImportId,
+    public readonly componentId: ComponentId,
+    public readonly resourceId: ResourceId,
+    public readonly resourceKind: ResourceKind,
+  ) {}
+}

--- a/api/apps/api/src/modules/clone/import/domain/events/all-pieces-imported.event.ts
+++ b/api/apps/api/src/modules/clone/import/domain/events/all-pieces-imported.event.ts
@@ -1,11 +1,6 @@
-import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
 import { ImportId } from '../import/import.id';
 
 export class AllPiecesImported implements IEvent {
-  constructor(
-    public readonly importId: ImportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-  ) {}
+  constructor(public readonly importId: ImportId) {}
 }

--- a/api/apps/api/src/modules/clone/import/domain/events/import-requested.event.ts
+++ b/api/apps/api/src/modules/clone/import/domain/events/import-requested.event.ts
@@ -4,7 +4,7 @@ import { ImportId } from '../import/import.id';
 
 export class ImportRequested implements IEvent {
   constructor(
-    public readonly id: ImportId,
+    public readonly importId: ImportId,
     public readonly resourceId: ResourceId,
     public readonly resourceKind: ResourceKind,
   ) {}

--- a/api/apps/api/src/modules/clone/import/domain/events/piece-import-requested.event.ts
+++ b/api/apps/api/src/modules/clone/import/domain/events/piece-import-requested.event.ts
@@ -11,7 +11,7 @@ import { ImportId } from '../import/import.id';
 export class PieceImportRequested implements IEvent {
   constructor(
     public readonly importId: ImportId,
-    public readonly id: ComponentId,
+    public readonly componentId: ComponentId,
     public readonly piece: ClonePiece,
     public readonly resourceId: ResourceId,
     public readonly resourceKind: ResourceKind,

--- a/api/apps/api/src/modules/clone/import/domain/import/import.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.ts
@@ -84,7 +84,10 @@ export class Import extends AggregateRoot {
     const isThisTheLastBatch = false;
     const isThisBatchCompleted = false;
 
-    if (isThisTheLastBatch) this.apply(new AllPiecesImported());
+    if (isThisTheLastBatch)
+      this.apply(
+        new AllPiecesImported(this.id, this.resourceId, this.resourceKind),
+      );
     if (isThisTheLastBatch || !isThisBatchCompleted) return right(true);
 
     const nextBatch = this.pieces.filter(
@@ -119,7 +122,9 @@ export class Import extends AggregateRoot {
 
   private requestFirstBatch() {
     if (this.pieces.length === 0) {
-      this.apply(new AllPiecesImported());
+      this.apply(
+        new AllPiecesImported(this.id, this.resourceId, this.resourceKind),
+      );
       return;
     }
     const firstBatchOrder = Math.min(

--- a/api/apps/api/src/modules/clone/import/domain/import/import.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.ts
@@ -91,13 +91,15 @@ export class Import extends AggregateRoot {
       (piece) => piece.order === pieceToComplete.order + 1,
     );
 
-    for (const nextPiece of nextBatch) {
+    for (const component of nextBatch) {
       this.apply(
         new PieceImportRequested(
-          nextPiece.id,
-          nextPiece.piece,
-          nextPiece.resourceId,
-          nextPiece.uris,
+          this.id,
+          component.id,
+          component.piece,
+          component.resourceId,
+          this.resourceKind,
+          component.uris,
         ),
       );
     }
@@ -129,9 +131,11 @@ export class Import extends AggregateRoot {
     )) {
       this.apply(
         new PieceImportRequested(
+          this.id,
           component.id,
           component.piece,
           component.resourceId,
+          this.resourceKind,
           component.uris,
         ),
       );

--- a/api/apps/api/src/modules/clone/infra/export/cancel-export-pending-jobs.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/cancel-export-pending-jobs.command.ts
@@ -1,6 +1,6 @@
 import { Command } from '@nestjs-architects/typed-cqrs';
-import { ExportId, ResourceId } from '@marxan-api/modules/clone';
-import { ResourceKind } from '@marxan/cloning/domain';
+import { ExportId } from '@marxan-api/modules/clone';
+import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 
 export class CancelExportPendingJobs extends Command<void> {
   constructor(

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
@@ -1,4 +1,6 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
 import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
+import { ResourceKind } from '@marxan/cloning/domain';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import {
   CommandBus,
@@ -10,15 +12,13 @@ import {
 } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
 import { v4 } from 'uuid';
-import { API_EVENT_KINDS } from '@marxan/api-events';
-import { ResourceKind } from '@marxan/cloning/domain';
 import { CreateApiEventDTO } from '../../../api-events/dto/create.api-event.dto';
 import { QueueModule } from '../../../queue';
 import { EventData, EventFactory } from '../../../queue-api-events';
+import { CompleteExportPiece } from '../../export/application/complete-export-piece.command';
+import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
 import { ExportPieceEventsHandler } from './export-piece.events-handler';
 import { exportPieceEventsFactoryToken } from './export-queue.provider';
-import { CompletePiece } from '../../export/application/complete-piece.command';
-import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -129,7 +129,7 @@ const getFixtures = async () => {
     ThenACompletePieceCommandShouldBeSent: () => {
       expect(commands).toHaveLength(1);
       const [completePieceCommand] = commands;
-      expect(completePieceCommand).toBeInstanceOf(CompletePiece);
+      expect(completePieceCommand).toBeInstanceOf(CompleteExportPiece);
     },
     ThenAExportPieceFailedEventShouldBePublished: () => {
       expect(events).toHaveLength(1);
@@ -170,7 +170,7 @@ export class FakeQueueEvents {
   }
 }
 
-@CommandHandler(CompletePiece)
+@CommandHandler(CompleteExportPiece)
 export class FakeCompletePieceHandler {
   async execute(): Promise<void> {}
 }

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
@@ -11,12 +11,13 @@ import {
   ComponentId,
   ComponentLocation,
   ResourceKind,
+  ResourceId,
 } from '@marxan/cloning/domain';
 import { assertDefined } from '@marxan/utils';
 import { Inject, Injectable } from '@nestjs/common';
 import { CommandBus, EventBus } from '@nestjs/cqrs';
 import { ApiEventsService } from '../../../api-events';
-import { ExportId, ResourceId } from '../../export';
+import { ExportId } from '../../export';
 import { CompleteExportPiece } from '../../export/application/complete-export-piece.command';
 import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
 import { exportPieceEventsFactoryToken } from './export-queue.provider';

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
@@ -1,29 +1,25 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { CommandBus, EventBus } from '@nestjs/cqrs';
-
-import { ExportJobInput, ExportJobOutput } from '@marxan/cloning';
-
 import { CreateApiEventDTO } from '@marxan-api/modules/api-events/dto/create.api-event.dto';
-import { API_EVENT_KINDS } from '@marxan/api-events';
-import { assertDefined } from '@marxan/utils';
 import {
   CreateWithEventFactory,
   EventData,
   EventFactory,
   QueueEventsAdapter,
 } from '@marxan-api/modules/queue-api-events';
-
-import { exportPieceEventsFactoryToken } from './export-queue.provider';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { ExportJobInput, ExportJobOutput } from '@marxan/cloning';
 import {
-  CompletePiece,
   ComponentId,
   ComponentLocation,
-  ExportId,
-} from '../../export/application/complete-piece.command';
-import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
-import { ResourceId } from '../../export';
+  ResourceKind,
+} from '@marxan/cloning/domain';
+import { assertDefined } from '@marxan/utils';
+import { Inject, Injectable } from '@nestjs/common';
+import { CommandBus, EventBus } from '@nestjs/cqrs';
 import { ApiEventsService } from '../../../api-events';
-import { ResourceKind } from '@marxan/cloning/domain';
+import { ExportId, ResourceId } from '../../export';
+import { CompleteExportPiece } from '../../export/application/complete-export-piece.command';
+import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
+import { exportPieceEventsFactoryToken } from './export-queue.provider';
 
 @Injectable()
 export class ExportPieceEventsHandler
@@ -97,7 +93,7 @@ export class ExportPieceEventsHandler
     const result = await event.result;
     assertDefined(result);
     await this.commandBus.execute(
-      new CompletePiece(
+      new CompleteExportPiece(
         new ExportId(result.exportId),
         new ComponentId(result.componentId),
         result.uris.map(

--- a/api/apps/api/src/modules/clone/infra/export/export.infra.module.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export.infra.module.ts
@@ -1,4 +1,4 @@
-import { Logger, Module } from '@nestjs/common';
+import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 
 import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
@@ -39,7 +39,11 @@ import { MarkExportPiecesAsFailedHandler } from './mark-export-pieces-as-failed.
     CancelExportPendingJobsHandler,
     MarkExportAsFailedHandler,
     MarkExportPiecesAsFailedHandler,
-    Logger,
+    {
+      provide: Logger,
+      useClass: Logger,
+      scope: Scope.TRANSIENT,
+    },
   ],
 })
 export class ExportInfraModule {}

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.command.ts
@@ -1,6 +1,6 @@
 import { Command } from '@nestjs-architects/typed-cqrs';
-import { ExportId, ResourceId } from '@marxan-api/modules/clone';
-import { ResourceKind } from '@marxan/cloning/domain';
+import { ExportId } from '@marxan-api/modules/clone';
+import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 
 export class MarkExportAsFailed extends Command<void> {
   constructor(

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.command.ts
@@ -1,6 +1,6 @@
 import { Command } from '@nestjs-architects/typed-cqrs';
-import { ExportId, ResourceId } from '@marxan-api/modules/clone';
-import { ResourceKind } from '@marxan/cloning/domain';
+import { ExportId } from '@marxan-api/modules/clone';
+import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 
 export class MarkExportAsFinished extends Command<void> {
   constructor(

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-submitted.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-submitted.command.ts
@@ -1,6 +1,6 @@
 import { Command } from '@nestjs-architects/typed-cqrs';
-import { ResourceKind } from '@marxan/cloning/domain';
-import { ExportId, ResourceId } from '../../export';
+import { ResourceKind, ResourceId } from '@marxan/cloning/domain';
+import { ExportId } from '../../export';
 
 export class MarkExportAsSubmitted extends Command<void> {
   constructor(

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-pieces-as-failed.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-pieces-as-failed.command.ts
@@ -1,6 +1,6 @@
 import { Command } from '@nestjs-architects/typed-cqrs';
-import { ComponentId, ResourceKind } from '@marxan/cloning/domain';
-import { ExportId, ResourceId } from '../../export';
+import { ComponentId, ResourceKind, ResourceId } from '@marxan/cloning/domain';
+import { ExportId } from '../../export';
 
 export class MarkExportPiecesAsFailed extends Command<void> {
   constructor(

--- a/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.spec.ts
@@ -1,19 +1,20 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import {
+  ClonePiece,
+  ComponentId,
+  ResourceId,
+  ResourceKind,
+} from '@marxan/cloning/domain';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
 import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
-import { v4 } from 'uuid';
-import { ClonePiece, ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { ApiEventsService } from '../../../api-events';
-import {
-  ComponentId,
-  ExportId,
-} from '../../export/application/complete-piece.command';
+import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
+import { ExportId } from '../../export/domain';
 import { exportPieceQueueToken } from './export-queue.provider';
 import { SchedulePieceExport } from './schedule-piece-export.command';
 import { SchedulePieceExportHandler } from './schedule-piece-export.handler';
-import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
-import { API_EVENT_KINDS } from '@marxan/api-events';
-import { Logger } from '@nestjs/common';
 
 let fixtures: FixtureType<typeof getFixtures>;
 

--- a/api/apps/api/src/modules/clone/infra/import/all-pieces-imported.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/all-pieces-imported.saga.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MarkImportAsFinished } from './mark-import-as-finished.command';
+import { AllPiecesImported } from '../../import/domain';
+
+@Injectable()
+export class AllPiecesImportedSaga {
+  @Saga()
+  finalizeArchive = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(AllPiecesImported),
+      map(
+        (event) =>
+          new MarkImportAsFinished(
+            event.importId,
+            event.resourceId,
+            event.resourceKind,
+          ),
+      ),
+    );
+}

--- a/api/apps/api/src/modules/clone/infra/import/all-pieces-imported.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/all-pieces-imported.saga.ts
@@ -11,13 +11,6 @@ export class AllPiecesImportedSaga {
   finalizeArchive = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
       ofType(AllPiecesImported),
-      map(
-        (event) =>
-          new MarkImportAsFinished(
-            event.importId,
-            event.resourceId,
-            event.resourceKind,
-          ),
-      ),
+      map((event) => new MarkImportAsFinished(event.importId)),
     );
 }

--- a/api/apps/api/src/modules/clone/infra/import/import-requested-saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import-requested-saga.ts
@@ -11,13 +11,6 @@ export class ImportRequestedSaga {
   emitApiEvents = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
       ofType(ImportRequested),
-      map(
-        (event) =>
-          new MarkImportAsSubmitted(
-            event.id,
-            event.resourceId,
-            event.resourceKind,
-          ),
-      ),
+      map((event) => new MarkImportAsSubmitted(event.importId)),
     );
 }

--- a/api/apps/api/src/modules/clone/infra/import/import-requested-saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import-requested-saga.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ImportRequested } from '../../import/domain';
+import { MarkImportAsSubmitted } from './mark-import-as-submitted.command';
+
+@Injectable()
+export class ImportRequestedSaga {
+  @Saga()
+  emitApiEvents = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(ImportRequested),
+      map(
+        (event) =>
+          new MarkImportAsSubmitted(
+            event.id,
+            event.resourceId,
+            event.resourceKind,
+          ),
+      ),
+    );
+}

--- a/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
@@ -7,6 +7,8 @@ import {
   importPiecenQueueEventsProvider,
   importPieceQueueProvider,
 } from './import-queue.provider';
+import { ImportRequestedSaga } from './import-requested-saga';
+import { MarkImportAsSubmittedHandler } from './mark-import-as-submitted.handler';
 import { PieceImportRequestedSaga } from './piece-import-requested.saga';
 import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
 
@@ -15,6 +17,8 @@ import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
   providers: [
     PieceImportRequestedSaga,
     SchedulePieceImportHandler,
+    ImportRequestedSaga,
+    MarkImportAsSubmittedHandler,
     importPieceQueueProvider,
     importPiecenQueueEventsProvider,
     importPieceEventsFactoryProvider,

--- a/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
@@ -1,7 +1,8 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { ApiEventsModule } from '../../../api-events';
 import { QueueApiEventsModule } from '../../../queue-api-events';
+import { ImportAdaptersModule } from '../../import/adapters/import-adapters.module';
 import { AllPiecesImportedSaga } from './all-pieces-imported.saga';
 import {
   importPieceEventsFactoryProvider,
@@ -15,7 +16,12 @@ import { PieceImportRequestedSaga } from './piece-import-requested.saga';
 import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
 
 @Module({
-  imports: [ApiEventsModule, QueueApiEventsModule, CqrsModule],
+  imports: [
+    ApiEventsModule,
+    QueueApiEventsModule,
+    CqrsModule,
+    ImportAdaptersModule,
+  ],
   providers: [
     PieceImportRequestedSaga,
     AllPiecesImportedSaga,
@@ -23,6 +29,11 @@ import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
     ImportRequestedSaga,
     MarkImportAsSubmittedHandler,
     MarkImportAsFinishedHandler,
+    {
+      provide: Logger,
+      useClass: Logger,
+      scope: Scope.TRANSIENT,
+    },
     importPieceQueueProvider,
     importPiecenQueueEventsProvider,
     importPieceEventsFactoryProvider,

--- a/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
@@ -7,10 +7,14 @@ import {
   importPiecenQueueEventsProvider,
   importPieceQueueProvider,
 } from './import-queue.provider';
+import { PieceImportRequestedSaga } from './piece-import-requested.saga';
+import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
 
 @Module({
   imports: [ApiEventsModule, QueueApiEventsModule, CqrsModule],
   providers: [
+    PieceImportRequestedSaga,
+    SchedulePieceImportHandler,
     importPieceQueueProvider,
     importPiecenQueueEventsProvider,
     importPieceEventsFactoryProvider,

--- a/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import.infra.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { ApiEventsModule } from '../../../api-events';
 import { QueueApiEventsModule } from '../../../queue-api-events';
+import { AllPiecesImportedSaga } from './all-pieces-imported.saga';
 import {
   importPieceEventsFactoryProvider,
   importPiecenQueueEventsProvider,
   importPieceQueueProvider,
 } from './import-queue.provider';
 import { ImportRequestedSaga } from './import-requested-saga';
+import { MarkImportAsFinishedHandler } from './mark-import-as-finished.handler';
 import { MarkImportAsSubmittedHandler } from './mark-import-as-submitted.handler';
 import { PieceImportRequestedSaga } from './piece-import-requested.saga';
 import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
@@ -16,9 +18,11 @@ import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
   imports: [ApiEventsModule, QueueApiEventsModule, CqrsModule],
   providers: [
     PieceImportRequestedSaga,
+    AllPiecesImportedSaga,
     SchedulePieceImportHandler,
     ImportRequestedSaga,
     MarkImportAsSubmittedHandler,
+    MarkImportAsFinishedHandler,
     importPieceQueueProvider,
     importPiecenQueueEventsProvider,
     importPieceEventsFactoryProvider,

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.command.ts
@@ -1,11 +1,13 @@
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
-import { IEvent } from '@nestjs/cqrs';
-import { ImportId } from '../import/import.id';
+import { Command } from '@nestjs-architects/typed-cqrs';
+import { ImportId } from '../../import/domain';
 
-export class AllPiecesImported implements IEvent {
+export class MarkImportAsFinished extends Command<void> {
   constructor(
     public readonly importId: ImportId,
     public readonly resourceId: ResourceId,
     public readonly resourceKind: ResourceKind,
-  ) {}
+  ) {
+    super();
+  }
 }

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.command.ts
@@ -1,13 +1,8 @@
-import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { ImportId } from '../../import/domain';
 
 export class MarkImportAsFinished extends Command<void> {
-  constructor(
-    public readonly importId: ImportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-  ) {
+  constructor(public readonly importId: ImportId) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.handler.ts
@@ -1,7 +1,9 @@
 import { ApiEventsService } from '@marxan-api/modules/api-events';
 import { API_EVENT_KINDS } from '@marxan/api-events';
 import { ResourceKind } from '@marxan/cloning/domain';
+import { Logger } from '@nestjs/common';
 import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { ImportRepository } from '../../import/application/import.repository.port';
 import { MarkImportAsFinished } from './mark-import-as-finished.command';
 
 @CommandHandler(MarkImportAsFinished)
@@ -12,21 +14,31 @@ export class MarkImportAsFinishedHandler
     scenario: API_EVENT_KINDS.scenario__import__finished__v1__alpha,
   };
 
-  constructor(private readonly apiEvents: ApiEventsService) {}
+  constructor(
+    private readonly apiEvents: ApiEventsService,
+    private readonly importRepository: ImportRepository,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(MarkImportAsFinishedHandler.name);
+  }
 
-  async execute({
-    resourceKind,
-    resourceId,
-    importId,
-  }: MarkImportAsFinished): Promise<void> {
+  async execute({ importId }: MarkImportAsFinished): Promise<void> {
+    const importInstance = await this.importRepository.find(importId);
+
+    if (!importInstance) {
+      this.logger.error(`Import with ID ${importId.value} not found`);
+      return;
+    }
+    const { resourceKind, resourceId } = importInstance.toSnapshot();
+
     const kind = this.eventMapper[resourceKind];
 
     await this.apiEvents.createIfNotExists({
       kind,
-      topic: resourceId.value,
+      topic: resourceId,
       data: {
         exportId: importId.value,
-        resourceId: resourceId.value,
+        resourceId: resourceId,
         resourceKind,
       },
     });

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.handler.ts
@@ -1,0 +1,34 @@
+import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { ResourceKind } from '@marxan/cloning/domain';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { MarkImportAsFinished } from './mark-import-as-finished.command';
+
+@CommandHandler(MarkImportAsFinished)
+export class MarkImportAsFinishedHandler
+  implements IInferredCommandHandler<MarkImportAsFinished> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__import__finished__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__import__finished__v1__alpha,
+  };
+
+  constructor(private readonly apiEvents: ApiEventsService) {}
+
+  async execute({
+    resourceKind,
+    resourceId,
+    importId,
+  }: MarkImportAsFinished): Promise<void> {
+    const kind = this.eventMapper[resourceKind];
+
+    await this.apiEvents.createIfNotExists({
+      kind,
+      topic: resourceId.value,
+      data: {
+        exportId: importId.value,
+        resourceId: resourceId.value,
+        resourceKind,
+      },
+    });
+  }
+}

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.command.ts
@@ -1,0 +1,13 @@
+import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
+import { ImportId } from '../../import/domain';
+
+export class MarkImportAsSubmitted extends Command<void> {
+  constructor(
+    public readonly importId: ImportId,
+    public readonly resourceId: ResourceId,
+    public readonly resourceKind: ResourceKind,
+  ) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.command.ts
@@ -1,13 +1,8 @@
-import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { ImportId } from '../../import/domain';
 
 export class MarkImportAsSubmitted extends Command<void> {
-  constructor(
-    public readonly importId: ImportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-  ) {
+  constructor(public readonly importId: ImportId) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.handler.ts
@@ -1,0 +1,34 @@
+import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { ResourceKind } from '@marxan/cloning/domain';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { MarkImportAsSubmitted } from './mark-import-as-submitted.command';
+
+@CommandHandler(MarkImportAsSubmitted)
+export class MarkImportAsSubmittedHandler
+  implements IInferredCommandHandler<MarkImportAsSubmitted> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__import__submitted__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__import__submitted__v1__alpha,
+  };
+
+  constructor(private readonly apiEvents: ApiEventsService) {}
+
+  async execute({
+    importId,
+    resourceId,
+    resourceKind,
+  }: MarkImportAsSubmitted): Promise<void> {
+    const kind = this.eventMapper[resourceKind];
+
+    await this.apiEvents.createIfNotExists({
+      kind,
+      topic: resourceId.value,
+      data: {
+        importId: importId.value,
+        resourceId: resourceId.value,
+        resourceKind,
+      },
+    });
+  }
+}

--- a/api/apps/api/src/modules/clone/infra/import/piece-import-requested.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/piece-import-requested.saga.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { PieceImportRequested } from '@marxan-api/modules/clone/import/domain';
+import { SchedulePieceImport } from './schedule-piece-import.command';
+
+@Injectable()
+export class PieceImportRequestedSaga {
+  @Saga()
+  scheduleImport = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(PieceImportRequested),
+      map(
+        (event) =>
+          new SchedulePieceImport(
+            event.importId,
+            event.id,
+            event.resourceId,
+            event.resourceKind,
+            event.piece,
+            event.uris,
+          ),
+      ),
+    );
+}

--- a/api/apps/api/src/modules/clone/infra/import/piece-import-requested.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/piece-import-requested.saga.ts
@@ -13,15 +13,7 @@ export class PieceImportRequestedSaga {
     events$.pipe(
       ofType(PieceImportRequested),
       map(
-        (event) =>
-          new SchedulePieceImport(
-            event.importId,
-            event.id,
-            event.resourceId,
-            event.resourceKind,
-            event.piece,
-            event.uris,
-          ),
+        (event) => new SchedulePieceImport(event.importId, event.componentId),
       ),
     );
 }

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.command.ts
@@ -1,3 +1,4 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
 import {
   ClonePiece,
   ComponentId,
@@ -5,16 +6,17 @@ import {
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';
-import { IEvent } from '@nestjs/cqrs';
-import { ImportId } from '../import/import.id';
+import { ImportId } from '@marxan-api/modules/clone/import/domain';
 
-export class PieceImportRequested implements IEvent {
+export class SchedulePieceImport extends Command<void> {
   constructor(
     public readonly importId: ImportId,
-    public readonly id: ComponentId,
-    public readonly piece: ClonePiece,
+    public readonly componentId: ComponentId,
     public readonly resourceId: ResourceId,
     public readonly resourceKind: ResourceKind,
+    public readonly piece: ClonePiece,
     public readonly uris: ComponentLocation[],
-  ) {}
+  ) {
+    super();
+  }
 }

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.command.ts
@@ -1,21 +1,11 @@
-import { Command } from '@nestjs-architects/typed-cqrs';
-import {
-  ClonePiece,
-  ComponentId,
-  ComponentLocation,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
 import { ImportId } from '@marxan-api/modules/clone/import/domain';
+import { ComponentId } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class SchedulePieceImport extends Command<void> {
   constructor(
     public readonly importId: ImportId,
     public readonly componentId: ComponentId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-    public readonly piece: ClonePiece,
-    public readonly uris: ComponentLocation[],
   ) {
     super();
   }

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
@@ -19,14 +19,6 @@ import { importPieceQueueToken } from './import-queue.provider';
 import { SchedulePieceImport } from './schedule-piece-import.command';
 import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
 
-function getDifferentComponentId(previous: ComponentId): ComponentId {
-  let newId = ComponentId.create();
-  while (previous.value === newId.value) {
-    newId = ComponentId.create();
-  }
-  return newId;
-}
-
 let fixtures: FixtureType<typeof getFixtures>;
 
 beforeEach(async () => {
@@ -58,10 +50,9 @@ it('should emit an ImportPieceFailed event if the import instance cannot be retr
 });
 
 it('should emit an ImportPieceFailed event if the import component is not found in import pieces', async () => {
-  const [importId, componentId] = await fixtures.GivenImportIsCreated();
-  const anotherComponentId = getDifferentComponentId(componentId);
+  const [importId] = await fixtures.GivenImportIsCreated();
 
-  fixtures.GivenSchedulePieceImportCommand(importId, anotherComponentId);
+  fixtures.GivenSchedulePieceImportCommand(importId, ComponentId.create());
 
   await fixtures.WhenSchedulePieceImportHandlerIsInvoked({
     addMockResolvedValue: 'job',

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
@@ -1,0 +1,121 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import {
+  ClonePiece,
+  ComponentId,
+  ComponentLocation,
+  ResourceId,
+  ResourceKind,
+} from '@marxan/cloning/domain';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
+import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+import { ApiEventsService } from '../../../api-events';
+import { ImportPieceFailed } from '../../import/application/import-piece-failed.event';
+import { ImportId } from '../../import/domain';
+import { importPieceQueueToken } from './import-queue.provider';
+import { SchedulePieceImport } from './schedule-piece-import.command';
+import { SchedulePieceImportHandler } from './schedule-piece-import.handler';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+it('should add a import-piece job to the queue and create a import piece submitted api event', async () => {
+  fixtures.GivenSchedulePieceImportCommand();
+
+  await fixtures.WhenJobIsAddedToQueue();
+
+  fixtures.ThenImportPieceSubmittedApiEventIsCreated();
+});
+
+it('should emit an ImportPieceFailed event if the job cannot be added to the queue', async () => {
+  fixtures.GivenSchedulePieceImportCommand();
+
+  await fixtures.WhenAddingJobToQueueFails();
+
+  fixtures.ThenImportPieceFailedEventIsPublished();
+});
+
+const getFixtures = async () => {
+  const createIfNotExistsMock = jest.fn();
+  const addMock = jest.fn();
+
+  const sandbox = await Test.createTestingModule({
+    imports: [CqrsModule],
+    providers: [
+      {
+        provide: ApiEventsService,
+        useValue: {
+          createIfNotExists: createIfNotExistsMock,
+        },
+      },
+      {
+        provide: importPieceQueueToken,
+        useValue: {
+          add: addMock,
+        },
+      },
+      {
+        provide: Logger,
+        useValue: {
+          setContext: () => {},
+          error: () => {},
+        },
+      },
+      SchedulePieceImportHandler,
+    ],
+  }).compile();
+  await sandbox.init();
+
+  const events: IEvent[] = [];
+  sandbox.get(EventBus).subscribe((event) => {
+    events.push(event);
+  });
+  let command: SchedulePieceImport;
+
+  const sut = sandbox.get(SchedulePieceImportHandler);
+
+  const uri = 'zip.location';
+  const relativePath = './project.metadata.json';
+
+  return {
+    GivenSchedulePieceImportCommand: (): SchedulePieceImport => {
+      command = new SchedulePieceImport(
+        ImportId.create(),
+        ComponentId.create(),
+        ResourceId.create(),
+        ResourceKind.Project,
+        ClonePiece.ProjectMetadata,
+        [new ComponentLocation(uri, relativePath)],
+      );
+
+      return command;
+    },
+    WhenJobIsAddedToQueue: async () => {
+      addMock.mockResolvedValueOnce('job added successfully');
+
+      await sut.execute(command);
+    },
+    WhenAddingJobToQueueFails: async () => {
+      addMock.mockResolvedValueOnce(undefined);
+
+      await sut.execute(command);
+    },
+    ThenImportPieceSubmittedApiEventIsCreated: () => {
+      expect(createIfNotExistsMock).toHaveBeenCalledTimes(1);
+      expect(createIfNotExistsMock).toHaveBeenCalledWith({
+        kind: API_EVENT_KINDS.project__import__piece__submitted__v1__alpha,
+        topic: command.componentId.value,
+        data: expect.any(Object),
+      });
+    },
+    ThenImportPieceFailedEventIsPublished: () => {
+      expect(events).toHaveLength(1);
+      const [exportPieceFailedEvent] = events;
+      expect(exportPieceFailedEvent).toBeInstanceOf(ImportPieceFailed);
+    },
+  };
+};

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.ts
@@ -1,0 +1,68 @@
+import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { ImportJobInput } from '@marxan/cloning';
+import { ResourceKind } from '@marxan/cloning/domain';
+import { Inject } from '@nestjs/common';
+import {
+  CommandHandler,
+  EventBus,
+  IInferredCommandHandler,
+} from '@nestjs/cqrs';
+import { Queue } from 'bullmq';
+import { ImportPieceFailed } from '../../import/application/import-piece-failed.event';
+import { importPieceQueueToken } from './import-queue.provider';
+import { SchedulePieceImport } from './schedule-piece-import.command';
+
+@CommandHandler(SchedulePieceImport)
+export class SchedulePieceImportHandler
+  implements IInferredCommandHandler<SchedulePieceImport> {
+  private eventMapper: Record<ResourceKind, API_EVENT_KINDS> = {
+    project: API_EVENT_KINDS.project__import__piece__submitted__v1__alpha,
+    scenario: API_EVENT_KINDS.scenario__import__piece__submitted__v1__alpha,
+  };
+
+  constructor(
+    private readonly apiEvents: ApiEventsService,
+    @Inject(importPieceQueueToken)
+    private readonly queue: Queue<ImportJobInput>,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute({
+    piece,
+    importId,
+    componentId,
+    resourceId,
+    resourceKind,
+    uris,
+  }: SchedulePieceImport): Promise<void> {
+    const job = await this.queue.add(`import-piece`, {
+      piece,
+      importId: importId.value,
+      componentId: componentId.value,
+      resourceId: resourceId.value,
+      resourceKind,
+      uris,
+    });
+
+    if (!job) {
+      this.eventBus.publish(
+        new ImportPieceFailed(importId, componentId, resourceId, resourceKind),
+      );
+      return;
+    }
+
+    const kind = this.eventMapper[resourceKind];
+
+    await this.apiEvents.createIfNotExists({
+      kind,
+      topic: componentId.value,
+      data: {
+        piece,
+        importId: importId.value,
+        componentId: componentId.value,
+        resourceId: resourceId.value,
+      },
+    });
+  }
+}

--- a/api/apps/api/src/modules/projects/job-status/job-status.view.api.entity.ts
+++ b/api/apps/api/src/modules/projects/job-status/job-status.view.api.entity.ts
@@ -155,4 +155,13 @@ const eventToJobStatusMapping: Record<ValuesType<ScenarioEvents>, JobStatus> = {
     JobStatus.done,
   [API_EVENT_KINDS.scenario__export__piece__submitted__v1__alpha]:
     JobStatus.running,
+  [API_EVENT_KINDS.scenario__import__failed__v1__alpha]: JobStatus.failure,
+  [API_EVENT_KINDS.scenario__import__finished__v1__alpha]: JobStatus.done,
+  [API_EVENT_KINDS.scenario__import__submitted__v1__alpha]: JobStatus.running,
+  [API_EVENT_KINDS.scenario__import__piece__failed__v1__alpha]:
+    JobStatus.failure,
+  [API_EVENT_KINDS.scenario__import__piece__finished__v1__alpha]:
+    JobStatus.done,
+  [API_EVENT_KINDS.scenario__import__piece__submitted__v1__alpha]:
+    JobStatus.running,
 };

--- a/api/apps/api/src/modules/projects/job-status/project-status.view.api.entity.ts
+++ b/api/apps/api/src/modules/projects/job-status/project-status.view.api.entity.ts
@@ -65,4 +65,12 @@ const eventToJobStatusMapping: Record<ValuesType<ProjectEvents>, JobStatus> = {
   [API_EVENT_KINDS.project__export__piece__finished__v1__alpha]: JobStatus.done,
   [API_EVENT_KINDS.project__export__piece__submitted__v1__alpha]:
     JobStatus.running,
+  [API_EVENT_KINDS.project__import__failed__v1__alpha]: JobStatus.failure,
+  [API_EVENT_KINDS.project__import__finished__v1__alpha]: JobStatus.done,
+  [API_EVENT_KINDS.project__import__submitted__v1__alpha]: JobStatus.running,
+  [API_EVENT_KINDS.project__import__piece__failed__v1__alpha]:
+    JobStatus.failure,
+  [API_EVENT_KINDS.project__import__piece__finished__v1__alpha]: JobStatus.done,
+  [API_EVENT_KINDS.project__import__piece__submitted__v1__alpha]:
+    JobStatus.running,
 };

--- a/api/apps/api/src/modules/scenarios/cost-surface/application/cost-surface-application.module.ts
+++ b/api/apps/api/src/modules/scenarios/cost-surface/application/cost-surface-application.module.ts
@@ -1,4 +1,4 @@
-import { Logger, Module } from '@nestjs/common';
+import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Project } from '../../../projects/project.api.entity';
@@ -14,6 +14,14 @@ import { UpdateCostSurfaceHandler } from './update-cost-surface.handler';
     CqrsModule,
     TypeOrmModule.forFeature([Project]),
   ],
-  providers: [Logger, SetInitialCostSurfaceHandler, UpdateCostSurfaceHandler],
+  providers: [
+    {
+      provide: Logger,
+      useClass: Logger,
+      scope: Scope.TRANSIENT,
+    },
+    SetInitialCostSurfaceHandler,
+    UpdateCostSurfaceHandler,
+  ],
 })
 export class CostSurfaceApplicationModule {}

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -88,7 +88,7 @@ import {
   GetScenarioFailure,
   scenarioNotFound,
 } from '@marxan-api/modules/blm/values/blm-repos';
-import { ResourceId } from '../clone';
+
 import { ExportScenario } from '../clone/export/application/export-scenario.command';
 import {
   SetInitialCostSurface,
@@ -102,6 +102,7 @@ import {
   noLockInPlace,
 } from '@marxan-api/modules/access-control/scenarios-acl/locks/lock.service';
 import { ScenarioLockResultSingular } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
+import { ResourceId } from '@marxan/cloning/domain';
 
 /** @debt move to own module */
 const EmptyGeoFeaturesSpecification: GeoFeatureSetSpecification = {

--- a/api/apps/api/test/cloning/export-piece-failed.saga.e2e-spec.ts
+++ b/api/apps/api/test/cloning/export-piece-failed.saga.e2e-spec.ts
@@ -1,12 +1,11 @@
 import { ApiEventsService } from '@marxan-api/modules/api-events';
-import { ResourceId } from '@marxan-api/modules/clone';
 import { ExportEntity } from '@marxan-api/modules/clone/export/adapters/entities/exports.api.entity';
 import { ExportPieceFailed } from '@marxan-api/modules/clone/export/application/export-piece-failed.event';
 import { ExportRepository } from '@marxan-api/modules/clone/export/application/export-repository.port';
 import { ExportId } from '@marxan-api/modules/clone/export/domain';
 import { exportPieceQueueToken } from '@marxan-api/modules/clone/infra/export/export-queue.provider';
 import { API_EVENT_KINDS } from '@marxan/api-events';
-import { ComponentId } from '@marxan/cloning/domain';
+import { ComponentId, ResourceId } from '@marxan/cloning/domain';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { EventBus } from '@nestjs/cqrs';
 import * as request from 'supertest';

--- a/api/apps/api/test/integration/typeorm-export.repository.integration.e2e-spec.ts
+++ b/api/apps/api/test/integration/typeorm-export.repository.integration.e2e-spec.ts
@@ -1,19 +1,19 @@
-import {
-  ClonePiece,
-  ComponentId,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
-import { FixtureType } from '@marxan/utils/tests/fixture-type';
-import { Connection } from 'typeorm';
 import { ExportEntity } from '@marxan-api/modules/clone/export/adapters/entities/exports.api.entity';
-import { ComponentLocation } from '@marxan-api/modules/clone/export/application/complete-piece.command';
 import { ExportRepository } from '@marxan-api/modules/clone/export/application/export-repository.port';
 import {
   Export,
   ExportComponent,
   ExportId,
 } from '@marxan-api/modules/clone/export/domain';
+import {
+  ClonePiece,
+  ComponentId,
+  ComponentLocation,
+  ResourceId,
+  ResourceKind,
+} from '@marxan/cloning/domain';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Connection } from 'typeorm';
 import { bootstrapApplication } from '../utils/api-application';
 
 describe('Typeorm export repository', () => {

--- a/api/apps/api/test/integration/typeorm-import.repository.integration.e2e-spec.ts
+++ b/api/apps/api/test/integration/typeorm-import.repository.integration.e2e-spec.ts
@@ -107,7 +107,7 @@ const getFixtures = async () => {
           }),
         ],
       );
-      importId = importInstance.id;
+      importId = importInstance.importId;
       await repo.save(importInstance);
     },
     GivenImportWithMultipleComponentsWasRequested: async () => {
@@ -134,7 +134,7 @@ const getFixtures = async () => {
         archiveLocation,
         components,
       );
-      importId = importInstance.id;
+      importId = importInstance.importId;
       await repo.transaction(async (repository) => {
         await repository.save(importInstance);
       });

--- a/api/apps/api/test/project/get-export-file.e2e-spec.ts
+++ b/api/apps/api/test/project/get-export-file.e2e-spec.ts
@@ -1,11 +1,7 @@
 import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
 import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
 import { ExportEntity } from '@marxan-api/modules/clone/export/adapters/entities/exports.api.entity';
-import {
-  CompletePiece,
-  ComponentId,
-  ComponentLocation,
-} from '@marxan-api/modules/clone/export/application/complete-piece.command';
+import { CompleteExportPiece } from '@marxan-api/modules/clone/export/application/complete-export-piece.command';
 import { ExportRepository } from '@marxan-api/modules/clone/export/application/export-repository.port';
 import {
   ArchiveReady,
@@ -13,6 +9,7 @@ import {
   ExportId,
 } from '@marxan-api/modules/clone/export/domain';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
+import { ComponentId, ComponentLocation } from '@marxan/cloning/domain';
 import { FileRepository } from '@marxan/files-repository';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
@@ -190,7 +187,7 @@ export const getFixtures = async () => {
 
       exportInstance!.toSnapshot().exportPieces.forEach((piece) => {
         commandBus.execute(
-          new CompletePiece(exportId, new ComponentId(piece.id), [
+          new CompleteExportPiece(exportId, new ComponentId(piece.id), [
             new ComponentLocation(
               piecesUris[piece.id],
               `${piece.id}-${piece.piece}.txt`,

--- a/api/apps/api/test/project/get-latest-export.e2e-spec.ts
+++ b/api/apps/api/test/project/get-latest-export.e2e-spec.ts
@@ -1,11 +1,7 @@
 import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
 import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
 import { ExportEntity } from '@marxan-api/modules/clone/export/adapters/entities/exports.api.entity';
-import {
-  CompletePiece,
-  ComponentId,
-  ComponentLocation,
-} from '@marxan-api/modules/clone/export/application/complete-piece.command';
+import { CompleteExportPiece } from '@marxan-api/modules/clone/export/application/complete-export-piece.command';
 import { ExportRepository } from '@marxan-api/modules/clone/export/application/export-repository.port';
 import {
   ArchiveReady,
@@ -13,6 +9,7 @@ import {
   ExportId,
 } from '@marxan-api/modules/clone/export/domain';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
+import { ComponentId, ComponentLocation } from '@marxan/cloning/domain';
 import { FileRepository } from '@marxan/files-repository';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
@@ -195,7 +192,7 @@ export const getFixtures = async () => {
 
       exportInstance!.toSnapshot().exportPieces.forEach((piece) => {
         commandBus.execute(
-          new CompletePiece(exportId, new ComponentId(piece.id), [
+          new CompleteExportPiece(exportId, new ComponentId(piece.id), [
             new ComponentLocation(
               piecesUris[piece.id],
               `${piece.id}-${piece.piece}.txt`,

--- a/api/apps/geoprocessing/src/app.module.ts
+++ b/api/apps/geoprocessing/src/app.module.ts
@@ -17,6 +17,7 @@ import { ScenariosModule } from '@marxan-geoprocessing/modules/scenarios/scenari
 import { ScenarioProtectedAreaCalculationModule } from '@marxan-geoprocessing/modules/scenario-protected-area-calculation/scenario-protected-area-calculation.module';
 import { ScenarioPlanningUnitsFeaturesAggregateModule } from '@marxan-geoprocessing/modules/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate.module';
 import { ExportModule } from '@marxan-geoprocessing/export/export.module';
+import { ImportModule } from './import/import.module';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { ExportModule } from '@marxan-geoprocessing/export/export.module';
     ScenariosModule,
     ScenarioPlanningUnitsFeaturesAggregateModule,
     ExportModule,
+    ImportModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/api/libs/api-events/src/api-event-kinds.enum.ts
+++ b/api/libs/api-events/src/api-event-kinds.enum.ts
@@ -64,6 +64,18 @@ export enum API_EVENT_KINDS {
   scenario__export__piece__submitted__v1__alpha = 'scenario.export.piece.submitted/v1/alpha',
   scenario__export__piece__finished__v1__alpha = 'scenario.export.piece.finished/v1/alpha',
   scenario__export__piece__failed__v1__alpha = 'scenario.export.piece.failed/v1/alpha',
+  project__import__submitted__v1__alpha = 'project.import.submitted/v1/alpha',
+  project__import__finished__v1__alpha = 'project.import.finished/v1/alpha',
+  project__import__failed__v1__alpha = 'project.import.failed/v1/alpha',
+  project__import__piece__submitted__v1__alpha = 'project.import.piece.submitted/v1/alpha',
+  project__import__piece__finished__v1__alpha = 'project.import.piece.finished/v1/alpha',
+  project__import__piece__failed__v1__alpha = 'project.import.piece.failed/v1/alpha',
+  scenario__import__submitted__v1__alpha = 'scenario.import.submitted/v1/alpha',
+  scenario__import__finished__v1__alpha = 'scenario.import.finished/v1/alpha',
+  scenario__import__failed__v1__alpha = 'scenario.import.failed/v1/alpha',
+  scenario__import__piece__submitted__v1__alpha = 'scenario.import.piece.submitted/v1/alpha',
+  scenario__import__piece__finished__v1__alpha = 'scenario.import.piece.finished/v1/alpha',
+  scenario__import__piece__failed__v1__alpha = 'scenario.import.piece.failed/v1/alpha',
 }
 
 export type ProjectEvents = Pick<

--- a/api/libs/cloning/src/domain/index.ts
+++ b/api/libs/cloning/src/domain/index.ts
@@ -1,6 +1,7 @@
 export { ArchiveLocation } from './archive-location';
 export { ClonePiece } from './clone-piece';
-export { ComponentId } from './component.id';
 export { ComponentLocation } from './component-location';
+export { ComponentLocationSnapshot } from './component-location.snapshot';
+export { ComponentId } from './component.id';
 export { ResourceId } from './resource.id';
 export { ResourceKind } from './resource.kind';

--- a/api/libs/cloning/src/job-input.ts
+++ b/api/libs/cloning/src/job-input.ts
@@ -1,4 +1,4 @@
-import { ClonePiece, ResourceKind } from './domain';
+import { ClonePiece, ComponentLocationSnapshot, ResourceKind } from './domain';
 
 export interface ExportJobInput {
   readonly exportId: string;
@@ -15,5 +15,5 @@ export interface ImportJobInput {
   readonly resourceId: string;
   readonly resourceKind: ResourceKind;
   readonly piece: ClonePiece;
-  readonly archiveLocation: string;
+  readonly uris: ComponentLocationSnapshot[];
 }


### PR DESCRIPTION
## Ensure import flow is connected together

This PR includes the following features and refactors:

- Added import api events for scenarios and projects
- Added `SchedulePieceImportHandler`  and `PieceImportRequestedSaga`.  When `PieceImportRequested` event is emitted `PieceImportRequestedSaga` sends a `SchedulePieceImport` command , then `SchedulePieceImportHandler` adds a `import-piece` job to queue.
- Renamed `CompletePiece` to `CompleteExportPiece`. Now we can have `CompleteExportPiece` and `CompleteImportPiece` events.
- Fixed some javascript import/export issues regarding `ResourceId` and `ExportId`.
- Added `MarkImportAsSubmittedHandler` and `ImportRequestedSaga`. When `ImportRequested ` event is emitted `ImportRequestedSaga` sends a `MarkImportAsSubmitted` command, then `MarkImportAsSubmittedHandler` creates an import submitted api event.
- Added `MarkImportAsFinishedHandler` and `AllPiecesImportedSaga`. When `AllPiecesImported ` event is emitted `AllPiecesImportedSaga` sends a `MarkImportAsFinished` command, then `MarkImportAsFinishedHandler` creates an import finished api event.

### Feature relevant tickets

[Ensure import flow is connected together](https://vizzuality.atlassian.net/browse/MARXAN-875)



