### PR TITLE
fire scenario.planningAreaProtectedCalculation.submitted much earlier [MARXAN-1316]

### DIFF
--- a/api/apps/api/src/modules/planning-units-protection-level/calculate-planning-units-protection-level.handler.ts
+++ b/api/apps/api/src/modules/planning-units-protection-level/calculate-planning-units-protection-level.handler.ts
@@ -5,6 +5,7 @@ import {
 } from './calculate-planning-units-protection-level.command';
 import { QueueService } from '../queue/queue.service';
 import { ApiEventsService } from '../api-events/api-events.service';
+import { Logger } from '@nestjs/common';
 
 @CommandHandler(CalculatePlanningUnitsProtectionLevel)
 export class CalculatePlanningUnitsProtectionLevelHandler
@@ -29,6 +30,6 @@ export class CalculatePlanningUnitsProtectionLevelHandler
   }
 
   onCompleted({ jobId }: { jobId: string }) {
-    console.log(`--- job ${jobId} completed`);
+    Logger.log(`--- job ${jobId} completed`);
   }
 }

--- a/api/apps/api/src/modules/planning-units-protection-level/calculate-planning-units-protection-level.handler.ts
+++ b/api/apps/api/src/modules/planning-units-protection-level/calculate-planning-units-protection-level.handler.ts
@@ -1,5 +1,4 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { API_EVENT_KINDS } from '@marxan/api-events';
 import {
   CalculatePlanningUnitsProtectionLevelResult,
   CalculatePlanningUnitsProtectionLevel,
@@ -20,11 +19,6 @@ export class CalculatePlanningUnitsProtectionLevelHandler
   async execute(
     command: CalculatePlanningUnitsProtectionLevel,
   ): Promise<CalculatePlanningUnitsProtectionLevelResult> {
-    await this.events.create({
-      kind:
-        API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__submitted__v1__alpha1,
-      topic: command.scenarioId,
-    });
     await this.queueService.queue.add(
       `calculate-planning-units-protection-level-${command.scenarioId}`,
       command,

--- a/api/apps/api/src/modules/scenarios/protected-area/selection/selection-change.module.ts
+++ b/api/apps/api/src/modules/scenarios/protected-area/selection/selection-change.module.ts
@@ -13,6 +13,7 @@ import { SelectionGetterModule } from '../getter/selection-getter.module';
 import { SelectionUpdateService } from './selection-update.service';
 import { SelectionChangedSaga } from './selection-changed.saga';
 import { UpdatePlanningUnitsHandler } from './update-planning-units.handler';
+import { ApiEventsModule } from '@marxan-api/modules/api-events';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { UpdatePlanningUnitsHandler } from './update-planning-units.handler';
     ProtectionStatusModule.for(DbConnections.geoprocessingDB),
     PlanningAreasModule,
     SelectionGetterModule,
+    ApiEventsModule,
   ],
   providers: [
     SelectionUpdateService,

--- a/api/apps/api/src/modules/scenarios/protected-area/selection/selection-update.service.integration.spec.ts
+++ b/api/apps/api/src/modules/scenarios/protected-area/selection/selection-update.service.integration.spec.ts
@@ -29,6 +29,7 @@ import { SelectionGetService } from '../getter/selection-get.service';
 import { SelectionUpdateService } from './selection-update.service';
 import { UpdatePlanningUnitsHandler } from './update-planning-units.handler';
 import { SelectionChangedSaga } from './selection-changed.saga';
+import { ApiEventsService } from '@marxan-api/modules/api-events';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -76,6 +77,12 @@ const getFixtures = async () => {
         provide: scenarioRepoToken,
         useClass: ScenarioRepo,
       },
+      {
+        provide: ApiEventsService,
+        useValue: {
+          create: jest.fn()
+        }
+      }
     ],
   }).compile();
 

--- a/api/apps/api/src/modules/scenarios/protected-area/selection/selection-update.service.ts
+++ b/api/apps/api/src/modules/scenarios/protected-area/selection/selection-update.service.ts
@@ -2,7 +2,7 @@ import { Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EventBus } from '@nestjs/cqrs';
-import { Either, right } from 'fp-ts/Either';
+import { Either, left, right } from 'fp-ts/Either';
 
 import { ProjectSnapshot } from '@marxan/projects';
 
@@ -13,6 +13,8 @@ import { SelectProtectedArea } from '../select-protected-area';
 import { ProtectedAreaKind } from '../protected-area.kind';
 import { ProtectedAreaUnlinked } from '../protected-area-unlinked';
 import { SelectionChangedEvent } from './selection-changed.event';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { ApiEventsService } from '@marxan-api/modules/api-events';
 
 export const invalidProtectedAreaId = Symbol(`invalid protected area id`);
 export type ChangeProtectedAreasError = typeof invalidProtectedAreaId;
@@ -24,6 +26,7 @@ export class SelectionUpdateService {
     @InjectRepository(Scenario)
     protected readonly scenarios: Repository<Scenario>,
     private readonly events: EventBus,
+    private readonly apiEvents: ApiEventsService,
   ) {}
 
   async selectFor(
@@ -96,6 +99,36 @@ export class SelectionUpdateService {
     );
 
     if (idsToAdd.length > 0 || idsToRemove.length > 0) {
+      /**
+       * We did originally fire the event below in
+       * `CalculatePlanningUnitsProtectionLevelHandler.execute()`, however this
+       * would be *after* some potentially expensive SQL queries had been run in
+       * `ScenarioPlanningUnitsProtectedStatusCalculatorService.calculatedProtectionStatusForPlanningUnitsIn()`,
+       * which would lead is some cases to a very long delay between the time an
+       * API user submits a request for `POST
+       * /api/scenarios/:id/protected-areas` and the time a
+       * `scenario.planningAreaProtectedCalculation.submitted/v1/alpha` event
+       * shows up in the scenario status data.
+       *
+       * However, as we're moving the firing of this event across a couple of
+       * cqrs event boundaries, I am less confident that we would consistently
+       * fire a `finished` or `failed` event paired with this `submitted` one in
+       * case of any unexpected errors. So, long story short, if something
+       * starts breaking horribly in how we deal with these
+       * `planningAreaProtectedCalculation` events, we should reassess this:
+       * probably keeping the event firing here, but adding more appropriately
+       * robust error handling, if needed.
+       */
+      try {
+        await this.apiEvents.create({
+          kind:
+            API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__submitted__v1__alpha1,
+          topic: scenario.id,
+        });
+      } catch (error: unknown) {
+        return left(invalidProtectedAreaId);
+      }
+
       this.events.publish(
         new SelectionChangedEvent(scenario.id, scenario.threshold, idsToAdd),
       );


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1316

We did originally fire the event changed in this PR in `CalculatePlanningUnitsProtectionLevelHandler.execute()`, however this would be *after* some potentially expensive SQL queries had been run in `ScenarioPlanningUnitsProtectedStatusCalculatorService.calculatedProtectionStatusForPlanningUnitsIn()`,
which would lead is some cases to a very long delay between the time an API user submits a request for `POST /api/scenarios/:id/protected-areas` and the time a `scenario.planningAreaProtectedCalculation.submitted/v1/alpha` event shows up in the scenario status data.

However, as we're moving the firing of this event across a couple of cqrs event boundaries, I am less confident that we would consistently fire a `finished` or `failed` event paired with this `submitted` one in case of any unexpected errors. So, long story short, if something starts breaking horribly in how we deal with these `planningAreaProtectedCalculation` events, we should reassess this: probably keeping the event firing here, but adding more appropriately robust error handling, if needed.
