### PR TITLE
fix(front): consistent number formatting[MARXAN-1324]

### DIFF
--- a/app/components/gap-analysis/item/component.tsx
+++ b/app/components/gap-analysis/item/component.tsx
@@ -1,7 +1,7 @@
 import React, { MouseEventHandler } from 'react';
 
-import { useNumberFormatter } from '@react-aria/i18n';
 import classnames from 'classnames';
+import { format } from 'd3';
 
 import Icon from 'components/icon';
 
@@ -32,8 +32,6 @@ export interface ItemProps {
 export const Item: React.FC<ItemProps> = ({
   name, current, target, className, highlighted, muted, onMouseEnter, onMouseLeave, onHighlight,
 }: ItemProps) => {
-  const percentFormatter = useNumberFormatter({ style: 'percent' });
-
   return (
     <div
       className={classnames({
@@ -63,7 +61,7 @@ export const Item: React.FC<ItemProps> = ({
           <span className="text-sm">
             Current:
             {' '}
-            {percentFormatter.format(current.percent)}
+            {format('.2~%')(current.percent)}
             {' '}
             (
             {current.value}
@@ -77,7 +75,7 @@ export const Item: React.FC<ItemProps> = ({
           <span className="text-sm">
             Target:
             {' '}
-            {percentFormatter.format(target.percent)}
+            {format('.2~%')(target.percent)}
             {' '}
             (
             {target.value}

--- a/app/components/map/legend/item/component.tsx
+++ b/app/components/map/legend/item/component.tsx
@@ -3,8 +3,8 @@ import React, {
   useState,
 } from 'react';
 
-import { useNumberFormatter } from '@react-aria/i18n';
 import cx from 'classnames';
+import { dotFormat } from 'utils/units';
 
 import Slider from 'components/forms/slider';
 import Icon from 'components/icon';
@@ -62,10 +62,6 @@ export const LegendItem: React.FC<LegendItemProps> = ({
 
   const { opacity = 1, visibility = true } = settings || {};
 
-  const { format } = useNumberFormatter({
-    style: 'percent',
-  });
-
   return (
     <div
       key={id}
@@ -115,7 +111,7 @@ export const LegendItem: React.FC<LegendItemProps> = ({
                   className="p-2 text-gray-500 bg-white rounded"
                 >
                   Opacity (
-                  {format(opacity)}
+                  {dotFormat(opacity)}
                   )
                 </div>
               )}

--- a/app/components/map/legend/types/gradient/component.tsx
+++ b/app/components/map/legend/types/gradient/component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { useNumberFormatter } from '@react-aria/i18n';
 import cx from 'classnames';
+import { dotFormat } from 'utils/units';
 
 export interface LegendTypeGradientProps {
   className?: {
@@ -19,10 +19,6 @@ export const LegendTypeGradient: React.FC<LegendTypeGradientProps> = ({
   className,
   items,
 }: LegendTypeGradientProps) => {
-  const { format } = useNumberFormatter({
-    style: 'decimal',
-  });
-
   return (
     <div
       className={cx({
@@ -50,7 +46,7 @@ export const LegendTypeGradient: React.FC<LegendTypeGradientProps> = ({
                 [className.labels]: className.labels,
               })}
             >
-              {format(+parseInt(value, 10))}
+              {dotFormat(value)}
             </li>
           ))}
       </ul>

--- a/app/components/projects/published-item/component.tsx
+++ b/app/components/projects/published-item/component.tsx
@@ -48,7 +48,7 @@ export const PublishedItem: React.FC<PublishedItemProps> = ({
       </td>
       <td className="">
         <div className="flex flex-row justify-between pl-10">
-          <p className="w-6 text-sm">{timesDuplicated && (format('.3s')(timesDuplicated))}</p>
+          <p className="w-6 text-sm">{timesDuplicated && (format('~s')(timesDuplicated))}</p>
           <ComingSoon theme="dark">
             <DuplicateButton
               id={id}

--- a/app/components/table/component.tsx
+++ b/app/components/table/component.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
+import { useNumberFormatter } from '@react-aria/i18n';
 import cx from 'classnames';
 
 import Icon from 'components/icon';
@@ -53,6 +54,10 @@ export const Table: React.FC<TableProps> = ({
   useEffect(() => {
     setSortedBody(body);
   }, [body]);
+
+  const { format } = useNumberFormatter({
+    style: 'decimal',
+  });
 
   return (
     <table
@@ -129,7 +134,7 @@ export const Table: React.FC<TableProps> = ({
                       {/* Cell is a function */}
                       {CellIsFunction && Cell(value, rowData)}
 
-                      {!Cell && value}
+                      {!Cell && format(value)}
                     </td>
                   );
                 })

--- a/app/components/table/component.tsx
+++ b/app/components/table/component.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
-import { useNumberFormatter } from '@react-aria/i18n';
 import cx from 'classnames';
+import { dotFormat } from 'utils/units';
 
 import Icon from 'components/icon';
 
@@ -54,10 +54,6 @@ export const Table: React.FC<TableProps> = ({
   useEffect(() => {
     setSortedBody(body);
   }, [body]);
-
-  const { format } = useNumberFormatter({
-    style: 'decimal',
-  });
 
   return (
     <table
@@ -134,7 +130,7 @@ export const Table: React.FC<TableProps> = ({
                       {/* Cell is a function */}
                       {CellIsFunction && Cell(value, rowData)}
 
-                      {!Cell && format(value)}
+                      {!Cell && dotFormat(value)}
                     </td>
                   );
                 })

--- a/app/layout/community/published-projects/detail/component.tsx
+++ b/app/layout/community/published-projects/detail/component.tsx
@@ -88,7 +88,7 @@ export const CommunityProjectsDetail: React.FC<CommunityProjectsDetailProps> = (
                     {timesDuplicated && (
                       <p className="ml-5 text-sm">
                         Duplicated
-                        {format('.3s')(timesDuplicated)}
+                        {format('~s')(timesDuplicated)}
                         {' '}
                         times
                       </p>

--- a/app/layout/projects/new/form/planning-area-selector/planning-unit-area-size/component.tsx
+++ b/app/layout/projects/new/form/planning-area-selector/planning-unit-area-size/component.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { useNumberFormatter } from '@react-aria/i18n';
+import { dotFormat } from 'utils/units';
 
 import Input from 'components/forms/input';
 import Label from 'components/forms/label';
@@ -28,10 +28,6 @@ export const PlanningUnitAreaSize: React.FC<PlanningUnitAreaSizeProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [minPuAreaSize]);
-
-  const { format } = useNumberFormatter({
-    style: 'decimal',
-  });
 
   return (
     <div>
@@ -87,7 +83,7 @@ export const PlanningUnitAreaSize: React.FC<PlanningUnitAreaSizeProps> = ({
       </div>
 
       {minPuAreaSize && maxPuAreaSize && (
-        <p className="mt-2 text-xs opacity-50">{`Going below ${format(minPuAreaSize)} km2 could cause performance issues`}</p>
+        <p className="mt-2 text-xs opacity-50">{`Going below ${dotFormat(minPuAreaSize)} km2 could cause performance issues`}</p>
       )}
     </div>
   );

--- a/app/layout/solutions/selected/component.tsx
+++ b/app/layout/solutions/selected/component.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useNumberFormatter } from '@react-aria/i18n';
+
 import Icon from 'components/icon';
 
 import HIDE_SVG from 'svgs/ui/hide.svg?sprite';
@@ -28,6 +30,10 @@ export const SelectedSolution: React.FC<SelectedSolutionProps> = ({
     runId, scoreValue, costValue, missingValues, planningUnits,
   } = values;
   const { visibility = true } = settings || {};
+
+  const { format } = useNumberFormatter({
+    style: 'decimal',
+  });
 
   return (
     <div className="w-full">
@@ -60,19 +66,19 @@ export const SelectedSolution: React.FC<SelectedSolutionProps> = ({
       <div className="grid grid-cols-2 pt-5 pl-1 pr-32 text-sm text-white gap-y-6 gap-x-5">
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Score:</p>
-          <p className="w-20 font-semibold text-left">{scoreValue}</p>
+          <p className="w-20 font-semibold text-left">{format(scoreValue)}</p>
         </div>
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Cost:</p>
-          <p className="w-20 font-semibold text-left">{costValue}</p>
+          <p className="w-20 font-semibold text-left">{format(costValue)}</p>
         </div>
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Missing:</p>
-          <p className="w-20 font-semibold text-left">{missingValues}</p>
+          <p className="w-20 font-semibold text-left">{format(missingValues)}</p>
         </div>
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Planning:</p>
-          <p className="w-20 font-semibold text-left">{planningUnits}</p>
+          <p className="w-20 font-semibold text-left">{format(planningUnits)}</p>
         </div>
       </div>
     </div>

--- a/app/layout/solutions/selected/component.tsx
+++ b/app/layout/solutions/selected/component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useNumberFormatter } from '@react-aria/i18n';
+import { dotFormat } from 'utils/units';
 
 import Icon from 'components/icon';
 
@@ -30,10 +30,6 @@ export const SelectedSolution: React.FC<SelectedSolutionProps> = ({
     runId, scoreValue, costValue, missingValues, planningUnits,
   } = values;
   const { visibility = true } = settings || {};
-
-  const { format } = useNumberFormatter({
-    style: 'decimal',
-  });
 
   return (
     <div className="w-full">
@@ -66,19 +62,19 @@ export const SelectedSolution: React.FC<SelectedSolutionProps> = ({
       <div className="grid grid-cols-2 pt-5 pl-1 pr-32 text-sm text-white gap-y-6 gap-x-5">
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Score:</p>
-          <p className="w-20 font-semibold text-left">{format(scoreValue)}</p>
+          <p className="w-20 font-semibold text-left">{dotFormat(scoreValue)}</p>
         </div>
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Cost:</p>
-          <p className="w-20 font-semibold text-left">{format(costValue)}</p>
+          <p className="w-20 font-semibold text-left">{dotFormat(costValue)}</p>
         </div>
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Missing:</p>
-          <p className="w-20 font-semibold text-left">{format(missingValues)}</p>
+          <p className="w-20 font-semibold text-left">{dotFormat(missingValues)}</p>
         </div>
         <div className="flex pl-1.5 text-white border-l-2 border-blue-700 justify-between">
           <p>Planning:</p>
-          <p className="w-20 font-semibold text-left">{format(planningUnits)}</p>
+          <p className="w-20 font-semibold text-left">{dotFormat(planningUnits)}</p>
         </div>
       </div>
     </div>

--- a/app/utils/units.ts
+++ b/app/utils/units.ts
@@ -1,7 +1,15 @@
+import { format } from 'd3';
+
 /**
  * @param bytes Bytes to convert to Megabytes.
  * @returns Megabytes
  */
 export const bytesToMegabytes = (bytes: number): number => {
   return bytes / 1048576;
+};
+
+export const dotFormat = (num) => {
+  const commaFormat = format(',');
+  // The expression /,/g is a regular expression that matches all commas.
+  return commaFormat(num).replace(/,/g, '.');
 };


### PR DESCRIPTION
## Consistent number formatting

### Overview

We have left `d3` to format the numbers and removed `@react-aria/i18n` to have consistancy.
Slider requires the use of `@react-aria/i18n`: [React Aria useSlider Documentations](https://react-spectrum.adobe.com/react-aria/useSlider.html)

### Feature relevant tickets

[MARXAN-1324](https://vizzuality.atlassian.net/browse/MARXAN-1324)

