### PR TITLE
forcibly release all locks active at the time of migration [MARXAN-1091]

### DIFF
--- a/api/apps/api/src/migrations/api/1645026803969-AddTokenIdColumnToLocks.ts
+++ b/api/apps/api/src/migrations/api/1645026803969-AddTokenIdColumnToLocks.ts
@@ -4,7 +4,15 @@ export class AddTokenIdColumnToLocks1645026803969
   implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "scenario_locks"
+      `
+      -- forcibly remove all locks first in order to avoid possible constraint
+      -- violations when setting up a FK at the next step.
+      -- Sorry, active users! but there shouldn't really be any of you (active)
+      -- by the time this migration runs - at least there's no production
+      -- environment yet 😇).
+      DELETE FROM scenario_locks;
+      -- then go ahead with the actual core of the migration
+      ALTER TABLE "scenario_locks"
       ADD COLUMN token_id uuid references issued_authn_tokens(id) ON DELETE CASCADE,
       DROP CONSTRAINT scenario_locks_pk,
       ADD CONSTRAINT scenario_locks_pk PRIMARY KEY (scenario_id, user_id, token_id);`,

--- a/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
+++ b/api/apps/api/test/scenario-locks/project-scenario-locks.e2e-spec.ts
@@ -299,7 +299,7 @@ test('A lock is deleted after user token has expired', async () => {
   const ownerOfLockUserId = await fixtures.GivenUserWasAddedToScenario();
 
   const ownerOfLockUserToken = await fixtures.GivenUserIsLoggedIn('random');
-  
+
   const GivenUserAcquiredLockForScenario = await fixtures.WhenAcquiringLockForScenario(
     scenarioId,
     ownerOfLockUserToken,


### PR DESCRIPTION
This is so we don't risk running into a constraint violation when adding a FK reference later in the migration.

There should really be no "active" users by the time this migration runs, as there is no production environment yet, and LOFU should help the few developers and test users to keep their sessions running smoothly nevertheless.

I am not sure how wise it is to use an Unicode emoji in a PostgreSQL comment, but apparently we'll be fine with this 😇.
