### PR TITLE
MARXAN-1020-platformAdmins

### DIFF
--- a/api/apps/api/src/migrations/api/1645440886194-PlatformAdmins.ts
+++ b/api/apps/api/src/migrations/api/1645440886194-PlatformAdmins.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PlatformAdmins1645440886194 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE platform_admins (
+        user_id uuid not null references users(id) ON UPDATE CASCADE ON DELETE CASCADE,
+        PRIMARY KEY(user_id)
+      );`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE platform_admins;`);
+  }
+}

--- a/api/apps/api/src/modules/users/platform-admin/admin.api.entity.ts
+++ b/api/apps/api/src/modules/users/platform-admin/admin.api.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
+import { User } from '@marxan-api/modules/users/user.api.entity';
+import { BaseServiceResource } from '@marxan-api/types/resource.interface';
+
+export const platformAdminResource: BaseServiceResource = {
+  className: 'Platform_admin',
+  name: {
+    singular: 'platform_admin',
+    plural: 'platform_admins',
+  },
+  entitiesAllowedAsIncludes: ['users'],
+};
+
+@Entity(`platform_admins`)
+export class PlatformAdminEntity {
+  @PrimaryColumn({
+    type: `uuid`,
+    name: `user_id`,
+  })
+  userId!: string;
+
+  @OneToOne(() => User, {
+    onDelete: 'CASCADE',
+    primary: true,
+  })
+  @JoinColumn({
+    name: `user_id`,
+    referencedColumnName: `id`,
+  })
+  user?: User;
+}

--- a/api/apps/api/src/modules/users/users.controller.ts
+++ b/api/apps/api/src/modules/users/users.controller.ts
@@ -177,7 +177,7 @@ export class UsersController {
     @Request() req: RequestWithAuthenticatedUser,
     @Param('id', ParseUUIDPipe) userIdToDelete: string,
   ): Promise<void> {
-    const result = await this.service.addAdmin(req.user.id, userIdToDelete);
+    const result = await this.service.deleteAdmin(req.user.id, userIdToDelete);
     if (isLeft(result)) {
       throw new ForbiddenException();
     }

--- a/api/apps/api/src/modules/users/users.module.ts
+++ b/api/apps/api/src/modules/users/users.module.ts
@@ -5,10 +5,11 @@ import { UsersController } from './users.controller';
 import { User } from './user.api.entity';
 import { UsersService } from './users.service';
 import { AuthenticationModule } from '@marxan-api/modules/authentication/authentication.module';
+import { PlatformAdminEntity } from './platform-admin/admin.api.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([User, PlatformAdminEntity]),
     forwardRef(() => AuthenticationModule),
   ],
   providers: [UsersService],

--- a/api/apps/api/test/fixtures/test-data.sql
+++ b/api/apps/api/test/fixtures/test-data.sql
@@ -45,3 +45,8 @@ VALUES
 ((SELECT id FROM users WHERE lower(email) = 'aa@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 2 Project 2 Org 2'), 'scenario_owner'),
 ((SELECT id FROM users WHERE lower(email) = 'bb@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 2 Project 2 Org 2'), 'scenario_contributor'),
 ((SELECT id FROM users WHERE lower(email) = 'cc@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 2 Project 2 Org 2'), 'scenario_viewer');
+
+INSERT INTO platform_admins
+(user_id)
+VALUES
+((SELECT id FROM users WHERE lower(email) = 'dd@example.com'));

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -30,21 +30,9 @@ afterEach(async () => {
 });
 
 describe('ScenariosModule (e2e)', () => {
-  // beforeEach(async () => {
-  //   const response = await request(app.getHttpServer())
-  //     .get('/api/v1/projects')
-  //     .set('Authorization', `Bearer ${ownerToken}`)
-  //     .expect(200);
-  //   projects = response.body.data;
-  // });
-
   afterEach(async () => {
     await fixtures.cleanup();
   });
-
-  // it('Gets projects', async () => {
-  //   expect(projects[0].type).toBe('projects');
-  // });
 
   it('Creating a scenario with incomplete data should fail', async () => {
     const response = await fixtures.WhenCreatingAScenarioWithIncompleteData();


### PR DESCRIPTION
-Adds migration to introduce platform admins table.
-Adds Endpoints to get, create and delete admins.
-Adds tests for admins, refactors user-e2e-tests to fit GWT pattern.