### PR TITLE
feat: add logger error messages to piece exporters

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
@@ -4,7 +4,7 @@ import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { ProjectExportConfigContent } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
 import { FileRepository } from '@marxan/files-repository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
 import { Readable } from 'stream';
@@ -21,7 +21,10 @@ export class ExportConfigProjectPieceExporter implements ExportPieceProcessor {
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly entityManager: EntityManager,
-  ) {}
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ExportConfigProjectPieceExporter.name);
+  }
 
   isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
     return piece === ClonePiece.ExportConfig && kind === ResourceKind.Project;
@@ -37,7 +40,9 @@ export class ExportConfigProjectPieceExporter implements ExportPieceProcessor {
     );
 
     if (!project) {
-      throw new Error(`Project with ID ${input.resourceId} not found`);
+      const errorMessage = `Project with ID ${input.resourceId} not found`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const scenarios: {
@@ -64,9 +69,9 @@ export class ExportConfigProjectPieceExporter implements ExportPieceProcessor {
     );
 
     if (isLeft(outputFile)) {
-      throw new Error(
-        `${ExportConfigProjectPieceExporter.name} - Project - couldn't save file - ${outputFile.left.description}`,
-      );
+      const errorMessage = `${ExportConfigProjectPieceExporter.name} - Project - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     return {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
@@ -4,7 +4,7 @@ import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { ScenarioExportConfigContent } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
 import { FileRepository } from '@marxan/files-repository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
 import { Readable } from 'stream';
@@ -21,7 +21,10 @@ export class ExportConfigScenarioPieceExporter implements ExportPieceProcessor {
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly entityManager: EntityManager,
-  ) {}
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ExportConfigScenarioPieceExporter.name);
+  }
 
   isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
     return piece === ClonePiece.ExportConfig && kind === ResourceKind.Scenario;
@@ -40,7 +43,9 @@ export class ExportConfigScenarioPieceExporter implements ExportPieceProcessor {
     );
 
     if (!scenario) {
-      throw new Error(`Scenario with ID ${input.resourceId} not found`);
+      const errorMessage = `Scenario with ID ${input.resourceId} not found`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const fileContent: ScenarioExportConfigContent = {
@@ -59,9 +64,9 @@ export class ExportConfigScenarioPieceExporter implements ExportPieceProcessor {
     );
 
     if (isLeft(outputFile)) {
-      throw new Error(
-        `${ExportConfigScenarioPieceExporter.name} - Scenario - couldn't save file - ${outputFile.left.description}`,
-      );
+      const errorMessage = `${ExportConfigScenarioPieceExporter.name} - Scenario - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     return {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { FileRepositoryModule } from '@marxan/files-repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
@@ -25,6 +25,7 @@ import { ExportConfigScenarioPieceExporter } from './export-config.scenario-piec
     PlanningAreaCustomPieceExporter,
     PlanningAreaCustomGridPieceExporter,
     ScenarioMetadataPieceExporter,
+    Logger,
   ],
 })
 export class PiecesExportersModule {}

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom.piece-exporter.ts
@@ -4,7 +4,7 @@ import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { PlanningAreaCustomContent } from '@marxan/cloning/infrastructure/clone-piece-data/planning-area-custom';
 import { FileRepository } from '@marxan/files-repository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
 import { Readable } from 'stream';
@@ -34,7 +34,10 @@ export class PlanningAreaCustomPieceExporter implements ExportPieceProcessor {
     private readonly geoprocessingEntityManager: EntityManager,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly apiEntityManager: EntityManager,
-  ) {}
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(PlanningAreaCustomPieceExporter.name);
+  }
 
   isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
     return (
@@ -56,7 +59,9 @@ export class PlanningAreaCustomPieceExporter implements ExportPieceProcessor {
     );
 
     if (!project) {
-      throw new Error(`Project with ID ${input.resourceId} not found`);
+      const errorMessage = `Project with ID ${input.resourceId} not found`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const [planningArea]: [
@@ -71,9 +76,9 @@ export class PlanningAreaCustomPieceExporter implements ExportPieceProcessor {
     );
 
     if (!planningArea) {
-      throw new Error(
-        `Custom planning area not found for project with ID: ${input.resourceId}`,
-      );
+      const errorMessage = `Custom planning area not found for project with ID: ${input.resourceId}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const planningAreaGeoJson = await this.fileRepository.save(
@@ -93,15 +98,15 @@ export class PlanningAreaCustomPieceExporter implements ExportPieceProcessor {
     );
 
     if (isLeft(outputFile)) {
-      throw new Error(
-        `${PlanningAreaCustomPieceExporter.name} - Project Custom PA - couldn't save file - ${outputFile.left.description}`,
-      );
+      const errorMessage = `${PlanningAreaCustomPieceExporter.name} - Project Custom PA - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     if (isLeft(planningAreaGeoJson)) {
-      throw new Error(
-        `${PlanningAreaCustomPieceExporter.name} - Project Custom PA - couldn't save file - ${planningAreaGeoJson.left.description}`,
-      );
+      const errorMessage = `${PlanningAreaCustomPieceExporter.name} - Project Custom PA - couldn't save file - ${planningAreaGeoJson.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     return {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@marxan/files-repository';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { getEntityManagerToken } from '@nestjs/typeorm';
 import { Either, left, Right, right } from 'fp-ts/lib/Either';
@@ -75,6 +76,7 @@ const getFixtures = async () => {
         provide: geoprocessingEntityManagerToken,
         useClass: FakeEntityManager,
       },
+      Logger,
     ],
   }).compile();
   await sandbox.init();

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.ts
@@ -5,7 +5,7 @@ import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-pi
 import { PlanningAreaGadmContent } from '@marxan/cloning/infrastructure/clone-piece-data/planning-area-gadm';
 import { FileRepository } from '@marxan/files-repository';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
 import { Readable } from 'stream';
@@ -31,7 +31,10 @@ export class PlanningAreaGadmPieceExporter implements ExportPieceProcessor {
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly entityManager: EntityManager,
-  ) {}
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(PlanningAreaGadmPieceExporter.name);
+  }
 
   isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
     return (
@@ -60,9 +63,9 @@ export class PlanningAreaGadmPieceExporter implements ExportPieceProcessor {
     );
 
     if (!gadm) {
-      throw new Error(
-        `Gadm data not found for project with ID: ${input.resourceId}`,
-      );
+      const errorMessage = `Gadm data not found for project with ID: ${input.resourceId}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const fileContent: PlanningAreaGadmContent = {
@@ -80,9 +83,9 @@ export class PlanningAreaGadmPieceExporter implements ExportPieceProcessor {
     );
 
     if (isLeft(outputFile)) {
-      throw new Error(
-        `${PlanningAreaGadmPieceExporter.name} - Project GADM - couldn't save file - ${outputFile.left.description}`,
-      );
+      const errorMessage = `${PlanningAreaGadmPieceExporter.name} - Project GADM - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     return {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
@@ -4,7 +4,7 @@ import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { ProjectMetadataContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-metadata';
 import { FileRepository } from '@marxan/files-repository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
 import { Readable } from 'stream';
@@ -21,7 +21,10 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly entityManager: EntityManager,
-  ) {}
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ProjectMetadataPieceExporter.name);
+  }
 
   isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
     return (
@@ -39,9 +42,9 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
     );
 
     if (!projectData) {
-      throw new Error(
-        `${ProjectMetadataPieceExporter.name} - Project ${input.resourceId} does not exist.`,
-      );
+      const errorMessage = `${ProjectMetadataPieceExporter.name} - Project ${input.resourceId} does not exist.`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const fileContent: ProjectMetadataContent = {
@@ -55,9 +58,9 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
     );
 
     if (isLeft(outputFile)) {
-      throw new Error(
-        `${ProjectMetadataPieceExporter.name} - Project - couldn't save file - ${outputFile.left.description}`,
-      );
+      const errorMessage = `${ProjectMetadataPieceExporter.name} - Project - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     return {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-metadata.piece-exporter.ts
@@ -4,7 +4,7 @@ import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePaths } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { ScenarioMetadataContent } from '@marxan/cloning/infrastructure/clone-piece-data/scenario-metadata';
 import { FileRepository } from '@marxan/files-repository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
 import { Readable } from 'stream';
@@ -21,7 +21,10 @@ export class ScenarioMetadataPieceExporter implements ExportPieceProcessor {
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly entityManager: EntityManager,
-  ) {}
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ScenarioMetadataPieceExporter.name);
+  }
 
   isSupported(piece: ClonePiece): boolean {
     return piece === ClonePiece.ScenarioMetadata;
@@ -41,9 +44,9 @@ export class ScenarioMetadataPieceExporter implements ExportPieceProcessor {
     );
 
     if (!scenario) {
-      throw new Error(
-        `${ScenarioMetadataPieceExporter.name} - Scenario ${input.resourceId} does not exist.`,
-      );
+      const errorMessage = `${ScenarioMetadataPieceExporter.name} - Scenario ${input.resourceId} does not exist.`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const fileContent: ScenarioMetadataContent = {
@@ -57,9 +60,9 @@ export class ScenarioMetadataPieceExporter implements ExportPieceProcessor {
     );
 
     if (isLeft(outputFile)) {
-      throw new Error(
-        `${ScenarioMetadataPieceExporter.name} - Scenario - couldn't save file - ${outputFile.left.description}`,
-      );
+      const errorMessage = `${ScenarioMetadataPieceExporter.name} - Scenario - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
     }
 
     const isProjectImport = input.resourceKind === ResourceKind.Project;


### PR DESCRIPTION
This PR adds error messages logs within exporters pieces. Other possible solution could be to log the error in `handleFailed` method of `QueueEventsAdapter` class, but this would affect all async jobs that are being handled with this class. 