### PR TITLE
MARXAN-1237-scenarioLocks-on-all-endpoints

### DIFF
--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.controller.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.controller.ts
@@ -29,7 +29,7 @@ import {
   UserRoleInProjectDto,
   UsersInProjectResult,
 } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
-import { aclErrorHandler } from '@marxan-api/utils/acl.utils';
+import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
 import { ImplementsAcl } from '@marxan-api/decorators/acl.decorator';
 
 @ImplementsAcl()
@@ -84,7 +84,7 @@ export class ProjectAclController {
     );
 
     if (isLeft(result)) {
-      aclErrorHandler(result.left);
+      throw mapAclDomainToHttpError(result.left);
     }
   }
 
@@ -107,7 +107,7 @@ export class ProjectAclController {
     );
 
     if (isLeft(result)) {
-      aclErrorHandler(result.left);
+      throw mapAclDomainToHttpError(result.left);
     }
   }
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/__mocks__/scenario-access-control.mock.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/__mocks__/scenario-access-control.mock.ts
@@ -51,7 +51,7 @@ export class ScenarioAccessControlMock implements ScenarioAccessControl {
   async releaseLock(
     userId: string,
     scenarioId: string,
-    projectId: string,
+    _projectId: string,
   ): Promise<Either<typeof forbiddenError | typeof lockedByAnotherUser, void>> {
     if (this.mock(userId, scenarioId)) {
       return left(forbiddenError);
@@ -75,6 +75,7 @@ export class ScenarioAccessControlMock implements ScenarioAccessControl {
   async findLock(
     userId: string,
     scenarioId: string,
+    _isDeletion?: boolean,
   ): Promise<Either<typeof forbiddenError, ScenarioLockResultSingular>> {
     if (this.mock(userId, scenarioId)) {
       return left(forbiddenError);

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-access-control.ts
@@ -36,6 +36,7 @@ export abstract class ScenarioAccessControl {
   abstract canEditScenarioAndOwnsLock(
     userId: string,
     scenarioId: string,
+    isDeletion?: boolean,
   ): Promise<
     Either<
       typeof forbiddenError | typeof lockedByAnotherUser | typeof noLockInPlace,

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.controller.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.controller.ts
@@ -29,7 +29,7 @@ import {
   UserRoleInScenarioDto,
   UsersInScenarioResult,
 } from '@marxan-api/modules/access-control/scenarios-acl/dto/user-role-scenario.dto';
-import { aclErrorHandler } from '@marxan-api/utils/acl.utils';
+import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
 import { ImplementsAcl } from '@marxan-api/decorators/acl.decorator';
 
 @ImplementsAcl()
@@ -84,7 +84,7 @@ export class ScenarioAclController {
     );
 
     if (isLeft(result)) {
-      aclErrorHandler(result.left);
+      throw mapAclDomainToHttpError(result.left);
     }
   }
 
@@ -107,7 +107,7 @@ export class ScenarioAclController {
     );
 
     if (isLeft(result)) {
-      aclErrorHandler(result.left);
+      throw mapAclDomainToHttpError(result.left);
     }
   }
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.ts
@@ -12,7 +12,7 @@ import {
 } from '@marxan-api/modules/access-control/scenarios-acl/dto/user-role-scenario.dto';
 import { UsersScenariosApiEntity } from '@marxan-api/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity';
 import { ScenarioAccessControl } from '@marxan-api/modules/access-control/scenarios-acl/scenario-access-control';
-import { Either, left, right } from 'fp-ts/lib/Either';
+import { Either, isRight, left, right } from 'fp-ts/lib/Either';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { assertDefined } from '@marxan/utils';
 import {
@@ -229,19 +229,31 @@ export class ScenarioAclService implements ScenarioAccessControl {
   async canEditScenarioAndOwnsLock(
     userId: string,
     scenarioId: string,
+    isDeletion?: boolean,
   ): Promise<
     Either<
       typeof forbiddenError | typeof lockedByAnotherUser | typeof noLockInPlace,
       boolean
     >
   > {
-    const scenarioIsLocked = await this.lockService.isLocked(scenarioId);
-    const canEditScenario = await this.canEditScenario(userId, scenarioId);
+    const scenarioIsAlreadyLocked = await this.lockService.isLocked(scenarioId);
+    const canProcessActionInScenario = isDeletion
+      ? await this.canDeleteScenario(userId, scenarioId)
+      : await this.canEditScenario(userId, scenarioId);
+    // LOFU (lock on first use): if scenario is not locked (maybe it's new and it
+    // was never locked, or any previous locks have expired or have been
+    // explicitly released), the current user can attempt to acquire a lock
+    // transparently.
+    const scenarioIsLocked =
+      canProcessActionInScenario && !scenarioIsAlreadyLocked
+        ? isRight(await this.acquireLock(userId, scenarioId))
+        : scenarioIsAlreadyLocked;
+
     const scenarioIsLockedByCurrentUser = await this.lockService.isLockedByUser(
       scenarioId,
       userId,
     );
-    if (!canEditScenario) {
+    if (!canProcessActionInScenario) {
       return left(forbiddenError);
     }
     if (!scenarioIsLocked) {
@@ -251,7 +263,9 @@ export class ScenarioAclService implements ScenarioAccessControl {
       return left(lockedByAnotherUser);
     }
     return right(
-      scenarioIsLocked && canEditScenario && scenarioIsLockedByCurrentUser,
+      scenarioIsLocked &&
+        canProcessActionInScenario &&
+        scenarioIsLockedByCurrentUser,
     );
   }
 

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1,7 +1,5 @@
 import {
-  BadRequestException,
   Body,
-  ConflictException,
   Controller,
   Delete,
   ForbiddenException,
@@ -9,8 +7,6 @@ import {
   Header,
   HttpCode,
   HttpStatus,
-  InternalServerErrorException,
-  NotFoundException,
   Param,
   ParseUUIDPipe,
   Patch,

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -63,11 +63,7 @@ import {
 import { UpdateScenarioPlanningUnitLockStatusDto } from './dto/update-scenario-planning-unit-lock-status.dto';
 import { ShapefileGeoJSONResponseDTO } from './dto/shapefile.geojson.response.dto';
 import { ApiConsumesShapefile } from '@marxan-api/decorators/shapefile.decorator';
-import {
-  projectDoesntExist,
-  projectNotReady,
-  ScenariosService,
-} from './scenarios.service';
+import { ScenariosService } from './scenarios.service';
 import { ScenarioSerializer } from './dto/scenario.serializer';
 import { ScenarioFeatureSerializer } from './dto/scenario-feature.serializer';
 import { ScenarioFeatureResultDto } from './dto/scenario-feature-result.dto';
@@ -91,7 +87,6 @@ import {
 } from '@marxan-api/dto/async-job.dto';
 import { asyncJobTag } from '@marxan-api/dto/async-job-tag';
 import { inlineJobTag } from '@marxan-api/dto/inline-job-tag';
-import { submissionFailed } from '@marxan-api/modules/scenarios/protected-area';
 import {
   GeometryFileInterceptor,
   GeometryKind,
@@ -103,37 +98,15 @@ import { StartScenarioBlmCalibrationDto } from '@marxan-api/modules/scenarios/dt
 import { BlmCalibrationRunResultDto } from './dto/scenario-blm-calibration-results.dto';
 import { ImplementsAcl } from '@marxan-api/decorators/acl.decorator';
 import { forbiddenError } from '@marxan-api/modules/access-control';
-import { internalError } from '@marxan-api/modules/specification/application/submit-specification.command';
 import { notFound as notFoundSpec } from '@marxan-api/modules/scenario-specification/application/last-updated-specification.query';
-import {
-  marxanFailed,
-  metadataNotFound,
-  outputZipNotYetAvailable,
-} from './output-files/output-files.service';
-import {
-  inputZipNotYetAvailable,
-  metadataNotFound as inputMetadataNotFound,
-} from './input-files';
-import { notFound as protectedAreaProjectNotFound } from '@marxan/projects';
-import { invalidProtectedAreaId } from './protected-area/selection/selection-update.service';
+
 import { ScenarioAccessControl } from '@marxan-api/modules/access-control/scenarios-acl/scenario-access-control';
 import { BlmRangeDto } from '@marxan-api/modules/scenarios/dto/blm-range.dto';
-import { blmCreationFailure } from '@marxan-api/modules/scenarios/blm-calibration/create-initial-scenario-blm.command';
-import { invalidRange } from '@marxan-api/modules/scenarios/blm-calibration/change-scenario-blm-range.command';
-import {
-  scenarioNotFound,
-  unknownError as scenarioUnknownError,
-} from '@marxan-api/modules/blm/values/blm-repos';
-import {
-  noLockInPlace,
-  lockedByAnotherUser,
-  lockedScenario,
-  unknownError as lockUnknownError,
-} from '@marxan-api/modules/access-control/scenarios-acl/locks/lock.service';
 import {
   ScenarioLockResultPlural,
   ScenarioLockResultSingular,
 } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
+import { aclErrorHandler } from '@marxan-api/utils/acl.utils';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -280,17 +253,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case scenarioNotFound:
-          throw new NotFoundException(`Scenario ${id} could not be found`);
-        case scenarioUnknownError:
-          throw new InternalServerErrorException();
-        default:
-          const _exhaustiveCheck: never = result.left;
-          throw _exhaustiveCheck;
-      }
+      return aclErrorHandler(result.left, {
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return await this.scenarioSerializer.serialize(result.right);
@@ -308,23 +274,10 @@ export class ScenariosController {
       authenticatedUser: req.user,
     });
     if (isLeft(result)) {
-      switch (result.left) {
-        case projectNotReady:
-          throw new ConflictException();
-        case projectDoesntExist:
-          throw new NotFoundException(`Project doesn't exist`);
-        case forbiddenError:
-          throw new ForbiddenException(
-            `User with ID: ${req.user.id} is not allowed to create scenarios`,
-          );
-        case blmCreationFailure:
-          throw new InternalServerErrorException(
-            `Could not create initial BLM for scenario`,
-          );
-
-        default:
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return await this.scenarioSerializer.serialize(
       result.right,
@@ -344,15 +297,11 @@ export class ScenariosController {
     const result = await this.service.createSpecification(id, req.user.id, dto);
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case internalError:
-          throw new InternalServerErrorException(result.left.description);
-        case forbiddenError:
-          throw new ForbiddenException();
-        default:
-          const _check: never = result.left;
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return await this.geoFeatureSetSerializer.serialize(
@@ -380,8 +329,8 @@ export class ScenariosController {
         case forbiddenError:
           throw new ForbiddenException();
         default:
-          const _check: never = result.left;
-          throw new InternalServerErrorException();
+          const _exhaustiveCheck: never = result.left;
+          throw _exhaustiveCheck;
       }
     }
     return await this.geoFeatureSetSerializer.serialize(result.right);
@@ -403,7 +352,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
@@ -416,7 +369,11 @@ export class ScenariosController {
   ): Promise<CostRangeDto> {
     const result = await this.service.getCostRange(scenarioId, req.user.id);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return plainToClass<CostRangeDto, CostRangeDto>(CostRangeDto, result.right);
   }
@@ -436,7 +393,11 @@ export class ScenariosController {
       file,
     );
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return result.right;
   }
@@ -453,19 +414,11 @@ export class ScenariosController {
     const result = await this.service.update(id, req.user.id, dto);
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case lockedByAnotherUser:
-          throw new BadRequestException(
-            `Scenario ${id} is already being edited.`,
-          );
-        case noLockInPlace:
-          throw new NotFoundException(`Scenario ${id} has no locks in place.`);
-        default:
-          const _check: never = result.left;
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return await this.scenarioSerializer.serialize(
@@ -485,7 +438,11 @@ export class ScenariosController {
     const result = await this.service.remove(id, req.user.id);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
   }
 
@@ -499,7 +456,11 @@ export class ScenariosController {
   ): Promise<JsonApiAsyncJobMeta> {
     const result = await this.service.changeLockStatus(id, req.user.id, input);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
@@ -513,7 +474,11 @@ export class ScenariosController {
     const result = await this.service.resetLockStatus(id, req.user.id);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
   }
 
@@ -526,7 +491,11 @@ export class ScenariosController {
     const result = await this.service.getPlanningUnits(id, req.user.id);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return this.planningUnitsSerializer.serialize(result.right);
@@ -543,7 +512,11 @@ export class ScenariosController {
   ): Promise<Partial<ScenarioFeaturesData>[]> {
     const result = await this.service.getFeatures(id, req.user.id);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return this.scenarioFeatureSerializer.serialize(
       result.right.data,
@@ -577,7 +550,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return this.scenarioFeaturesGapData.serialize(
       result.right.data,
@@ -596,7 +573,11 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getInputParameterFile(id, req.user.id);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return result.right;
   }
@@ -612,7 +593,11 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getSpecDatCsv(id, req.user.id);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return result.right;
   }
@@ -628,7 +613,11 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getPuvsprDatCsv(id, req.user.id);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return result.right;
   }
@@ -644,7 +633,11 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getBoundDatCsv(id, req.user.id);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return result.right;
   }
@@ -667,23 +660,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case marxanFailed:
-          throw new InternalServerErrorException('Marxan failed');
-        case outputZipNotYetAvailable:
-          throw new InternalServerErrorException(
-            'Marxan output file - output file not available, possible error',
-          );
-        case metadataNotFound:
-          throw new InternalServerErrorException(
-            'Marxan was not yet executed.',
-          );
-        default:
-          const _check: never = result.left;
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     response.send(this.zipFilesSerializer.serialize(result));
@@ -707,21 +688,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case inputZipNotYetAvailable:
-          throw new InternalServerErrorException(
-            'marxan input file - input file not available, possible error',
-          );
-        case inputMetadataNotFound:
-          throw new InternalServerErrorException(
-            'marxan input file - metadata not found',
-          );
-        default:
-          const _check: never = result.left;
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     response.send(this.zipFilesSerializer.serialize(result));
   }
@@ -753,7 +724,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return this.scenarioSolutionSerializer.serialize(
@@ -783,7 +758,11 @@ export class ScenariosController {
   ): Promise<JsonApiAsyncJobMeta> {
     const result = await this.service.run(id, req.user.id, blm);
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
@@ -804,7 +783,11 @@ export class ScenariosController {
     const result = await this.service.cancelMarxanRun(id, req.user.id);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
   }
 
@@ -826,7 +809,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return this.scenarioSolutionSerializer.serialize(result.right[0]);
@@ -850,7 +837,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return this.scenarioSolutionSerializer.serialize(result.right[0]);
@@ -890,7 +881,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return this.scenarioFeaturesOutputGapData.serialize(
@@ -918,7 +913,11 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return this.scenarioSolutionSerializer.serialize(result.right);
@@ -943,7 +942,11 @@ export class ScenariosController {
     const result = await this.service.getCostSurfaceCsv(id, req.user.id, res);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
   }
 
@@ -961,17 +964,11 @@ export class ScenariosController {
     });
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case scenarioNotFound:
-          throw new NotFoundException('Scenario not found');
-        case protectedAreaProjectNotFound:
-          throw new NotFoundException('Project not found');
-        default:
-          const _exhaustiveCheck: never = result.left;
-          throw _exhaustiveCheck;
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return result.right;
@@ -992,19 +989,11 @@ export class ScenariosController {
     });
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case scenarioNotFound:
-          throw new NotFoundException('Scenario not found');
-        case protectedAreaProjectNotFound:
-          throw new NotFoundException('Project not found');
-        case invalidProtectedAreaId:
-          throw new BadRequestException('Invalid protected area id');
-        default:
-          const _exhaustiveCheck: never = result.left;
-          throw _exhaustiveCheck;
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return await this.getProtectedAreasForScenario(scenarioId, req);
   }
@@ -1030,14 +1019,11 @@ export class ScenariosController {
       dto,
     );
     if (isLeft(outcome)) {
-      switch (outcome.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case submissionFailed:
-          throw new InternalServerErrorException();
-        default:
-          throw new NotFoundException();
-      }
+      return aclErrorHandler(outcome.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
   }
@@ -1064,22 +1050,12 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException(
-            `User with ID: ${req.user.id} is not allowed to start a calibration for scenario with ID: ${id}`,
-          );
-        case scenarioNotFound:
-          throw new NotFoundException(
-            `Could not found scenario with ID: ${id}`,
-          );
-        case invalidRange:
-          throw new BadRequestException(
-            `Received range is invalid: [${range}]`,
-          );
-        default:
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+        range,
+      });
     }
 
     return AsyncJobDto.forScenario().asJsonApiMetadata();
@@ -1100,10 +1076,13 @@ export class ScenariosController {
   ): Promise<BlmCalibrationRunResultDto[]> {
     const result = await this.service.getBlmCalibrationResults(id, req.user.id);
 
-    if (isLeft(result))
-      throw new ForbiddenException(
-        `User with ID: ${req.user.id} cannot view scenario with ID: ${id}`,
-      );
+    if (isLeft(result)) {
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
+    }
 
     return result.right;
   }
@@ -1124,18 +1103,11 @@ export class ScenariosController {
     const result = await this.service.getBlmRange(id, req.user.id);
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException(
-            `User with ID: ${req.user.id} cannot retrieve BLM range for scenario with ID: ${id}`,
-          );
-        case scenarioNotFound:
-          throw new NotFoundException(
-            `Could not found project for scenario with ID: ${id}`,
-          );
-        default:
-          throw new InternalServerErrorException();
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return BlmRangeDto.fromBlmValues(result.right);
@@ -1153,7 +1125,11 @@ export class ScenariosController {
     const result = await this.service.cancelBlmCalibration(id, req.user.id);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
   }
 
@@ -1162,6 +1138,7 @@ export class ScenariosController {
     summary: `Creates a Lock entity with related scenario
      and user data to prevent other users from editing at the same time.`,
   })
+  @ApiOkResponse({ type: ScenarioLockResultSingular })
   @Post(`:id/lock`)
   async startScenarioEditingSession(
     @Param('id', ParseUUIDPipe) id: string,
@@ -1170,19 +1147,11 @@ export class ScenariosController {
     const result = await this.scenarioAclService.acquireLock(req.user.id, id);
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case lockedScenario:
-          throw new BadRequestException(
-            `Scenario ${id} is already being edited.`,
-          );
-        case lockUnknownError:
-          throw new InternalServerErrorException();
-        default:
-          const _exhaustiveCheck: never = result.left;
-          throw _exhaustiveCheck;
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
     return { data: result.right };
   }
@@ -1205,23 +1174,11 @@ export class ScenariosController {
     const result = await this.service.releaseLock(id, req.user.id);
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case lockedByAnotherUser:
-          throw new BadRequestException(
-            'Scenario lock belongs to a different user.',
-          );
-        case noLockInPlace:
-          throw new NotFoundException(`Scenario ${id} has no locks in place.`);
-        case scenarioNotFound:
-          throw new NotFoundException(`Scenario ${id} could not be found`);
-        case scenarioUnknownError:
-          throw new InternalServerErrorException();
-        default:
-          const _exhaustiveCheck: never = result.left;
-          throw _exhaustiveCheck;
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId: id,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
   }
 
@@ -1229,6 +1186,7 @@ export class ScenariosController {
   @ApiOperation({
     summary: 'Get lock for scenario if it exists. Otherwise, it returns null',
   })
+  @ApiOkResponse({ type: ScenarioLockResultPlural })
   async findLocksForScenariosWithinParentProject(
     @Param('scenarioId', ParseUUIDPipe) scenarioId: string,
     @Req() req: RequestWithAuthenticatedUser,
@@ -1236,19 +1194,11 @@ export class ScenariosController {
     const result = await this.service.findLock(scenarioId, req.user.id);
 
     if (isLeft(result)) {
-      switch (result.left) {
-        case forbiddenError:
-          throw new ForbiddenException();
-        case scenarioNotFound:
-          throw new NotFoundException(
-            `Scenario ${scenarioId} could not be found`,
-          );
-        case scenarioUnknownError:
-          throw new InternalServerErrorException();
-        default:
-          const _exhaustiveCheck: never = result.left;
-          throw _exhaustiveCheck;
-      }
+      return aclErrorHandler(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: 'scenarios',
+      });
     }
 
     return result.right;

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -102,7 +102,7 @@ import {
   ScenarioLockResultPlural,
   ScenarioLockResultSingular,
 } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
-import { aclErrorHandler } from '@marxan-api/utils/acl.utils';
+import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -249,9 +249,9 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -270,9 +270,9 @@ export class ScenariosController {
       authenticatedUser: req.user,
     });
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return await this.scenarioSerializer.serialize(
@@ -293,10 +293,10 @@ export class ScenariosController {
     const result = await this.service.createSpecification(id, req.user.id, dto);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -348,10 +348,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
@@ -365,10 +365,10 @@ export class ScenariosController {
   ): Promise<CostRangeDto> {
     const result = await this.service.getCostRange(scenarioId, req.user.id);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return plainToClass<CostRangeDto, CostRangeDto>(CostRangeDto, result.right);
@@ -389,10 +389,10 @@ export class ScenariosController {
       file,
     );
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return result.right;
@@ -410,10 +410,10 @@ export class ScenariosController {
     const result = await this.service.update(id, req.user.id, dto);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -434,10 +434,10 @@ export class ScenariosController {
     const result = await this.service.remove(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
   }
@@ -452,10 +452,10 @@ export class ScenariosController {
   ): Promise<JsonApiAsyncJobMeta> {
     const result = await this.service.changeLockStatus(id, req.user.id, input);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
@@ -470,10 +470,10 @@ export class ScenariosController {
     const result = await this.service.resetLockStatus(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
   }
@@ -487,10 +487,10 @@ export class ScenariosController {
     const result = await this.service.getPlanningUnits(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -508,10 +508,10 @@ export class ScenariosController {
   ): Promise<Partial<ScenarioFeaturesData>[]> {
     const result = await this.service.getFeatures(id, req.user.id);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return this.scenarioFeatureSerializer.serialize(
@@ -546,10 +546,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return this.scenarioFeaturesGapData.serialize(
@@ -569,10 +569,10 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getInputParameterFile(id, req.user.id);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return result.right;
@@ -589,10 +589,10 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getSpecDatCsv(id, req.user.id);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return result.right;
@@ -609,10 +609,10 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getPuvsprDatCsv(id, req.user.id);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return result.right;
@@ -629,10 +629,10 @@ export class ScenariosController {
   ): Promise<string> {
     const result = await this.service.getBoundDatCsv(id, req.user.id);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return result.right;
@@ -656,10 +656,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -684,10 +684,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     response.send(this.zipFilesSerializer.serialize(result));
@@ -720,10 +720,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -754,10 +754,10 @@ export class ScenariosController {
   ): Promise<JsonApiAsyncJobMeta> {
     const result = await this.service.run(id, req.user.id, blm);
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
@@ -779,10 +779,10 @@ export class ScenariosController {
     const result = await this.service.cancelMarxanRun(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
   }
@@ -805,10 +805,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -833,10 +833,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -877,10 +877,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -909,10 +909,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -938,10 +938,10 @@ export class ScenariosController {
     const result = await this.service.getCostSurfaceCsv(id, req.user.id, res);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
   }
@@ -960,10 +960,10 @@ export class ScenariosController {
     });
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -985,10 +985,10 @@ export class ScenariosController {
     });
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return await this.getProtectedAreasForScenario(scenarioId, req);
@@ -1015,10 +1015,10 @@ export class ScenariosController {
       dto,
     );
     if (isLeft(outcome)) {
-      return aclErrorHandler(outcome.left, {
+      throw mapAclDomainToHttpError(outcome.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return AsyncJobDto.forScenario().asJsonApiMetadata();
@@ -1046,10 +1046,10 @@ export class ScenariosController {
     );
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
         range,
       });
     }
@@ -1073,10 +1073,10 @@ export class ScenariosController {
     const result = await this.service.getBlmCalibrationResults(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -1099,10 +1099,10 @@ export class ScenariosController {
     const result = await this.service.getBlmRange(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 
@@ -1121,10 +1121,10 @@ export class ScenariosController {
     const result = await this.service.cancelBlmCalibration(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
   }
@@ -1143,10 +1143,10 @@ export class ScenariosController {
     const result = await this.scenarioAclService.acquireLock(req.user.id, id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
     return { data: result.right };
@@ -1170,10 +1170,10 @@ export class ScenariosController {
     const result = await this.service.releaseLock(id, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId: id,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
   }
@@ -1190,10 +1190,10 @@ export class ScenariosController {
     const result = await this.service.findLock(scenarioId, req.user.id);
 
     if (isLeft(result)) {
-      return aclErrorHandler(result.left, {
+      throw mapAclDomainToHttpError(result.left, {
         scenarioId,
         userId: req.user.id,
-        resourceType: 'scenarios',
+        resourceType: scenarioResource.name.plural,
       });
     }
 

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -195,12 +195,19 @@ export class ScenariosService {
   async remove(
     scenarioId: string,
     userId: string,
-  ): Promise<Either<typeof forbiddenError, void>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof lockedByAnotherUser | typeof noLockInPlace,
+      void
+    >
+  > {
     await this.assertScenario(scenarioId);
-    if (
-      !(await this.scenarioAclService.canDeleteScenario(userId, scenarioId))
-    ) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     return right(await this.crudService.remove(scenarioId));
   }
@@ -214,8 +221,7 @@ export class ScenariosService {
       | typeof blmCreationFailure
       | ProjectNotReady
       | ProjectDoesntExist
-      | SetInitialCostSurfaceError
-      | typeof forbiddenError,
+      | SetInitialCostSurfaceError,
       Scenario
     >
   > {
@@ -343,10 +349,19 @@ export class ScenariosService {
     scenarioId: string,
     userId: string,
     input: UpdateScenarioPlanningUnitLockStatusDto,
-  ): Promise<Either<typeof forbiddenError, void>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof noLockInPlace | typeof lockedByAnotherUser,
+      void
+    >
+  > {
     await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     await this.updatePlanningUnits.update(scenarioId, {
       include: {
@@ -365,9 +380,18 @@ export class ScenariosService {
     scenarioId: string,
     userId: string,
     file: Express.Multer.File,
-  ): Promise<Either<typeof forbiddenError, void>> {
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof noLockInPlace | typeof lockedByAnotherUser,
+      void
+    >
+  > {
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
 
     await this.commandBus.execute(new UpdateCostSurface(scenarioId, file));
@@ -378,10 +402,19 @@ export class ScenariosService {
     scenarioId: string,
     userId: string,
     file: Express.Multer.File,
-  ): Promise<Either<typeof forbiddenError, any>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof noLockInPlace | typeof lockedByAnotherUser,
+      any
+    >
+  > {
     await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     /**
      * @validateStatus is required for HttpService to not reject and wrap geoprocessing's response
@@ -447,10 +480,19 @@ export class ScenariosService {
     scenarioId: string,
     userId: string,
     blm?: number,
-  ): Promise<Either<typeof forbiddenError, void>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof noLockInPlace | typeof lockedByAnotherUser,
+      void
+    >
+  > {
     const scenario = await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     await this.runService.run(
       pick(scenario, 'id', 'boundaryLengthModifier'),
@@ -485,7 +527,10 @@ export class ScenariosService {
     rangeToUpdate?: [number, number],
   ): Promise<
     Either<
-      ChangeScenarioRangeErrors | GetScenarioFailure | typeof forbiddenError,
+      | typeof forbiddenError
+      | typeof noLockInPlace
+      | typeof lockedByAnotherUser
+      | ChangeScenarioRangeErrors,
       true
     >
   > {
@@ -493,13 +538,12 @@ export class ScenariosService {
     assertDefined(userInfo.authenticatedUser);
     if (isLeft(scenario)) return left(forbiddenError);
 
-    if (
-      !(await this.scenarioAclService.canEditScenario(
-        userInfo.authenticatedUser?.id,
-        id,
-      ))
-    ) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userInfo.authenticatedUser.id,
+      id,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     const projectId = scenario.right.projectId;
     await this.blockGuard.ensureThatProjectIsNotBlocked(projectId);
@@ -539,10 +583,19 @@ export class ScenariosService {
   async cancelBlmCalibration(
     scenarioId: string,
     userId: string,
-  ): Promise<Either<typeof forbiddenError, void>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof noLockInPlace | typeof lockedByAnotherUser,
+      void
+    >
+  > {
     await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     await this.commandBus.execute(new CancelBlmCalibration(scenarioId));
     return right(void 0);
@@ -551,10 +604,19 @@ export class ScenariosService {
   async cancelMarxanRun(
     scenarioId: string,
     userId: string,
-  ): Promise<Either<typeof forbiddenError, void>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof noLockInPlace | typeof lockedByAnotherUser,
+      void
+    >
+  > {
     await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     const result = await this.runService.cancel(scenarioId);
     if (isLeft(result)) {
@@ -786,11 +848,24 @@ export class ScenariosService {
     scenarioId: string,
     userId: string,
     dto: CreateGeoFeatureSetDTO,
-  ): Promise<Either<typeof forbiddenError | typeof internalError, any>> {
+  ): Promise<
+    Either<
+      | typeof forbiddenError
+      | typeof internalError
+      | typeof lockedByAnotherUser
+      | typeof noLockInPlace,
+      any
+    >
+  > {
     const scenario = await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
+
     return await this.specificationService.submit(
       scenarioId,
       scenario.projectId,
@@ -830,10 +905,19 @@ export class ScenariosService {
   async resetLockStatus(
     scenarioId: string,
     userId: string,
-  ): Promise<Either<typeof forbiddenError, void>> {
+  ): Promise<
+    Either<
+      typeof forbiddenError | typeof lockedByAnotherUser | typeof noLockInPlace,
+      void
+    >
+  > {
     await this.assertScenario(scenarioId);
-    if (!(await this.scenarioAclService.canEditScenario(userId, scenarioId))) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      userId,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     await this.planningUnitsService.resetLockStatus(scenarioId);
     return right(void 0);
@@ -844,17 +928,24 @@ export class ScenariosService {
     file: Express.Multer.File,
     info: AppInfoDTO,
     dto: UploadShapefileDto,
-  ): Promise<Either<SubmitProtectedAreaError | typeof forbiddenError, true>> {
+  ): Promise<
+    Either<
+      | SubmitProtectedAreaError
+      | typeof forbiddenError
+      | typeof noLockInPlace
+      | typeof lockedByAnotherUser,
+      true
+    >
+  > {
     try {
       const scenario = await this.assertScenario(scenarioId);
       assertDefined(info.authenticatedUser);
-      if (
-        !(await this.scenarioAclService.canEditScenario(
-          info.authenticatedUser.id,
-          scenarioId,
-        ))
-      ) {
-        return left(forbiddenError);
+      const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+        info.authenticatedUser.id,
+        scenarioId,
+      );
+      if (isLeft(userCanEditScenario)) {
+        return userCanEditScenario;
       }
       const projectResponse = await this.queryBus.execute(
         new GetProjectQuery(scenario.projectId, info.authenticatedUser?.id),
@@ -925,16 +1016,23 @@ export class ScenariosService {
     scenarioId: string,
     dto: ProtectedAreasChangeDto,
     info: AppInfoDTO,
-  ): Promise<Either<UpdateProtectedAreasError | typeof forbiddenError, true>> {
+  ): Promise<
+    Either<
+      | UpdateProtectedAreasError
+      | typeof forbiddenError
+      | typeof noLockInPlace
+      | typeof lockedByAnotherUser,
+      true
+    >
+  > {
     const scenario = await this.assertScenario(scenarioId);
     assertDefined(info.authenticatedUser);
-    if (
-      !(await this.scenarioAclService.canEditScenario(
-        info.authenticatedUser?.id,
-        scenarioId,
-      ))
-    ) {
-      return left(forbiddenError);
+    const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
+      info.authenticatedUser?.id,
+      scenarioId,
+    );
+    if (isLeft(userCanEditScenario)) {
+      return userCanEditScenario;
     }
     const projectResponse = await this.queryBus.execute(
       new GetProjectQuery(scenario.projectId, info.authenticatedUser?.id),

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -205,6 +205,7 @@ export class ScenariosService {
     const userCanEditScenario = await this.scenarioAclService.canEditScenarioAndOwnsLock(
       userId,
       scenarioId,
+      true,
     );
     if (isLeft(userCanEditScenario)) {
       return userCanEditScenario;

--- a/api/apps/api/src/utils/acl.utils.ts
+++ b/api/apps/api/src/utils/acl.utils.ts
@@ -109,7 +109,7 @@ export const aclErrorHandler = (
       throw new InternalServerErrorException();
     case lockedByAnotherUser:
       throw new BadRequestException(
-        `Scenario ${options?.scenarioId} is already being edited.`,
+        `Scenario lock belongs to a different user.`,
       );
     case lockedScenario:
       throw new BadRequestException(

--- a/api/apps/api/src/utils/acl.utils.ts
+++ b/api/apps/api/src/utils/acl.utils.ts
@@ -59,7 +59,7 @@ interface ErrorHandlerOptions {
   userId?: string;
 }
 
-export const aclErrorHandler = (
+export const mapAclDomainToHttpError = (
   errorToCheck:
     | typeof forbiddenError
     | typeof lastOwner
@@ -94,89 +94,89 @@ export const aclErrorHandler = (
 ) => {
   switch (errorToCheck) {
     case forbiddenError:
-      throw new ForbiddenException(
+      return new ForbiddenException(
         `User with ID: ${options?.userId} is not allowed to perform this action on ${options?.resourceType}.`,
       );
     case lastOwner:
-      throw new ForbiddenException(`There must be at least one owner.`);
+      return new ForbiddenException(`There must be at least one owner.`);
     case queryFailed:
-      throw new BadRequestException(
+      return new BadRequestException(
         `Error while adding record to the database.`,
       );
     case transactionFailed:
-      throw new InternalServerErrorException(`Transaction failed.`);
+      return new InternalServerErrorException(`Transaction failed.`);
     case lockUnknownError:
-      throw new InternalServerErrorException();
+      return new InternalServerErrorException();
     case lockedByAnotherUser:
-      throw new BadRequestException(
+      return new BadRequestException(
         `Scenario lock belongs to a different user.`,
       );
     case lockedScenario:
-      throw new BadRequestException(
+      return new BadRequestException(
         `Scenario ${options?.scenarioId} is already being edited.`,
       );
     case noLockInPlace:
-      throw new NotFoundException(
+      return new NotFoundException(
         `Scenario ${options?.scenarioId} has no locks in place.`,
       );
     case internalError:
-      throw new InternalServerErrorException(errorToCheck.description);
+      return new InternalServerErrorException(errorToCheck.description);
     case marxanRunNotFound:
-      throw new NotFoundException(`Entity not found.`);
+      return new NotFoundException(`Entity not found.`);
     case blmUnknownError:
-      throw new InternalServerErrorException();
+      return new InternalServerErrorException();
     case scenarioNotFound:
-      throw new NotFoundException(
+      return new NotFoundException(
         `Scenario ${options?.scenarioId} could not be found.`,
       );
     case marxanFailed:
-      throw new InternalServerErrorException('Marxan failed.');
+      return new InternalServerErrorException('Marxan failed.');
     case outputZipNotYetAvailable:
-      throw new InternalServerErrorException(
+      return new InternalServerErrorException(
         'Marxan output file - output file not available, possible error.',
       );
     case metadataNotFound:
-      throw new InternalServerErrorException('Marxan was not yet executed.');
+      return new InternalServerErrorException('Marxan was not yet executed.');
     case inputZipNotYetAvailable:
-      throw new InternalServerErrorException(
+      return new InternalServerErrorException(
         'Marxan input file - input file not available, possible error.',
       );
     case inputMetadataNotFound:
-      throw new InternalServerErrorException(
+      return new InternalServerErrorException(
         'Marxan input file - metadata not found.',
       );
     case projectNotReady:
-      throw new ConflictException('Project is not ready.');
+      return new ConflictException('Project is not ready.');
     case projectDoesntExist:
-      throw new NotFoundException(`Project doesn't exist.`);
+      return new NotFoundException(`Project doesn't exist.`);
     case protectedAreaProjectNotFound:
-      throw new NotFoundException('Project not found.');
+      return new NotFoundException('Project not found.');
     case invalidProtectedAreaId:
-      throw new BadRequestException('Invalid protected area id.');
+      return new BadRequestException('Invalid protected area id.');
     case rangeUnknownError:
-      throw new InternalServerErrorException();
+      return new InternalServerErrorException();
     case updateFailure:
-      throw new InternalServerErrorException();
+      return new InternalServerErrorException();
     case invalidRange:
-      throw new BadRequestException(
+      return new BadRequestException(
         `Received range is invalid: [${options?.range}]`,
       );
     case blmCreationFailure:
-      throw new InternalServerErrorException(
+      return new InternalServerErrorException(
         `Could not create initial BLM for scenario.`,
       );
     case jobSubmissionFailed:
-      throw new InternalServerErrorException('Job submission failed.');
+      return new InternalServerErrorException('Job submission failed.');
     case submissionFailed:
-      throw new InternalServerErrorException(
+      return new InternalServerErrorException(
         'System could not submit the async job.',
       );
     case nullPlanningUnitGridShape:
-      throw new BadRequestException('Invalid planing unit grid shape.');
+      return new BadRequestException('Invalid planing unit grid shape.');
     case initialCostProjectNotFound:
-      throw new NotFoundException('Project not found.');
+      return new NotFoundException('Project not found.');
     default:
       const _exhaustiveCheck: never = errorToCheck;
-      throw _exhaustiveCheck;
+      return _exhaustiveCheck;
   }
 };

--- a/api/apps/api/src/utils/acl.utils.ts
+++ b/api/apps/api/src/utils/acl.utils.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
@@ -10,7 +11,53 @@ import {
   transactionFailed,
   queryFailed,
 } from '@marxan-api/modules/access-control';
-import { notFound } from '@marxan-api/modules/scenarios/marxan-run';
+import { notFound as marxanRunNotFound } from '@marxan-api/modules/scenarios/marxan-run';
+import {
+  scenarioNotFound,
+  unknownError as blmUnknownError,
+} from '@marxan-api/modules/blm/values/blm-repos';
+import {
+  projectDoesntExist,
+  projectNotReady,
+} from '@marxan-api/modules/scenarios/scenarios.service';
+import { blmCreationFailure } from '@marxan-api/modules/scenarios/blm-calibration/create-initial-scenario-blm.command';
+import { jobSubmissionFailed } from '@marxan/scenario-cost-surface';
+import {
+  nullPlanningUnitGridShape,
+  projectNotFound as initialCostProjectNotFound,
+} from '@marxan-api/modules/scenarios/cost-surface/application/set-initial-cost-surface.command';
+import { internalError } from '@marxan-api/modules/specification/application/submit-specification.command';
+import {
+  noLockInPlace,
+  lockedByAnotherUser,
+  lockedScenario,
+  unknownError as lockUnknownError,
+} from '@marxan-api/modules/access-control/scenarios-acl/locks/lock.service';
+import {
+  marxanFailed,
+  metadataNotFound,
+  outputZipNotYetAvailable,
+} from '@marxan-api/modules/scenarios/output-files/output-files.service';
+import {
+  inputZipNotYetAvailable,
+  metadataNotFound as inputMetadataNotFound,
+} from '@marxan-api/modules/scenarios/input-files';
+import { notFound as protectedAreaProjectNotFound } from '@marxan/projects';
+import { invalidProtectedAreaId } from '@marxan-api/modules/scenarios/protected-area/selection/selection-update.service';
+import { submissionFailed } from '@marxan-api/modules/scenarios/protected-area';
+import {
+  invalidRange,
+  updateFailure,
+  unknownError as rangeUnknownError,
+} from '@marxan-api/modules/scenarios/blm-calibration/change-scenario-blm-range.command';
+
+interface ErrorHandlerOptions {
+  projectId?: string;
+  range?: [number, number];
+  resourceType?: string;
+  scenarioId?: string;
+  userId?: string;
+}
 
 export const aclErrorHandler = (
   errorToCheck:
@@ -18,23 +65,118 @@ export const aclErrorHandler = (
     | typeof lastOwner
     | typeof transactionFailed
     | typeof queryFailed
-    | typeof notFound,
+    | typeof noLockInPlace
+    | typeof lockedByAnotherUser
+    | typeof lockUnknownError
+    | typeof lockedScenario
+    | typeof internalError
+    | typeof blmUnknownError
+    | typeof marxanFailed
+    | typeof outputZipNotYetAvailable
+    | typeof metadataNotFound
+    | typeof marxanRunNotFound
+    | typeof inputMetadataNotFound
+    | typeof inputZipNotYetAvailable
+    | typeof scenarioNotFound
+    | typeof invalidProtectedAreaId
+    | typeof projectNotReady
+    | typeof projectDoesntExist
+    | typeof protectedAreaProjectNotFound
+    | typeof invalidRange
+    | typeof updateFailure
+    | typeof rangeUnknownError
+    | typeof blmCreationFailure
+    | typeof jobSubmissionFailed
+    | typeof submissionFailed
+    | typeof nullPlanningUnitGridShape
+    | typeof initialCostProjectNotFound,
+  options?: ErrorHandlerOptions,
 ) => {
   switch (errorToCheck) {
     case forbiddenError:
-      throw new ForbiddenException();
+      throw new ForbiddenException(
+        `User with ID: ${options?.userId} is not allowed to perform this action on ${options?.resourceType}.`,
+      );
     case lastOwner:
-      throw new ForbiddenException(`There must be at least one owner`);
+      throw new ForbiddenException(`There must be at least one owner.`);
     case queryFailed:
       throw new BadRequestException(
-        `Error while adding record to the database`,
+        `Error while adding record to the database.`,
       );
     case transactionFailed:
-      throw new InternalServerErrorException(`Transaction failed`);
-    case notFound:
-      throw new NotFoundException(`Entity not found`);
+      throw new InternalServerErrorException(`Transaction failed.`);
+    case lockUnknownError:
+      throw new InternalServerErrorException();
+    case lockedByAnotherUser:
+      throw new BadRequestException(
+        `Scenario ${options?.scenarioId} is already being edited.`,
+      );
+    case lockedScenario:
+      throw new BadRequestException(
+        `Scenario ${options?.scenarioId} is already being edited.`,
+      );
+    case noLockInPlace:
+      throw new NotFoundException(
+        `Scenario ${options?.scenarioId} has no locks in place.`,
+      );
+    case internalError:
+      throw new InternalServerErrorException(errorToCheck.description);
+    case marxanRunNotFound:
+      throw new NotFoundException(`Entity not found.`);
+    case blmUnknownError:
+      throw new InternalServerErrorException();
+    case scenarioNotFound:
+      throw new NotFoundException(
+        `Scenario ${options?.scenarioId} could not be found.`,
+      );
+    case marxanFailed:
+      throw new InternalServerErrorException('Marxan failed.');
+    case outputZipNotYetAvailable:
+      throw new InternalServerErrorException(
+        'Marxan output file - output file not available, possible error.',
+      );
+    case metadataNotFound:
+      throw new InternalServerErrorException('Marxan was not yet executed.');
+    case inputZipNotYetAvailable:
+      throw new InternalServerErrorException(
+        'Marxan input file - input file not available, possible error.',
+      );
+    case inputMetadataNotFound:
+      throw new InternalServerErrorException(
+        'Marxan input file - metadata not found.',
+      );
+    case projectNotReady:
+      throw new ConflictException('Project is not ready.');
+    case projectDoesntExist:
+      throw new NotFoundException(`Project doesn't exist.`);
+    case protectedAreaProjectNotFound:
+      throw new NotFoundException('Project not found.');
+    case invalidProtectedAreaId:
+      throw new BadRequestException('Invalid protected area id.');
+    case rangeUnknownError:
+      throw new InternalServerErrorException();
+    case updateFailure:
+      throw new InternalServerErrorException();
+    case invalidRange:
+      throw new BadRequestException(
+        `Received range is invalid: [${options?.range}]`,
+      );
+    case blmCreationFailure:
+      throw new InternalServerErrorException(
+        `Could not create initial BLM for scenario.`,
+      );
+    case jobSubmissionFailed:
+      throw new InternalServerErrorException('Job submission failed.');
+    case submissionFailed:
+      throw new InternalServerErrorException(
+        'System could not submit the async job.',
+      );
+    case nullPlanningUnitGridShape:
+      throw new BadRequestException('Invalid planing unit grid shape.');
+    case initialCostProjectNotFound:
+      throw new NotFoundException('Project not found.');
     default:
-      const _check: never = errorToCheck;
-      throw _check;
+      const _exhaustiveCheck: never = errorToCheck;
+      throw _exhaustiveCheck;
   }
 };

--- a/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/project-acl/project-acl.fixtures.ts
@@ -341,13 +341,13 @@ export const getFixtures = async () => {
     ThenQueryFailedIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(400);
       const error: any = response.body.errors[0];
-      expect(error.title).toEqual(`Error while adding record to the database`);
+      expect(error.title).toEqual(`Error while adding record to the database.`);
     },
 
     ThenTransactionFailedIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(500);
       const error: any = response.body.errors[0];
-      expect(error.title).toEqual(`Transaction failed`);
+      expect(error.title).toEqual(`Transaction failed.`);
     },
 
     ThenNoContentIsReturned: (response: request.Response) => {

--- a/api/apps/api/test/access-control/scenario-acl/scenario-acl.fixtures.ts
+++ b/api/apps/api/test/access-control/scenario-acl/scenario-acl.fixtures.ts
@@ -348,13 +348,13 @@ export const getFixtures = async () => {
     ThenQueryFailedIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(400);
       const error: any = response.body.errors[0];
-      expect(error.title).toEqual(`Error while adding record to the database`);
+      expect(error.title).toEqual(`Error while adding record to the database.`);
     },
 
     ThenTransactionFailedIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(500);
       const error: any = response.body.errors[0];
-      expect(error.title).toEqual(`Transaction failed`);
+      expect(error.title).toEqual(`Transaction failed.`);
     },
 
     ThenSingleOwnerUserInScenarioIsReturned: (response: request.Response) => {

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -137,7 +137,6 @@ describe('ScenariosModule (e2e)', () => {
 async function getFixtures() {
   const app = await bootstrapApplication();
   const ownerToken = await GivenUserIsLoggedIn(app, 'aa');
-  const ownerUserId = await GivenUserExists(app, 'aa');
   const contributorToken = await GivenUserIsLoggedIn(app, 'bb');
   const contributorUserId = await GivenUserExists(app, 'bb');
   const viewerToken = await GivenUserIsLoggedIn(app, 'cc');

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -225,7 +225,7 @@ test(`getting all locks of scenarios as scenario viewer`, async () => {
   );
 });
 
-test.only(`getting the lock of a scenario if there is no lock in place`, async () => {
+test(`getting the lock of a scenario if there is no lock in place`, async () => {
   const ownerToken = await fixtures.GivenUserIsLoggedIn('owner');
   const scenarioIdObj = await fixtures.GivenTwoScenariosWereCreated();
 

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -280,7 +280,7 @@ test('Fails to update scenario as there was a lock in place by a different user'
   fixtures.ThenScenarioLockInfoForOwnerIsReturned(response);
 
   response = await fixtures.WhenUpdatingScenarioAsContributor();
-  fixtures.ThenScenarioIsLockedIsReturned(response);
+  fixtures.ThenScenarioIsLockedByAnotherUserIsReturned(response);
 });
 
 test('Updates scenario correctly as lock is in place by same user', async () => {


### PR DESCRIPTION
-Adds new lock logic check into every POST/PATCH/DELETE endpoint. Uses a flag for DELETE.
-Implements poor person's version of LOFU (Lock on first use)
-Adapts tests where needed for this new logic check, though with LOFU this would not be as needed as before.
-Refactors `aclErrorHandler` to address every type of error needed for `scenarios.controller` using exhaustive pattern (maybe the name should be changed into just  `errorHandler` or `exhaustiveErrorHandler`?).