### PR TITLE
MARXAN-1091-lock-expiration-userToken

### DIFF
--- a/api/apps/api/src/migrations/api/1645026803969-AddTokenIdColumnToLocks.ts
+++ b/api/apps/api/src/migrations/api/1645026803969-AddTokenIdColumnToLocks.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTokenIdColumnToLocks1645026803969
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "scenario_locks"
+      ADD COLUMN token_id uuid references issued_authn_tokens(id) ON DELETE CASCADE,
+      DROP CONSTRAINT scenario_locks_pk,
+      ADD CONSTRAINT scenario_locks_pk PRIMARY KEY (scenario_id, user_id, token_id);`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "scenario_locks"
+      DROP COLUMN token_id,
+      DROP CONSTRAINT scenario_locks_pk,
+      ADD CONSTRAINT scenario_locks_pk PRIMARY KEY (scenario_id, user_id);`,
+    );
+  }
+}

--- a/api/apps/api/src/modules/access-control/access-control.module.ts
+++ b/api/apps/api/src/modules/access-control/access-control.module.ts
@@ -15,6 +15,7 @@ import { ScenarioAclController } from './scenarios-acl/scenario-acl.controller';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
 import { ScenarioLockEntity } from './scenarios-acl/locks/entity/scenario.lock.api.entity';
 import { LockService } from './scenarios-acl/locks/lock.service';
+import { IssuedAuthnToken } from '../authentication/issued-authn-token.api.entity';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { LockService } from './scenarios-acl/locks/lock.service';
       UsersScenariosApiEntity,
       PublishedProject,
       ScenarioLockEntity,
+      IssuedAuthnToken,
     ]),
     ProjectAclModule,
     ScenarioAclModule,

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.module.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.module.ts
@@ -11,6 +11,7 @@ import { ProjectsModule } from '@marxan-api/modules/projects/projects.module';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
 import { ScenarioLockEntity } from '@marxan-api/modules/access-control/scenarios-acl/locks/entity/scenario.lock.api.entity';
 import { LockService } from '@marxan-api/modules/access-control/scenarios-acl/locks/lock.service';
+import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { LockService } from '@marxan-api/modules/access-control/scenarios-acl/lo
       UsersProjectsApiEntity,
       PublishedProject,
       ScenarioLockEntity,
+      IssuedAuthnToken,
     ]),
     forwardRef(() => UsersModule),
     forwardRef(() => ProjectsModule),

--- a/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.spec.ts
+++ b/api/apps/api/src/modules/access-control/projects-acl/project-acl.service.spec.ts
@@ -12,6 +12,7 @@ import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dt
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
 import { ScenarioLockEntity } from '@marxan-api/modules/access-control/scenarios-acl/locks/entity/scenario.lock.api.entity';
 import { LockService } from '@marxan-api/modules/access-control/scenarios-acl/locks/lock.service';
+import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -134,6 +135,13 @@ const getFixtures = async () => {
       },
       {
         provide: getRepositoryToken(ScenarioLockEntity),
+        useValue: {
+          find: jest.fn(),
+          findOne: jest.fn(),
+        },
+      },
+      {
+        provide: getRepositoryToken(IssuedAuthnToken),
         useValue: {
           find: jest.fn(),
           findOne: jest.fn(),

--- a/api/apps/api/src/modules/access-control/scenarios-acl/locks/entity/scenario.lock.api.entity.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/locks/entity/scenario.lock.api.entity.ts
@@ -1,3 +1,4 @@
+import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import { User } from '@marxan-api/modules/users/user.api.entity';
 import {
@@ -22,6 +23,12 @@ export class ScenarioLockEntity {
     name: `scenario_id`,
   })
   scenarioId!: string;
+
+  @PrimaryColumn({
+    type: `uuid`,
+    name: `token_id`,
+  })
+  tokenId!: string;
 
   @CreateDateColumn({
     name: 'created_at',
@@ -50,4 +57,14 @@ export class ScenarioLockEntity {
     referencedColumnName: `id`,
   })
   user?: User;
+
+  @ManyToOne(() => IssuedAuthnToken, {
+    onDelete: 'CASCADE',
+    primary: true,
+  })
+  @JoinColumn({
+    name: `token_id`,
+    referencedColumnName: `id`,
+  })
+  token?: IssuedAuthnToken;
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.module.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.module.ts
@@ -9,6 +9,7 @@ import { UsersModule } from '@marxan-api/modules/users/users.module';
 import { ScenariosModule } from '@marxan-api/modules/scenarios/scenarios.module';
 import { LockService } from './locks/lock.service';
 import { ScenarioLockEntity } from './locks/entity/scenario.lock.api.entity';
+import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ScenarioLockEntity } from './locks/entity/scenario.lock.api.entity';
     TypeOrmModule.forFeature([UsersScenariosApiEntity]),
     TypeOrmModule.forFeature([UsersProjectsApiEntity]),
     TypeOrmModule.forFeature([ScenarioLockEntity]),
+    TypeOrmModule.forFeature([IssuedAuthnToken]),
     forwardRef(() => UsersModule),
     forwardRef(() => ScenariosModule),
   ],

--- a/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.spec.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/scenario-acl.service.spec.ts
@@ -11,6 +11,7 @@ import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/proje
 import { ProjectRoles } from '../projects-acl/dto/user-role-project.dto';
 import { LockService } from './locks/lock.service';
 import { ScenarioLockEntity } from './locks/entity/scenario.lock.api.entity';
+import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -87,6 +88,13 @@ const getFixtures = async () => {
       },
       {
         provide: getRepositoryToken(ScenarioLockEntity),
+        useValue: {
+          find: jest.fn(),
+          findOne: jest.fn(),
+        },
+      },
+      {
+        provide: getRepositoryToken(IssuedAuthnToken),
         useValue: {
           find: jest.fn(),
           findOne: jest.fn(),

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -52,6 +52,7 @@ import { UsersScenariosApiEntity } from '@marxan-api/modules/access-control/scen
 import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block-guard.module';
 import { ScenarioLockEntity } from '@marxan-api/modules/access-control/scenarios-acl/locks/entity/scenario.lock.api.entity';
 import { LockService } from '../access-control/scenarios-acl/locks/lock.service';
+import { IssuedAuthnToken } from '../authentication/issued-authn-token.api.entity';
 
 @Module({
   imports: [
@@ -65,6 +66,7 @@ import { LockService } from '../access-control/scenarios-acl/locks/lock.service'
       ScenariosOutputResultsApiEntity,
       UsersScenariosApiEntity,
       ScenarioLockEntity,
+      IssuedAuthnToken,
     ]),
     TypeOrmModule.forFeature(
       [ScenariosPuOutputGeoEntity, ScenariosPlanningUnitGeoEntity],

--- a/api/apps/api/test/projects.e2e-spec.ts
+++ b/api/apps/api/test/projects.e2e-spec.ts
@@ -140,7 +140,7 @@ describe('ProjectsModule (e2e)', () => {
       const jsonAPIResponse: ProjectResultPlural = response.body;
 
       expect(jsonAPIResponse.data[0].type).toBe('projects');
-      expect(jsonAPIResponse.data).toHaveLength(5);
+      expect(jsonAPIResponse.data).toHaveLength(4);
 
       const projectNames: string[] = jsonAPIResponse.data.map(
         (p) => p.attributes.name,
@@ -203,7 +203,7 @@ describe('ProjectsModule (e2e)', () => {
       const jsonAPIResponse: ProjectResultPlural = response.body;
 
       expect(jsonAPIResponse.data[0].type).toBe('projects');
-      expect(jsonAPIResponse.data).toHaveLength(5);
+      expect(jsonAPIResponse.data).toHaveLength(4);
 
       const projectNames: string[] = jsonAPIResponse.data.map(
         (p) => p.attributes.name,

--- a/api/apps/api/test/projects.e2e-spec.ts
+++ b/api/apps/api/test/projects.e2e-spec.ts
@@ -140,7 +140,7 @@ describe('ProjectsModule (e2e)', () => {
       const jsonAPIResponse: ProjectResultPlural = response.body;
 
       expect(jsonAPIResponse.data[0].type).toBe('projects');
-      expect(jsonAPIResponse.data).toHaveLength(4);
+      expect(jsonAPIResponse.data).toHaveLength(5);
 
       const projectNames: string[] = jsonAPIResponse.data.map(
         (p) => p.attributes.name,
@@ -203,7 +203,7 @@ describe('ProjectsModule (e2e)', () => {
       const jsonAPIResponse: ProjectResultPlural = response.body;
 
       expect(jsonAPIResponse.data[0].type).toBe('projects');
-      expect(jsonAPIResponse.data).toHaveLength(4);
+      expect(jsonAPIResponse.data).toHaveLength(5);
 
       const projectNames: string[] = jsonAPIResponse.data.map(
         (p) => p.attributes.name,

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -294,22 +294,27 @@ test('Updates scenario correctly as lock is in place by same user', async () => 
   fixtures.ThenScenarioIsUpdated(response);
 });
 
-// test('A lock is deleted after user token has expired', async () => {
-//   const ownerUserId = await fixtures.GivenOwnerExists();
-//   const scenarioId = await fixtures.GivenScenarioWasCreated();
-//   await fixtures.GivenContributorWasAddedToScenario();
-//   let response = await fixtures.WhenAcquiringLockForScenarioAsOwner();
-//   fixtures.ThenScenarioLockInfoForOwnerIsReturned(response);
+test('A lock is deleted after user token has expired', async () => {
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+  const ownerOfLockUserId = await fixtures.GivenUserWasAddedToScenario();
 
-//   await fixtures.GivenUserTokenHasExpired(ownerUserId);
+  const ownerOfLockUserToken = await fixtures.GivenUserIsLoggedIn('random');
+  
+  const GivenUserAcquiredLockForScenario = await fixtures.WhenAcquiringLockForScenario(
+    scenarioId,
+    ownerOfLockUserToken,
+  );
+  await fixtures.GivenUserTokenHasExpired(ownerOfLockUserId);
 
-//   const differentUserToken = await fixtures.GivenUserIsLoggedIn('contributor');
-//   response = await fixtures.WhenGettingLockFromScenario(
-//     scenarioId,
-//     differentUserToken,
-//   );
-//   fixtures.ThenNoScenarioLockIsReturned(response);
-// });
+  const ownerOfScenarioButNotLockToken = await fixtures.GivenUserIsLoggedIn(
+    'owner',
+  );
+  const response = await fixtures.WhenGettingLockFromScenario(
+    scenarioId,
+    ownerOfScenarioButNotLockToken,
+  );
+  fixtures.ThenNoScenarioLockIsReturned(response);
+});
 
 test('Releases scenario lock correctly', async () => {
   await fixtures.GivenScenarioWasCreated();

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -294,6 +294,23 @@ test('Updates scenario correctly as lock is in place by same user', async () => 
   fixtures.ThenScenarioIsUpdated(response);
 });
 
+// test('A lock is deleted after user token has expired', async () => {
+//   const ownerUserId = await fixtures.GivenOwnerExists();
+//   const scenarioId = await fixtures.GivenScenarioWasCreated();
+//   await fixtures.GivenContributorWasAddedToScenario();
+//   let response = await fixtures.WhenAcquiringLockForScenarioAsOwner();
+//   fixtures.ThenScenarioLockInfoForOwnerIsReturned(response);
+
+//   await fixtures.GivenUserTokenHasExpired(ownerUserId);
+
+//   const differentUserToken = await fixtures.GivenUserIsLoggedIn('contributor');
+//   response = await fixtures.WhenGettingLockFromScenario(
+//     scenarioId,
+//     differentUserToken,
+//   );
+//   fixtures.ThenNoScenarioLockIsReturned(response);
+// });
+
 test('Releases scenario lock correctly', async () => {
   await fixtures.GivenScenarioWasCreated();
   const ownerToken = await fixtures.GivenUserIsLoggedIn('owner');
@@ -340,17 +357,4 @@ test('Fails to release scenario lock as it is not owned by the same user and thi
 
   response = await fixtures.WhenReleasingLockForScenario(randomUserToken);
   fixtures.ThenScenarioIsLockedByAnotherUserIsReturned(response);
-});
-
-test('A lock is deleted after user token has expired', async () => {
-  const ownerUserId = await fixtures.GivenOwnerExists();
-  const ownerToken = await fixtures.GivenUserIsLoggedIn('owner');
-  const scenarioId = await fixtures.GivenScenarioWasCreated();
-  let response = await fixtures.WhenAcquiringLockForScenarioAsOwner();
-  fixtures.ThenScenarioLockInfoForOwnerIsReturned(response);
-
-  await fixtures.GivenUserTokenHasExpired(ownerUserId);
-
-  response = await fixtures.WhenGettingLockFromScenario(scenarioId, ownerToken);
-  fixtures.ThenNoScenarioLockIsReturned(response);
 });

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -341,3 +341,16 @@ test('Fails to release scenario lock as it is not owned by the same user and thi
   response = await fixtures.WhenReleasingLockForScenario(randomUserToken);
   fixtures.ThenScenarioIsLockedByAnotherUserIsReturned(response);
 });
+
+test('A lock is deleted after user token has expired', async () => {
+  const ownerUserId = await fixtures.GivenOwnerExists();
+  const ownerToken = await fixtures.GivenUserIsLoggedIn('owner');
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+  let response = await fixtures.WhenAcquiringLockForScenarioAsOwner();
+  fixtures.ThenScenarioLockInfoForOwnerIsReturned(response);
+
+  await fixtures.GivenUserTokenHasExpired(ownerUserId);
+
+  response = await fixtures.WhenGettingLockFromScenario(scenarioId, ownerToken);
+  fixtures.ThenNoScenarioLockIsReturned(response);
+});

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
@@ -16,6 +16,7 @@ import { ProjectsTestUtils } from '../utils/projects.test.utils';
 import { User } from '@marxan-api/modules/users/user.api.entity';
 import { ScenarioLockDto } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
 import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
+import { assertDefined } from '@marxan/utils';
 
 export async function getFixtures() {
   const app = await bootstrapApplication();
@@ -27,6 +28,8 @@ export async function getFixtures() {
   const viewerUserId = await GivenUserExists(app, 'cc');
 
   const randomUserInfo = await GivenUserIsCreated(app);
+  assertDefined(randomUserInfo.user.id);
+  const randomUserId = randomUserInfo.user.id;
   const scenarioContributorRole = ScenarioRoles.scenario_contributor;
   const scenarioViewerRole = ScenarioRoles.scenario_viewer;
 
@@ -183,6 +186,7 @@ export async function getFixtures() {
         await usersRepo.delete({ id: randomUserInfo.user.id });
         return;
       });
+      return randomUserId;
     },
     GivenUserTokenHasExpired: async (userId: string) => {
       await tokenRepo.delete({ userId });

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.fixtures.ts
@@ -15,6 +15,7 @@ import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dt
 import { ProjectsTestUtils } from '../utils/projects.test.utils';
 import { User } from '@marxan-api/modules/users/user.api.entity';
 import { ScenarioLockDto } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
+import { IssuedAuthnToken } from '@marxan-api/modules/authentication/issued-authn-token.api.entity';
 
 export async function getFixtures() {
   const app = await bootstrapApplication();
@@ -42,6 +43,9 @@ export async function getFixtures() {
     getRepositoryToken(UsersProjectsApiEntity),
   );
   const usersRepo: Repository<User> = app.get(getRepositoryToken(User));
+  const tokenRepo: Repository<IssuedAuthnToken> = app.get(
+    getRepositoryToken(IssuedAuthnToken),
+  );
 
   const cleanups: (() => Promise<void>)[] = [];
 
@@ -179,6 +183,9 @@ export async function getFixtures() {
         await usersRepo.delete({ id: randomUserInfo.user.id });
         return;
       });
+    },
+    GivenUserTokenHasExpired: async (userId: string) => {
+      await tokenRepo.delete({ userId });
     },
 
     WhenAcquiringLockForScenario: async (scenarioId: string, token: string) =>


### PR DESCRIPTION
-Adds migration to add a `token_id` column for  `lock` entity.
-Assigns expiration to lock based on expiration of token (on a ON CASCADE DELETE relationship between entities)
-Adds tests to check that lock is effectively removed when user token expires.