### PR TITLE
feat: add version check to export config validation process

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
@@ -2,7 +2,10 @@ import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
-import { ProjectExportConfigContent } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
+import {
+  exportVersion,
+  ProjectExportConfigContent,
+} from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
 import { FileRepository } from '@marxan/files-repository';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
@@ -49,7 +52,7 @@ export class ExportConfigProjectPieceExporter implements ExportPieceProcessor {
     );
 
     const fileContent: ProjectExportConfigContent = {
-      version: `0.1.0`,
+      version: exportVersion,
       scenarios,
       name: project.name,
       description: project.description,

--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
@@ -2,7 +2,10 @@ import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
-import { ScenarioExportConfigContent } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
+import {
+  exportVersion,
+  ScenarioExportConfigContent,
+} from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
 import { FileRepository } from '@marxan/files-repository';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
@@ -44,7 +47,7 @@ export class ExportConfigScenarioPieceExporter implements ExportPieceProcessor {
     }
 
     const fileContent: ScenarioExportConfigContent = {
-      version: `0.1.0`,
+      version: exportVersion,
       name: scenario.name,
       description: scenario.description,
       projectId: scenario.project_id,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/export-config.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/export-config.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { Type } from 'class-transformer';
 import {
+  Equals,
   IsArray,
   IsEnum,
   IsOptional,
@@ -11,8 +12,11 @@ import {
 import { ClonePiece } from '../../domain/clone-piece';
 import { ResourceKind } from '../../domain/resource.kind';
 
+export const exportVersion = '0.1.0';
+
 class CommonFields {
   @IsString()
+  @Equals(exportVersion)
   version!: string;
 
   @IsEnum(ResourceKind)


### PR DESCRIPTION
This PR adds new check within the validation process of the export config file. Now the version of the export saved inside the exported config file must equal the version of the system 