### PR TITLE
Ref/export commands and events simplification

### DIFF
--- a/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
@@ -6,7 +6,7 @@ import {
 } from '../application/export-repository.port';
 import { Export, ExportId } from '../domain';
 
-export class InMemoryExportRepo implements ExportRepository {
+export class MemoryExportRepo implements ExportRepository {
   #memory: Record<string, Export> = {};
 
   async find(exportId: ExportId): Promise<Export | undefined> {

--- a/api/apps/api/src/modules/clone/export/application/all-pieces-ready.saga.ts
+++ b/api/apps/api/src/modules/clone/export/application/all-pieces-ready.saga.ts
@@ -3,7 +3,7 @@ import { ICommand, ofType, Saga } from '@nestjs/cqrs';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { ExportAllComponentsFinished } from '@marxan-api/modules/clone/export/domain';
+import { AllPiecesExported } from '@marxan-api/modules/clone/export/domain';
 import { FinalizeArchive } from './finalize-archive.command';
 
 @Injectable()
@@ -11,7 +11,7 @@ export class AllPiecesReadySaga {
   @Saga()
   finalizeArchive = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
-      ofType(ExportAllComponentsFinished),
+      ofType(AllPiecesExported),
       map((event) => new FinalizeArchive(event.exportId)),
     );
 }

--- a/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.spec.ts
@@ -13,7 +13,7 @@ import { v4 } from 'uuid';
 import { InMemoryExportRepo } from '../adapters/in-memory-export.repository';
 import {
   Export,
-  ExportAllComponentsFinished,
+  AllPiecesExported,
   ExportComponentFinished,
   ExportId,
 } from '../domain';
@@ -195,9 +195,7 @@ const getFixtures = async () => {
       expect(allComponentsFinishedEvent).toMatchObject({
         exportId,
       });
-      expect(allComponentsFinishedEvent).toBeInstanceOf(
-        ExportAllComponentsFinished,
-      );
+      expect(allComponentsFinishedEvent).toBeInstanceOf(AllPiecesExported);
     },
     ThenNoEventIsEmitted: () => {
       expect(events).toHaveLength(0);

--- a/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.ts
@@ -33,9 +33,9 @@ export class CompleteExportPieceHandler
         const exportInstance = await repo.find(exportId);
 
         if (!exportInstance) {
-          const errorMessage = `${CompleteExportPieceHandler.name} could not find export ${exportId.value} to complete piece: ${componentId.value}`;
-          this.logger.error(errorMessage);
-          throw new Error(errorMessage);
+          throw new Error(
+            `${CompleteExportPieceHandler.name} could not find export ${exportId.value} to complete piece: ${componentId.value}`,
+          );
         }
 
         const exportAggregate = this.eventPublisher.mergeObjectContext(
@@ -53,11 +53,10 @@ export class CompleteExportPieceHandler
                 `Could not find piece with ID: ${componentId} for export with ID: ${exportId}`,
               );
             case pieceAlreadyExported:
-              return;
-            default:
-              throw new Error(
-                `Unknown error while trying to complete piece with iD ${componentId} for export with ID: ${exportId}`,
+              this.logger.error(
+                `Component with id ${componentId} was already completed`,
               );
+              return;
           }
         }
 
@@ -65,7 +64,8 @@ export class CompleteExportPieceHandler
 
         exportAggregate.commit();
       })
-      .catch(() => {
+      .catch((err) => {
+        this.logger.error(err);
         this.eventBus.publish(new ExportPieceFailed(exportId, componentId));
       });
   }

--- a/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/complete-export-piece.handler.ts
@@ -7,7 +7,7 @@ import {
   IInferredCommandHandler,
 } from '@nestjs/cqrs';
 import { isLeft } from 'fp-ts/Either';
-import { Export } from '../domain';
+import { pieceAlreadyExported, pieceNotFound } from '../domain/export/export';
 import { CompleteExportPiece } from './complete-export-piece.command';
 import { ExportRepository } from './export-repository.port';
 
@@ -28,10 +28,9 @@ export class CompleteExportPieceHandler
     componentLocation,
     componentId,
   }: CompleteExportPiece): Promise<void> {
-    let exportInstance: Export | undefined;
     await this.exportRepository
       .transaction(async (repo) => {
-        exportInstance = await repo.find(exportId);
+        const exportInstance = await repo.find(exportId);
 
         if (!exportInstance) {
           const errorMessage = `${CompleteExportPieceHandler.name} could not find export ${exportId.value} to complete piece: ${componentId.value}`;
@@ -48,9 +47,18 @@ export class CompleteExportPieceHandler
           componentLocation,
         );
         if (isLeft(result)) {
-          throw new Error(
-            `Could not find piece with ID: ${componentId} for export with ID: ${exportId}`,
-          );
+          switch (result.left) {
+            case pieceNotFound:
+              throw new Error(
+                `Could not find piece with ID: ${componentId} for export with ID: ${exportId}`,
+              );
+            case pieceAlreadyExported:
+              return;
+            default:
+              throw new Error(
+                `Unknown error while trying to complete piece with iD ${componentId} for export with ID: ${exportId}`,
+              );
+          }
         }
 
         await repo.save(exportAggregate);
@@ -58,17 +66,7 @@ export class CompleteExportPieceHandler
         exportAggregate.commit();
       })
       .catch(() => {
-        if (exportInstance) {
-          this.eventBus.publish(
-            new ExportPieceFailed(
-              exportId,
-              componentId,
-              exportInstance.resourceId,
-              exportInstance.resourceKind,
-              componentLocation,
-            ),
-          );
-        }
+        this.eventBus.publish(new ExportPieceFailed(exportId, componentId));
       });
   }
 }

--- a/api/apps/api/src/modules/clone/export/application/export-piece-failed.event.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-piece-failed.event.ts
@@ -1,19 +1,10 @@
-import {
-  ComponentId,
-  ComponentLocation,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
 import { ExportId } from '@marxan-api/modules/clone';
+import { ComponentId } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
 
 export class ExportPieceFailed implements IEvent {
-  // TODO Check if all parameters are needed
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-    public readonly location?: ComponentLocation[],
   ) {}
 }

--- a/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
@@ -1,23 +1,24 @@
-import { Test } from '@nestjs/testing';
+import {
+  ClonePiece,
+  ComponentId,
+  ResourceId,
+  ResourceKind,
+} from '@marxan/cloning/domain';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Injectable } from '@nestjs/common';
 import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
-
-import { FixtureType } from '@marxan/utils/tests/fixture-type';
-
-import { ClonePiece, ResourceId, ResourceKind } from '@marxan/cloning/domain';
-
+import { Test } from '@nestjs/testing';
+import { MemoryExportRepo } from '../adapters/memory-export.repository';
 import {
   ExportComponent,
-  PieceExportRequested,
   ExportId,
   ExportRequested,
+  PieceExportRequested,
 } from '../domain';
-
-import { ExportProjectHandler } from './export-project.handler';
-import { ExportResourcePieces } from './export-resource-pieces.port';
-import { ExportRepository } from './export-repository.port';
 import { ExportProject } from './export-project.command';
-import { InMemoryExportRepo } from '../adapters/in-memory-export.repository';
+import { ExportProjectHandler } from './export-project.handler';
+import { ExportRepository } from './export-repository.port';
+import { ExportResourcePieces } from './export-resource-pieces.port';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -43,7 +44,7 @@ const getFixtures = async () => {
       },
       {
         provide: ExportRepository,
-        useClass: InMemoryExportRepo,
+        useClass: MemoryExportRepo,
       },
       ExportProjectHandler,
     ],
@@ -53,7 +54,7 @@ const getFixtures = async () => {
   const events: IEvent[] = [];
 
   const sut = sandbox.get(ExportProjectHandler);
-  const repo: InMemoryExportRepo = sandbox.get(ExportRepository);
+  const repo: MemoryExportRepo = sandbox.get(ExportRepository);
   const piecesResolver: FakePiecesProvider = sandbox.get(ExportResourcePieces);
   sandbox.get(EventBus).subscribe((event) => {
     events.push(event);
@@ -83,46 +84,22 @@ const getFixtures = async () => {
 
       expect(projectMetadataExport).toBeInstanceOf(PieceExportRequested);
       expect(projectMetadataExport).toMatchObject({
-        componentId: {
-          value: expect.any(String),
-        },
-        exportId: {
-          value: expect.any(String),
-        },
-        piece: 'project-metadata',
-        resourceId: {
-          value: projectId.value,
-        },
+        componentId: expect.any(ComponentId),
+        exportId: expect.any(ExportId),
       });
 
       expect(projectPlanningAreaCustomExport).toBeInstanceOf(
         PieceExportRequested,
       );
       expect(projectPlanningAreaCustomExport).toMatchObject({
-        componentId: {
-          value: expect.any(String),
-        },
-        exportId: {
-          value: expect.any(String),
-        },
-        piece: 'planning-area-shapefile',
-        resourceId: {
-          value: projectId.value,
-        },
+        componentId: expect.any(ComponentId),
+        exportId: expect.any(ExportId),
       });
 
       expect(exportConfigExport).toBeInstanceOf(PieceExportRequested);
       expect(exportConfigExport).toMatchObject({
-        componentId: {
-          value: expect.any(String),
-        },
-        exportId: {
-          value: expect.any(String),
-        },
-        piece: 'export-config',
-        resourceId: {
-          value: projectId.value,
-        },
+        componentId: expect.any(ComponentId),
+        exportId: expect.any(ExportId),
       });
     },
     ThenExportRequestsEventIsPresent(exportId: ExportId) {

--- a/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
@@ -8,7 +8,7 @@ import { ClonePiece, ResourceId, ResourceKind } from '@marxan/cloning/domain';
 
 import {
   ExportComponent,
-  ExportComponentRequested,
+  PieceExportRequested,
   ExportId,
   ExportRequested,
 } from '../domain';
@@ -81,7 +81,7 @@ const getFixtures = async () => {
       const projectPlanningAreaCustomExport = events[1];
       const exportConfigExport = events[2];
 
-      expect(projectMetadataExport).toBeInstanceOf(ExportComponentRequested);
+      expect(projectMetadataExport).toBeInstanceOf(PieceExportRequested);
       expect(projectMetadataExport).toMatchObject({
         componentId: {
           value: expect.any(String),
@@ -96,7 +96,7 @@ const getFixtures = async () => {
       });
 
       expect(projectPlanningAreaCustomExport).toBeInstanceOf(
-        ExportComponentRequested,
+        PieceExportRequested,
       );
       expect(projectPlanningAreaCustomExport).toMatchObject({
         componentId: {
@@ -111,7 +111,7 @@ const getFixtures = async () => {
         },
       });
 
-      expect(exportConfigExport).toBeInstanceOf(ExportComponentRequested);
+      expect(exportConfigExport).toBeInstanceOf(PieceExportRequested);
       expect(exportConfigExport).toMatchObject({
         componentId: {
           value: expect.any(String),

--- a/api/apps/api/src/modules/clone/export/domain/events/all-pieces-exported.event.ts
+++ b/api/apps/api/src/modules/clone/export/domain/events/all-pieces-exported.event.ts
@@ -1,6 +1,6 @@
 import { IEvent } from '@nestjs/cqrs';
 import { ExportId } from '../export/export.id';
 
-export class ExportAllComponentsFinished implements IEvent {
+export class AllPiecesExported implements IEvent {
   constructor(public readonly exportId: ExportId) {}
 }

--- a/api/apps/api/src/modules/clone/export/domain/events/archive-ready.event.ts
+++ b/api/apps/api/src/modules/clone/export/domain/events/archive-ready.event.ts
@@ -1,17 +1,10 @@
+import { ArchiveLocation } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
-
-import {
-  ArchiveLocation,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
 import { ExportId } from '../export/export.id';
 
 export class ArchiveReady implements IEvent {
   constructor(
     public readonly exportId: ExportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
     public readonly archiveLocation: ArchiveLocation,
   ) {}
 }

--- a/api/apps/api/src/modules/clone/export/domain/events/piece-export-requested.event.ts
+++ b/api/apps/api/src/modules/clone/export/domain/events/piece-export-requested.event.ts
@@ -1,20 +1,10 @@
+import { ComponentId } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
-
-import {
-  ClonePiece,
-  ComponentId,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
 import { ExportId } from '../export/export.id';
 
 export class PieceExportRequested implements IEvent {
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-    public readonly piece: ClonePiece,
-    public readonly allPieces: ClonePiece[],
   ) {}
 }

--- a/api/apps/api/src/modules/clone/export/domain/events/piece-export-requested.event.ts
+++ b/api/apps/api/src/modules/clone/export/domain/events/piece-export-requested.event.ts
@@ -8,7 +8,7 @@ import {
 } from '@marxan/cloning/domain';
 import { ExportId } from '../export/export.id';
 
-export class ExportComponentRequested implements IEvent {
+export class PieceExportRequested implements IEvent {
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,

--- a/api/apps/api/src/modules/clone/export/domain/events/piece-exported.event.ts
+++ b/api/apps/api/src/modules/clone/export/domain/events/piece-exported.event.ts
@@ -2,7 +2,7 @@ import { IEvent } from '@nestjs/cqrs';
 import { ComponentId, ComponentLocation } from '@marxan/cloning/domain';
 import { ExportId } from '../export/export.id';
 
-export class ExportComponentFinished implements IEvent {
+export class PieceExported implements IEvent {
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,

--- a/api/apps/api/src/modules/clone/export/domain/export/export.ts
+++ b/api/apps/api/src/modules/clone/export/domain/export/export.ts
@@ -1,6 +1,4 @@
-import { AggregateRoot } from '@nestjs/cqrs';
-import { Either, left, right } from 'fp-ts/Either';
-
+import { ExportRequested } from '@marxan-api/modules/clone/export/domain';
 import {
   ArchiveLocation,
   ComponentId,
@@ -8,16 +6,15 @@ import {
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';
-import { ExportId } from './export.id';
-
-import { ExportComponentRequested } from '../events/export-component-requested.event';
-import { ExportComponentFinished } from '../events/export-component-finished.event';
-import { ArchiveReady } from '../events/archive-ready.event';
-
-import { ExportComponent } from './export-component/export-component';
-import { ExportSnapshot } from './export.snapshot';
+import { AggregateRoot } from '@nestjs/cqrs';
+import { Either, left, right } from 'fp-ts/Either';
 import { AllPiecesExported } from '../events/all-pieces-exported.event';
-import { ExportRequested } from '@marxan-api/modules/clone/export/domain';
+import { ArchiveReady } from '../events/archive-ready.event';
+import { PieceExported } from '../events/piece-exported.event';
+import { ExportComponentRequested } from '../events/export-component-requested.event';
+import { ExportComponent } from './export-component/export-component';
+import { ExportId } from './export.id';
+import { ExportSnapshot } from './export.snapshot';
 
 export const pieceNotFound = Symbol('export piece not found');
 export const notReady = Symbol('some pieces of export are not yet ready');
@@ -74,7 +71,7 @@ export class Export extends AggregateRoot {
       return left(pieceNotFound);
     }
     piece.finish(pieceLocation);
-    this.apply(new ExportComponentFinished(this.id, id, pieceLocation));
+    this.apply(new PieceExported(this.id, id, pieceLocation));
 
     if (this.#allPiecesReady()) {
       this.apply(new AllPiecesExported(this.id));

--- a/api/apps/api/src/modules/clone/export/domain/export/export.ts
+++ b/api/apps/api/src/modules/clone/export/domain/export/export.ts
@@ -10,8 +10,8 @@ import { AggregateRoot } from '@nestjs/cqrs';
 import { Either, left, right } from 'fp-ts/Either';
 import { AllPiecesExported } from '../events/all-pieces-exported.event';
 import { ArchiveReady } from '../events/archive-ready.event';
-import { PieceExported } from '../events/piece-exported.event';
 import { PieceExportRequested } from '../events/piece-export-requested.event';
+import { PieceExported } from '../events/piece-exported.event';
 import { ExportComponent } from './export-component/export-component';
 import { ExportId } from './export.id';
 import { ExportSnapshot } from './export.snapshot';
@@ -85,14 +85,7 @@ export class Export extends AggregateRoot {
       return left(notReady);
     }
     this.archiveLocation = archiveLocation;
-    this.apply(
-      new ArchiveReady(
-        this.id,
-        this.resourceId,
-        this.resourceKind,
-        this.archiveLocation,
-      ),
-    );
+    this.apply(new ArchiveReady(this.id, this.archiveLocation));
     return right(true);
   }
 

--- a/api/apps/api/src/modules/clone/export/domain/export/export.ts
+++ b/api/apps/api/src/modules/clone/export/domain/export/export.ts
@@ -11,7 +11,7 @@ import { Either, left, right } from 'fp-ts/Either';
 import { AllPiecesExported } from '../events/all-pieces-exported.event';
 import { ArchiveReady } from '../events/archive-ready.event';
 import { PieceExported } from '../events/piece-exported.event';
-import { ExportComponentRequested } from '../events/export-component-requested.event';
+import { PieceExportRequested } from '../events/piece-export-requested.event';
 import { ExportComponent } from './export-component/export-component';
 import { ExportId } from './export.id';
 import { ExportSnapshot } from './export.snapshot';
@@ -41,7 +41,7 @@ export class Export extends AggregateRoot {
       .filter((part) => !part.isReady())
       .map(
         (part) =>
-          new ExportComponentRequested(
+          new PieceExportRequested(
             exportRequest.id,
             part.id,
             part.resourceId,

--- a/api/apps/api/src/modules/clone/export/domain/export/export.ts
+++ b/api/apps/api/src/modules/clone/export/domain/export/export.ts
@@ -16,7 +16,7 @@ import { ArchiveReady } from '../events/archive-ready.event';
 
 import { ExportComponent } from './export-component/export-component';
 import { ExportSnapshot } from './export.snapshot';
-import { ExportAllComponentsFinished } from '../events/export-all-components-finished.event';
+import { AllPiecesExported } from '../events/all-pieces-exported.event';
 import { ExportRequested } from '@marxan-api/modules/clone/export/domain';
 
 export const pieceNotFound = Symbol('export piece not found');
@@ -77,7 +77,7 @@ export class Export extends AggregateRoot {
     this.apply(new ExportComponentFinished(this.id, id, pieceLocation));
 
     if (this.#allPiecesReady()) {
-      this.apply(new ExportAllComponentsFinished(this.id));
+      this.apply(new AllPiecesExported(this.id));
     }
 
     return right(true);

--- a/api/apps/api/src/modules/clone/export/domain/index.ts
+++ b/api/apps/api/src/modules/clone/export/domain/index.ts
@@ -1,6 +1,6 @@
 export { ArchiveReady } from './events/archive-ready.event';
 export { PieceExported } from './events/piece-exported.event';
-export { ExportComponentRequested } from './events/export-component-requested.event';
+export { PieceExportRequested } from './events/piece-export-requested.event';
 export { AllPiecesExported } from './events/all-pieces-exported.event';
 export { ExportRequested } from './events/export-requested.event';
 

--- a/api/apps/api/src/modules/clone/export/domain/index.ts
+++ b/api/apps/api/src/modules/clone/export/domain/index.ts
@@ -1,5 +1,5 @@
 export { ArchiveReady } from './events/archive-ready.event';
-export { ExportComponentFinished } from './events/export-component-finished.event';
+export { PieceExported } from './events/piece-exported.event';
 export { ExportComponentRequested } from './events/export-component-requested.event';
 export { AllPiecesExported } from './events/all-pieces-exported.event';
 export { ExportRequested } from './events/export-requested.event';

--- a/api/apps/api/src/modules/clone/export/domain/index.ts
+++ b/api/apps/api/src/modules/clone/export/domain/index.ts
@@ -1,7 +1,7 @@
 export { ArchiveReady } from './events/archive-ready.event';
 export { ExportComponentFinished } from './events/export-component-finished.event';
 export { ExportComponentRequested } from './events/export-component-requested.event';
-export { ExportAllComponentsFinished } from './events/export-all-components-finished.event';
+export { AllPiecesExported } from './events/all-pieces-exported.event';
 export { ExportRequested } from './events/export-requested.event';
 
 export { ExportId } from './export/export.id';

--- a/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.spec.ts
@@ -132,7 +132,6 @@ const getFixtures = async () => {
 
   return {
     GivenImportWasRequested: async () => {
-      const importId = v4();
       const resourceId = ResourceId.create();
       const pieces = [
         ImportComponent.newOne(resourceId, ClonePiece.ProjectMetadata, 0, []),

--- a/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.ts
@@ -52,7 +52,7 @@ export class CompleteImportPieceHandler
               );
             case componentAlreadyCompleted:
               this.logger.error(
-                `Component with ${componentId} was already completed`,
+                `Component with id ${componentId} was already completed`,
               );
               return;
           }

--- a/api/apps/api/src/modules/clone/import/application/import-archive.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-archive.spec.ts
@@ -196,15 +196,8 @@ const getFixtures = async () => {
         events.filter((event) => event instanceof PieceImportRequested),
       ).toMatchObject([
         {
+          importId: expect.any(ImportId),
           componentId: new ComponentId(`import component unique id`),
-          resourceId: projectId,
-          piece: `project-metadata`,
-          uris: [
-            {
-              relativePath: `project-metadata.json`,
-              uri: `/tmp/project-metadata-random-uuid.json`,
-            },
-          ],
         },
       ]);
     },
@@ -213,26 +206,12 @@ const getFixtures = async () => {
         events.filter((event) => event instanceof PieceImportRequested),
       ).toMatchObject([
         {
+          importId: expect.any(ImportId),
           componentId: new ComponentId(`import component unique id`),
-          resourceId: projectId,
-          piece: `project-metadata`,
-          uris: [
-            {
-              relativePath: `project-metadata.json`,
-              uri: `/tmp/project-metadata-random-uuid.json`,
-            },
-          ],
         },
         {
+          importId: expect.any(ImportId),
           componentId: new ComponentId(`some other piece`),
-          resourceId: projectId,
-          piece: `planning-area-gadm`,
-          uris: [
-            {
-              relativePath: `planning-area/config.json`,
-              uri: `/tmp/project-planning-area-random-uuid.json`,
-            },
-          ],
         },
       ]);
     },

--- a/api/apps/api/src/modules/clone/import/domain/events/piece-import-requested.event.ts
+++ b/api/apps/api/src/modules/clone/import/domain/events/piece-import-requested.event.ts
@@ -1,10 +1,4 @@
-import {
-  ClonePiece,
-  ComponentId,
-  ComponentLocation,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
+import { ComponentId } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
 import { ImportId } from '../import/import.id';
 
@@ -12,9 +6,5 @@ export class PieceImportRequested implements IEvent {
   constructor(
     public readonly importId: ImportId,
     public readonly componentId: ComponentId,
-    public readonly piece: ClonePiece,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-    public readonly uris: ComponentLocation[],
   ) {}
 }

--- a/api/apps/api/src/modules/clone/import/domain/import/import.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.ts
@@ -87,16 +87,7 @@ export class Import extends AggregateRoot {
     );
 
     for (const component of nextBatch) {
-      this.apply(
-        new PieceImportRequested(
-          this.importId,
-          component.id,
-          component.piece,
-          component.resourceId,
-          this.resourceKind,
-          component.uris,
-        ),
-      );
+      this.apply(new PieceImportRequested(this.importId, component.id));
     }
 
     return right(true);
@@ -120,16 +111,7 @@ export class Import extends AggregateRoot {
     for (const component of this.pieces.filter(
       (pc) => pc.order === firstBatchOrder,
     )) {
-      this.apply(
-        new PieceImportRequested(
-          this.importId,
-          component.id,
-          component.piece,
-          component.resourceId,
-          this.resourceKind,
-          component.uris,
-        ),
-      );
+      this.apply(new PieceImportRequested(this.importId, component.id));
     }
   }
 

--- a/api/apps/api/src/modules/clone/infra/export/archive-ready.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/export/archive-ready.saga.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { ICommand, ofType, Saga } from '@nestjs/cqrs';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 import { ArchiveReady } from '../../export/domain';
 import { MarkExportAsFinished } from './mark-export-as-finished.command';
 
@@ -12,13 +11,6 @@ export class ArchiveReadySaga {
   emitApiEvents = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
       ofType(ArchiveReady),
-      map(
-        (event) =>
-          new MarkExportAsFinished(
-            event.exportId,
-            event.resourceId,
-            event.resourceKind,
-          ),
-      ),
+      map((event) => new MarkExportAsFinished(event.exportId)),
     );
 }

--- a/api/apps/api/src/modules/clone/infra/export/cancel-export-pending-jobs.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/cancel-export-pending-jobs.command.ts
@@ -1,13 +1,8 @@
-import { Command } from '@nestjs-architects/typed-cqrs';
 import { ExportId } from '@marxan-api/modules/clone';
-import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class CancelExportPendingJobs extends Command<void> {
-  constructor(
-    public readonly exportId: ExportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-  ) {
+  constructor(public readonly exportId: ExportId) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/export/cancel-export-pending-jobs.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/cancel-export-pending-jobs.handler.ts
@@ -1,4 +1,6 @@
+import { MarkExportPiecesAsFailed } from '@marxan-api/modules/clone/infra/export/mark-export-pieces-as-failed.command';
 import { ExportJobInput } from '@marxan/cloning';
+import { ComponentId } from '@marxan/cloning/domain';
 import { Inject } from '@nestjs/common';
 import {
   CommandBus,
@@ -8,8 +10,6 @@ import {
 import { Job, Queue } from 'bullmq';
 import { CancelExportPendingJobs } from './cancel-export-pending-jobs.command';
 import { exportPieceQueueToken } from './export-queue.provider';
-import { ComponentId } from '@marxan/cloning/domain';
-import { MarkExportPiecesAsFailed } from '@marxan-api/modules/clone/infra/export/mark-export-pieces-as-failed.command';
 
 @CommandHandler(CancelExportPendingJobs)
 export class CancelExportPendingJobsHandler
@@ -20,11 +20,7 @@ export class CancelExportPendingJobsHandler
     private readonly commandBus: CommandBus,
   ) {}
 
-  async execute({
-    exportId,
-    resourceKind,
-    resourceId,
-  }: CancelExportPendingJobs): Promise<void> {
+  async execute({ exportId }: CancelExportPendingJobs): Promise<void> {
     const pendingJobs: Job<ExportJobInput>[] = await this.queue.getJobs([
       'waiting',
       'delayed',
@@ -49,8 +45,6 @@ export class CancelExportPendingJobsHandler
     await this.commandBus.execute(
       new MarkExportPiecesAsFailed(
         exportId,
-        resourceId,
-        resourceKind,
         exportJobs.map((job) => new ComponentId(job.data.componentId)),
       ),
     );

--- a/api/apps/api/src/modules/clone/infra/export/export-piece-failed.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece-failed.saga.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { ICommand, ofType, Saga } from '@nestjs/cqrs';
 import { Observable, of } from 'rxjs';
-import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
 import { mergeMap } from 'rxjs/operators';
-import { MarkExportAsFailed } from './mark-export-as-failed.command';
+import { ExportPieceFailed } from '../../export/application/export-piece-failed.event';
 import { CancelExportPendingJobs } from './cancel-export-pending-jobs.command';
+import { MarkExportAsFailed } from './mark-export-as-failed.command';
 
 @Injectable()
 export class ExportPieceFailedSaga {
@@ -14,16 +14,8 @@ export class ExportPieceFailedSaga {
       ofType(ExportPieceFailed),
       mergeMap((event) =>
         of(
-          new MarkExportAsFailed(
-            event.exportId,
-            event.resourceId,
-            event.resourceKind,
-          ),
-          new CancelExportPendingJobs(
-            event.exportId,
-            event.resourceId,
-            event.resourceKind,
-          ),
+          new MarkExportAsFailed(event.exportId),
+          new CancelExportPendingJobs(event.exportId),
         ),
       ),
     );

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
@@ -11,7 +11,6 @@ import {
   ComponentId,
   ComponentLocation,
   ResourceKind,
-  ResourceId,
 } from '@marxan/cloning/domain';
 import { assertDefined } from '@marxan/utils';
 import { Inject, Injectable } from '@nestjs/common';
@@ -105,18 +104,11 @@ export class ExportPieceEventsHandler
   }
 
   private async failed(event: EventData<ExportJobInput, unknown>) {
-    const {
-      exportId,
-      componentId,
-      resourceId,
-      resourceKind,
-    } = await event.data;
+    const { exportId, componentId } = await event.data;
     this.eventBus.publish(
       new ExportPieceFailed(
         new ExportId(exportId),
         new ComponentId(componentId),
-        new ResourceId(resourceId),
-        resourceKind,
       ),
     );
   }

--- a/api/apps/api/src/modules/clone/infra/export/export.infra.module.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export.infra.module.ts
@@ -1,29 +1,32 @@
+import { ApiEventsModule } from '@marxan-api/modules/api-events';
+import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
-
-import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
-import { ApiEventsModule } from '@marxan-api/modules/api-events';
-
-import { PieceExportRequestedSaga } from './piece-export-requested.saga';
-import { ExportStartedSaga } from './export-started.saga';
-
-import { SchedulePieceExportHandler } from './schedule-piece-export.handler';
+import { ExportAdaptersModule } from '../../export/adapters/export-adapters.module';
+import { ArchiveReadySaga } from './archive-ready.saga';
+import { CancelExportPendingJobsHandler } from './cancel-export-pending-jobs.handler';
+import { ExportPieceFailedSaga } from './export-piece-failed.saga';
+import { ExportPieceEventsHandler } from './export-piece.events-handler';
 import {
   exportPieceEventsFactoryProvider,
   exportPiecenQueueEventsProvider,
   exportPieceQueueProvider,
 } from './export-queue.provider';
-import { ExportPieceEventsHandler } from './export-piece.events-handler';
-import { MarkExportAsSubmittedHandler } from './mark-export-as-submitted.handler';
-import { MarkExportAsFinishedHandler } from './mark-export-as-finished.handler';
-import { ArchiveReadySaga } from './archive-ready.saga';
-import { ExportPieceFailedSaga } from './export-piece-failed.saga';
-import { CancelExportPendingJobsHandler } from './cancel-export-pending-jobs.handler';
+import { ExportStartedSaga } from './export-started.saga';
 import { MarkExportAsFailedHandler } from './mark-export-as-failed.handler';
+import { MarkExportAsFinishedHandler } from './mark-export-as-finished.handler';
+import { MarkExportAsSubmittedHandler } from './mark-export-as-submitted.handler';
 import { MarkExportPiecesAsFailedHandler } from './mark-export-pieces-as-failed.handler';
+import { PieceExportRequestedSaga } from './piece-export-requested.saga';
+import { SchedulePieceExportHandler } from './schedule-piece-export.handler';
 
 @Module({
-  imports: [ApiEventsModule, QueueApiEventsModule, CqrsModule],
+  imports: [
+    ApiEventsModule,
+    QueueApiEventsModule,
+    CqrsModule,
+    ExportAdaptersModule,
+  ],
   providers: [
     SchedulePieceExportHandler,
     PieceExportRequestedSaga,

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.command.ts
@@ -1,13 +1,8 @@
-import { Command } from '@nestjs-architects/typed-cqrs';
 import { ExportId } from '@marxan-api/modules/clone';
-import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class MarkExportAsFailed extends Command<void> {
-  constructor(
-    public readonly exportId: ExportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-  ) {
+  constructor(public readonly exportId: ExportId) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
@@ -1,9 +1,9 @@
 import { ApiEventsService } from '@marxan-api/modules/api-events';
-import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
-
-import { ResourceKind } from '@marxan/cloning/domain';
 import { API_EVENT_KINDS } from '@marxan/api-events';
-
+import { ResourceKind } from '@marxan/cloning/domain';
+import { Logger } from '@nestjs/common';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { ExportRepository } from '../../export/application/export-repository.port';
 import { MarkExportAsFailed } from './mark-export-as-failed.command';
 
 @CommandHandler(MarkExportAsFailed)
@@ -14,13 +14,24 @@ export class MarkExportAsFailedHandler
     scenario: API_EVENT_KINDS.scenario__export__failed__v1__alpha,
   };
 
-  constructor(private readonly apiEvents: ApiEventsService) {}
+  constructor(
+    private readonly apiEvents: ApiEventsService,
+    private readonly exportRepository: ExportRepository,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(MarkExportAsFailedHandler.name);
+  }
 
-  async execute({
-    resourceKind,
-    resourceId,
-    exportId,
-  }: MarkExportAsFailed): Promise<void> {
+  async execute({ exportId }: MarkExportAsFailed): Promise<void> {
+    const exportInstance = await this.exportRepository.find(exportId);
+
+    if (!exportInstance) {
+      this.logger.error(`Export with ID ${exportId.value} not found`);
+      return;
+    }
+
+    const { resourceId, resourceKind } = exportInstance;
+
     const kind = this.eventMapper[resourceKind];
 
     await this.apiEvents.createIfNotExists({

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.command.ts
@@ -1,13 +1,8 @@
-import { Command } from '@nestjs-architects/typed-cqrs';
 import { ExportId } from '@marxan-api/modules/clone';
-import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class MarkExportAsFinished extends Command<void> {
-  constructor(
-    public readonly exportId: ExportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-  ) {
+  constructor(public readonly exportId: ExportId) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.handler.ts
@@ -38,7 +38,7 @@ export class MarkExportAsFinishedHandler
       topic: resourceId,
       data: {
         exportId: exportId.value,
-        resourceId: resourceId,
+        resourceId,
         resourceKind,
       },
     });

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-finished.handler.ts
@@ -1,9 +1,9 @@
 import { ApiEventsService } from '@marxan-api/modules/api-events';
-import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
-
-import { ResourceKind } from '@marxan/cloning/domain';
 import { API_EVENT_KINDS } from '@marxan/api-events';
-
+import { ResourceKind } from '@marxan/cloning/domain';
+import { Logger } from '@nestjs/common';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { ExportRepository } from '../../export/application/export-repository.port';
 import { MarkExportAsFinished } from './mark-export-as-finished.command';
 
 @CommandHandler(MarkExportAsFinished)
@@ -14,21 +14,31 @@ export class MarkExportAsFinishedHandler
     scenario: API_EVENT_KINDS.scenario__export__finished__v1__alpha,
   };
 
-  constructor(private readonly apiEvents: ApiEventsService) {}
+  constructor(
+    private readonly apiEvents: ApiEventsService,
+    private readonly exportRepository: ExportRepository,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(MarkExportAsFinishedHandler.name);
+  }
 
-  async execute({
-    resourceKind,
-    resourceId,
-    exportId,
-  }: MarkExportAsFinished): Promise<void> {
+  async execute({ exportId }: MarkExportAsFinished): Promise<void> {
+    const exportInstance = await this.exportRepository.find(exportId);
+
+    if (!exportInstance) {
+      this.logger.error(`Export with ID ${exportId.value} not found`);
+      return;
+    }
+    const { resourceKind, resourceId } = exportInstance.toSnapshot();
+
     const kind = this.eventMapper[resourceKind];
 
     await this.apiEvents.createIfNotExists({
       kind,
-      topic: resourceId.value,
+      topic: resourceId,
       data: {
         exportId: exportId.value,
-        resourceId: resourceId.value,
+        resourceId: resourceId,
         resourceKind,
       },
     });

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-pieces-as-failed.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-pieces-as-failed.command.ts
@@ -1,12 +1,10 @@
+import { ComponentId } from '@marxan/cloning/domain';
 import { Command } from '@nestjs-architects/typed-cqrs';
-import { ComponentId, ResourceKind, ResourceId } from '@marxan/cloning/domain';
 import { ExportId } from '../../export';
 
 export class MarkExportPiecesAsFailed extends Command<void> {
   constructor(
     public readonly exportId: ExportId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
     public readonly componentsId: ComponentId[],
   ) {
     super();

--- a/api/apps/api/src/modules/clone/infra/export/piece-export-requested.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/export/piece-export-requested.saga.ts
@@ -3,7 +3,7 @@ import { ICommand, ofType, Saga } from '@nestjs/cqrs';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { ExportComponentRequested } from '@marxan-api/modules/clone/export/domain';
+import { PieceExportRequested } from '@marxan-api/modules/clone/export/domain';
 import { SchedulePieceExport } from './schedule-piece-export.command';
 
 @Injectable()
@@ -11,7 +11,7 @@ export class PieceExportRequestedSaga {
   @Saga()
   scheduleExport = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
-      ofType(ExportComponentRequested),
+      ofType(PieceExportRequested),
       map(
         (event) =>
           new SchedulePieceExport(

--- a/api/apps/api/src/modules/clone/infra/export/piece-export-requested.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/export/piece-export-requested.saga.ts
@@ -1,9 +1,8 @@
+import { PieceExportRequested } from '@marxan-api/modules/clone/export/domain';
 import { Injectable } from '@nestjs/common';
 import { ICommand, ofType, Saga } from '@nestjs/cqrs';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
-import { PieceExportRequested } from '@marxan-api/modules/clone/export/domain';
 import { SchedulePieceExport } from './schedule-piece-export.command';
 
 @Injectable()
@@ -13,15 +12,7 @@ export class PieceExportRequestedSaga {
     events$.pipe(
       ofType(PieceExportRequested),
       map(
-        (event) =>
-          new SchedulePieceExport(
-            event.exportId,
-            event.componentId,
-            event.resourceId,
-            event.resourceKind,
-            event.piece,
-            event.allPieces,
-          ),
+        (event) => new SchedulePieceExport(event.exportId, event.componentId),
       ),
     );
 }

--- a/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.command.ts
@@ -1,20 +1,11 @@
-import { Command } from '@nestjs-architects/typed-cqrs';
-import {
-  ClonePiece,
-  ComponentId,
-  ResourceId,
-  ResourceKind,
-} from '@marxan/cloning/domain';
 import { ExportId } from '@marxan-api/modules/clone/export/domain';
+import { ComponentId } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class SchedulePieceExport extends Command<void> {
   constructor(
     public readonly exportId: ExportId,
     public readonly componentId: ComponentId,
-    public readonly resourceId: ResourceId,
-    public readonly resourceKind: ResourceKind,
-    public readonly piece: ClonePiece,
-    public readonly allPieces: ClonePiece[],
   ) {
     super();
   }

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.handler.ts
@@ -38,7 +38,7 @@ export class MarkImportAsFinishedHandler
       topic: resourceId,
       data: {
         exportId: importId.value,
-        resourceId: resourceId,
+        resourceId,
         resourceKind,
       },
     });

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-submitted.handler.ts
@@ -38,7 +38,7 @@ export class MarkImportAsSubmittedHandler
       topic: resourceId,
       data: {
         importId: importId.value,
-        resourceId: resourceId,
+        resourceId,
         resourceKind,
       },
     });

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.ts
@@ -63,7 +63,7 @@ export class SchedulePieceImportHandler
       piece,
       importId: importId.value,
       componentId: componentId.value,
-      resourceId: resourceId,
+      resourceId,
       resourceKind,
       uris,
     });
@@ -83,7 +83,7 @@ export class SchedulePieceImportHandler
         piece,
         importId: importId.value,
         componentId: componentId.value,
-        resourceId: resourceId,
+        resourceId,
       },
     });
   }

--- a/api/apps/api/test/cloning/export-piece-failed.saga.e2e-spec.ts
+++ b/api/apps/api/test/cloning/export-piece-failed.saga.e2e-spec.ts
@@ -107,11 +107,7 @@ const getFixtures = async () => {
 
       expect(exportInstance).toBeDefined();
 
-      const {
-        exportPieces,
-        resourceKind,
-        resourceId,
-      } = exportInstance!.toSnapshot();
+      const { exportPieces } = exportInstance!.toSnapshot();
 
       const [failedPiece, ...rest] = exportPieces;
 
@@ -126,13 +122,7 @@ const getFixtures = async () => {
       exportPieceQueue.getJobs.mockResolvedValueOnce(fakePendingJobs);
 
       eventBus.publish(
-        new ExportPieceFailed(
-          exportId,
-          new ComponentId(failedPiece.id),
-          new ResourceId(resourceId),
-          resourceKind,
-          [],
-        ),
+        new ExportPieceFailed(exportId, new ComponentId(failedPiece.id)),
       );
 
       await delay(3000);

--- a/api/apps/api/test/project/request-project-export.e2e-spec.ts
+++ b/api/apps/api/test/project/request-project-export.e2e-spec.ts
@@ -17,6 +17,8 @@ import { ProjectCheckerFake } from '../utils/project-checker.service-fake';
 import { ScenarioChecker } from '../../src/modules/scenarios/scenario-checker/scenario-checker.service';
 import { ScenarioCheckerFake } from '../utils/scenario-checker.service-fake';
 import { GivenScenarioExists } from '../steps/given-scenario-exists';
+import { FakeQueue } from '../utils/queues';
+import { exportPieceQueueToken } from '../../src/modules/clone/infra/export/export-queue.provider';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -121,6 +123,8 @@ export const getFixtures = async () => {
   );
   const fakeProjectChecker = app.get(ProjectChecker) as ProjectCheckerFake;
   const fakeScenarioChecker = app.get(ScenarioChecker) as ScenarioCheckerFake;
+  const exportPieceQueue = app.get<FakeQueue>(exportPieceQueueToken);
+  exportPieceQueue.getJobs.mockResolvedValue([]);
 
   const ownerToken = await GivenUserIsLoggedIn(app, 'aa');
   const contributorToken = await GivenUserIsLoggedIn(app, 'bb');


### PR DESCRIPTION
This PR simplifies several export commands and events:

- `ArchiveReady` event
- `ExportPieceFailed` event
- `PieceExportRequested` event
- `PieceImportRequested` event
- `CancelExportPendingJobs` command
- `MarkExportAsFinished` command
- `MarkExportAsFailed` command
- `MarkExportPiecesAsFailed` command
- `SchedulePieceExport` command