### PR TITLE
remove nonsense COPY from Dockerfile

### DIFF
--- a/webshot/Dockerfile
+++ b/webshot/Dockerfile
@@ -35,8 +35,6 @@ COPY --chown=$USER:$USER tsconfig.json tsconfig.build.json nodemon.json ./
 
 RUN yarn prestart:prod
 
-COPY --chown=$USER:$USER dist ./dist
-
 EXPOSE 3000
 USER $USER
 


### PR DESCRIPTION
`dist` is generated while building the Docker image, definitely not carried over from the build context (where it is, alas, gitignored), so `COPY`ing is nonsense. Apologies.
