### PR TITLE
Marxan 1164 implicit permissions

### DIFF
--- a/api/apps/api/src/migrations/api/1645550554581-ImplicitRolesFunctionsAndTriggers.ts
+++ b/api/apps/api/src/migrations/api/1645550554581-ImplicitRolesFunctionsAndTriggers.ts
@@ -25,51 +25,53 @@ export class ImplicitRolesFunctionsAndTriggers1645550554581
           E as (
             SELECT scenario_id FROM users_scenarios us WHERE us.user_id = $1 AND is_implicit IS false
           ),
-          I as (
-            SELECT * FROM P EXCEPT SELECT * FROM E
-          ),
           C as (
             SELECT scenario_id FROM users_scenarios us WHERE us.user_id = $1 AND is_implicit IS true
           ),
-          -- @todo: this will need to be joined with the user role on each of the scenarios' parent project
           G as (
-            SELECT * FROM I EXCEPT SELECT * FROM C
+            SELECT * FROM P EXCEPT SELECT * FROM E
           ),
-		      J as (
-			      SELECT s.id, up.role_id as role_id FROM G * LEFT OUTER JOIN scenarios s ON G.id = s.id JOIN projects pro ON s.id = pro.id JOIN users_projects up ON up.project_id = pro.id AND up.user_id = $1
+		      GR as (
+			      SELECT s.id, up.role_id as role_id FROM G
+              LEFT OUTER JOIN scenarios s ON G.id = s.id
+              JOIN projects pro ON s.project_id = pro.id
+              JOIN users_projects up ON up.project_id = pro.id AND up.user_id = $1
           ),
           R as (
-            SELECT * FROM C EXCEPT SELECT * FROM I
+            SELECT * FROM C EXCEPT SELECT * FROM G
           )
-        SELECT array((SELECT (id, role_id)::role_on_entity FROM J)) AS grant_on, array((SELECT * FROM R)) AS revoke_on;
+        SELECT array((SELECT (id, regexp_replace(role_id, '^project_', 'scenario_'))::role_on_entity FROM GR)) AS grant_on, array((SELECT * FROM R)) AS revoke_on;
         $$ LANGUAGE 'sql';
     `);
 
     await queryRunner.query(`
-      CREATE OR REPLACE FUNCTION apply_scenario_acl_diff_for_user(_user_id uuid, grant_on role_on_entity[], revoke_on (uuid[] ) RETURNS void as $$
-      DECLARE
-        grant_on_scenario_id role_on_entity;
-        revoke_on_scenario_id uuid;
-      BEGIN
-        FOREACH grant_on_scenario IN array grant_on
-        LOOP
-          RAISE NOTICE 'Granting implicit % role on scenario % to user %', grant_on_scenario.role_id, grant_on_scenario.scenario_id, _user_id;
+    CREATE OR REPLACE FUNCTION apply_scenario_acl_diff_for_user(_user_id uuid, grant_on role_on_entity[], revoke_on uuid[]) RETURNS void as $$
+    DECLARE
+      grant_on_scenario role_on_entity;
+      revoke_on_scenario uuid;
+    BEGIN
+      FOREACH grant_on_scenario IN array grant_on
+      LOOP
+        RAISE NOTICE 'Granting implicit % role on scenario % to user %', grant_on_scenario.role_id, grant_on_scenario.entity_id, _user_id;
 
-          INSERT INTO users_scenarios
-            (user_id, scenario_id, role_id, is_implicit)
-            VALUES
-            (_user_id, grant_on_scenario.scenario_id, grant_on_scenario.role_id, true);
-        END LOOP;
+        -- first delete, then redo - this is so that we can easily reflect a
+        -- change on user role on the parent project
+        DELETE FROM users_scenarios WHERE user_id = _user_id AND scenario_id = grant_on_scenario.entity_id AND is_implicit IS true;
+        INSERT INTO users_scenarios
+          (user_id, scenario_id, role_id, is_implicit)
+          VALUES
+          (_user_id, grant_on_scenario.entity_id, grant_on_scenario.role_id, true);
+      END LOOP;
 
-        FOREACH revoke_on_scenario_id IN array revoke_on
-        LOOP
-          RAISE NOTICE 'Revoking implicit role on scenario % from user %', revoke_on_scenario_id, _user_id;
+      FOREACH revoke_on_scenario IN array revoke_on
+      LOOP
+        RAISE NOTICE 'Revoking implicit role on scenario % from user %', revoke_on_scenario, _user_id;
 
-          DELETE FROM users_scenarios us
-            WHERE us.user_id = _user_id AND scenario_id = revoke_on_scenario_id;
-        END LOOP;
-      END;
-      $$ LANGUAGE 'plpgsql';
+        DELETE FROM users_scenarios us
+          WHERE us.user_id = _user_id AND scenario_id = revoke_on_scenario;
+      END LOOP;
+    END;
+    $$ LANGUAGE 'plpgsql';
     `);
 
     await queryRunner.query(`
@@ -78,30 +80,24 @@ export class ImplicitRolesFunctionsAndTriggers1645550554581
       $$
       DECLARE
         scenario_id uuid;
+        user_id uuid;
         is_implicit boolean;
-        role_name varchar;
       BEGIN
-        -- define constants
-        -- set is_implicit to false as default
-        is_implicit := false;
-
-        -- set user_id and is_implicit from row being created or deleted,
+        -- set user_id from row being created or deleted,
         -- as applicable
-        IF TG_OP = 'INSERT' THEN
+        IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
           user_id := NEW.user_id;
-          IF TG_TABLE_NAME = 'users_projects' THEN
-            is_implicit := NEW.is_implicit;
-          END IF;
         ELSIF TG_OP = 'DELETE' THEN
             user_id := OLD.user_id;
-            IF TG_TABLE_NAME = 'users_projects' THEN
-              is_implicit := OLD.is_implicit;
-            END IF;
         END IF;
 
-        PERFORM apply_scenario_acl_diff_for_user(user_id, (select grant_on from compute_implicit_scenario_roles_for_user(user_id)));
+        PERFORM apply_scenario_acl_diff_for_user(
+          user_id,
+          (select grant_on from compute_implicit_scenario_roles_for_user(user_id)),
+          (select revoke_on from compute_implicit_scenario_roles_for_user(user_id))
+        );
 
-        IF TG_OP = 'INSERT' THEN
+        IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
           RETURN NEW;
         END IF;
 
@@ -137,12 +133,7 @@ export class ImplicitRolesFunctionsAndTriggers1645550554581
     await queryRunner.query(`
       -- triggers for implicit scenario roles
       CREATE OR REPLACE TRIGGER compute_implicit_scenario_roles_for_projects
-      AFTER INSERT OR DELETE ON users_projects
-      FOR EACH ROW
-      EXECUTE PROCEDURE manage_implicit_scenario_roles();
-
-      CREATE OR REPLACE TRIGGER compute_implicit_scenario_roles_for_scenarios
-      AFTER DELETE ON users_scenarios
+      AFTER INSERT OR UPDATE OR DELETE ON users_projects
       FOR EACH ROW
       EXECUTE PROCEDURE manage_implicit_scenario_roles();
 

--- a/api/apps/api/src/migrations/api/1645550554581-ImplicitRolesFunctionsAndTriggers.ts
+++ b/api/apps/api/src/migrations/api/1645550554581-ImplicitRolesFunctionsAndTriggers.ts
@@ -1,0 +1,107 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ImplicitRolesFunctionsAndTriggers1645550554581
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(``);
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION compute_implicit_scenario_roles_for_user(_scenario_id uuid)
+      RETURNS table(grant_on uuid[]) AS $$
+        WITH
+          O AS (
+            SELECT id FROM users WHERE id IN (SELECT user_id FROM users_projects project_user WHERE project_id IN (SELECT project_id FROM scenarios WHERE scenarios.id = $1))
+          )
+        SELECT array((SELECT * FROM O)) AS grant_on;
+        $$ LANGUAGE 'sql';
+    `);
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION apply_scenarios_acl_for_user(_scenario_id uuid, grant_on uuid[], role_name varchar) RETURNS void as $$
+      DECLARE
+        grant_on_user_id uuid;
+      BEGIN
+        FOREACH grant_on_user_id IN array grant_on
+        LOOP
+          RAISE NOTICE 'Granting implicit % role on scenario % to user %', role_name, _scenario_id, grant_on_user_id;
+
+          INSERT INTO users_scenarios
+            (user_id, scenario_id, role_id)
+            VALUES
+            (grant_on_user_id, _scenario_id, , (SELECT name from roles WHERE name = role_name), true);
+
+        END LOOP;
+      END;
+      $$ LANGUAGE 'plpgsql';
+    `);
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION manage_implicit_scenario_roles()
+        RETURNS trigger AS
+      $$
+      DECLARE
+        scenario_id uuid;
+        role_name varchar;
+      BEGIN
+        -- define constants
+        role_name := 'scenario_viewer';
+
+        IF TG_OP = 'INSERT' THEN
+          user_id := NEW.user_id;
+        END IF;
+
+        PERFORM apply_scenario_acl_diff_for_user(scenario_id, (select grant_on from compute_implicit_scenario_roles_for_user(scenario_id)), role_name);
+
+        IF TG_OP = 'INSERT' THEN
+          RETURN NEW;
+        END IF;
+      END;
+      $$ language 'plpgsql';
+    `);
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION change_implicit_scenario_role_to_explicit()
+        RETURNS trigger AS
+      $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM users_scenarios WHERE user_id = NEW.user_id AND scenario_id = NEW.scenario_id) THEN
+          IF TG_OP = 'INSERT' AND TG_TABLE_NAME = 'users_scenarios' THEN
+            UPDATE users_scenarios SET
+              role_id = NEW.role_id
+              WHERE user_id = NEW.user_id AND scenario_id = NEW.scenario_id;
+            RETURN NULL;
+          END IF;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$ language 'plpgsql';
+    `);
+    await queryRunner.query(`
+      -- triggers for implicit scenario roles
+      CREATE OR REPLACE TRIGGER compute_implicit_scenario_roles_for_projects
+      AFTER DELETE ON users_scenarios
+      FOR EACH ROW
+      EXECUTE PROCEDURE manage_implicit_scenario_roles();
+
+      CREATE OR REPLACE TRIGGER change_implicit_scenario_role_to_explicit
+      AFTER INSERT ON users_scenarios
+      FOR EACH ROW
+      EXECUTE PROCEDURE change_implicit_scenario_role_to_explicit();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        DROP TRIGGER IF EXISTS compute_implicit_scenario_roles_for_projects ON users_scenarios;
+        DROP TRIGGER IF EXISTS change_implicit_scenario_role_to_explicit ON users_scenarios;
+
+        DROP FUNCTION IF EXISTS change_implicit_scenario_role_to_explicit();
+
+        DROP FUNCTION IF EXISTS manage_implicit_scenario_roles();
+
+        DROP FUNCTION IF EXISTS apply_scenarios_acl_for_user(uuid, uuid[], varchar);
+
+        DROP FUNCTION IF EXISTS compute_implicit_scenario_roles_for_user(uuid);
+  `);
+  }
+}

--- a/api/apps/api/src/migrations/api/1645550554581-ImplicitRolesFunctionsAndTriggers.ts
+++ b/api/apps/api/src/migrations/api/1645550554581-ImplicitRolesFunctionsAndTriggers.ts
@@ -108,31 +108,32 @@ export class ImplicitRolesFunctionsAndTriggers1645550554581
       $$ language 'plpgsql';
     `);
 
-    // await queryRunner.query(`
-    // CREATE OR REPLACE FUNCTION manage_existing_project_roles_for_scenario()
-    // RETURNS trigger as $$
-    // DECLARE
-    //   users_to_grant role_on_entity[];
-    //   project_id uuid;
-    //   scenario_id uuid;
-    //   user_to_grant role_on_entity;
-    // BEGIN
-    //   project_id := NEW.project_id;
-    //   scenario_id := NEW.id;
-    //   users_to_grant := (SELECT user_id, role_id FROM users_projects up WHERE up.project_id = project_id);
-      
-    //   FOREACH user_to_grant IN array users_to_grant
-    //   LOOP
-    //     RAISE NOTICE 'Granting implicit % role on scenario % to user %', regexp_replace(user_to_grant.role_id, '^project_', 'scenario_'), scenario_id, user_to_grant.entity_id;
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION manage_existing_project_roles_for_scenario()
+      RETURNS trigger as $$
+      DECLARE
+        users_to_grant role_on_entity[];
+        upper_project_id uuid;
+        scenario_id uuid;
+        user_to_grant role_on_entity;
+      BEGIN
+        upper_project_id := NEW.project_id;
+        scenario_id := NEW.id;
+        users_to_grant := ARRAY(SELECT ROW(user_id, role_id) FROM users_projects up WHERE up.project_id = upper_project_id);
+          
+        FOREACH user_to_grant IN array users_to_grant
+        LOOP
+          RAISE NOTICE 'Granting implicit % role on scenario % to user %', regexp_replace(user_to_grant.role_id, '^project_', 'scenario_'), scenario_id, user_to_grant.entity_id;
 
-    //     INSERT INTO users_scenarios
-    //       (user_id, scenario_id, role_id, is_implicit)
-    //       VALUES
-    //       (user_to_grant.entity_id, scenario_id, regexp_replace(user_to_grant.role_id, '^project_', 'scenario_'), true);
-    //   END LOOP;
-    // END;
-    // $$ LANGUAGE 'plpgsql';
-    // `);
+          INSERT INTO users_scenarios
+            (user_id, scenario_id, role_id, is_implicit)
+            VALUES
+            (user_to_grant.entity_id, scenario_id, regexp_replace(user_to_grant.role_id, '^project_', 'scenario_'), true);
+        END LOOP;
+	      RETURN NULL;
+      END;
+      $$ LANGUAGE 'plpgsql';
+    `);
 
     await queryRunner.query(`
       -- triggers for implicit scenario roles
@@ -141,11 +142,11 @@ export class ImplicitRolesFunctionsAndTriggers1645550554581
       FOR EACH ROW
       EXECUTE PROCEDURE manage_implicit_scenario_roles();
 
+      CREATE OR REPLACE TRIGGER compute_implicit_scenario_roles_for_scenarios
+      AFTER INSERT ON scenarios
+      FOR EACH ROW
+      EXECUTE PROCEDURE manage_existing_project_roles_for_scenario();
       `);
-      // CREATE OR REPLACE TRIGGER compute_implicit_scenario_roles_for_scenarios
-      // AFTER INSERT ON scenarios
-      // FOR EACH ROW
-      // EXECUTE PROCEDURE manage_existing_project_roles_for_scenario();
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/api/apps/api/src/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity.ts
@@ -25,6 +25,14 @@ export class UsersScenariosApiEntity {
   })
   roleName!: ScenarioRoles;
 
+  @PrimaryColumn({
+    type: 'boolean',
+    name: 'is_implicit',
+    default: false,
+  })
+  isImplicit!: boolean;
+
+
   @ManyToOne(() => Scenario, {
     onDelete: 'CASCADE',
     primary: true,

--- a/api/apps/api/src/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity.ts
@@ -1,5 +1,5 @@
 import { Role } from '@marxan-api/modules/access-control/role.api.entity';
-import { Check, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Check, Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { User } from '@marxan-api/modules/users/user.api.entity';
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import { ScenarioRoles } from '@marxan-api/modules/access-control/scenarios-acl/dto/user-role-scenario.dto';
@@ -19,13 +19,13 @@ export class UsersScenariosApiEntity {
   scenarioId!: string;
 
   @Check(`role_id`, `LIKE 'scenario_%'`)
-  @PrimaryColumn({
+  @Column({
     type: `varchar`,
     name: `role_id`,
   })
   roleName!: ScenarioRoles;
 
-  @PrimaryColumn({
+  @Column({
     type: 'boolean',
     name: 'is_implicit',
     default: false,

--- a/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
@@ -142,14 +142,12 @@ export class ScenariosCrudService extends AppBaseService<
   }
 
   async assignCreatorRole(scenarioId: string, userId: string): Promise<void> {
-    await this.userScenarios.save(
-      this.userScenarios.create({
-        scenarioId,
-        userId,
-        roleName: ScenarioRoles.scenario_owner,
-        isImplicit: false,
-      }),
-    );
+    await this.userScenarios.save({
+      scenarioId,
+      userId,
+      roleName: ScenarioRoles.scenario_owner,
+      isImplicit: false,
+    });
   }
 
   async setDataUpdate(

--- a/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
@@ -147,6 +147,7 @@ export class ScenariosCrudService extends AppBaseService<
         scenarioId,
         userId,
         roleName: ScenarioRoles.scenario_owner,
+        isImplicit: false,
       }),
     );
   }

--- a/api/apps/api/test/implicit-permissions/implicit-permissions.e2e-spec.ts
+++ b/api/apps/api/test/implicit-permissions/implicit-permissions.e2e-spec.ts
@@ -1,0 +1,97 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getFixtures } from './implicit-permissions.fixtures';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+afterEach(async () => {
+  await fixtures?.cleanup();
+});
+
+test(`All users roles in project must be replicated in newly created scenario`, async () => {
+  /*
+    To test everything at once and for clarity purposes, we will
+    consider the creator of project not as owner but as "creator",
+    as another owner will be added as well to test that every single
+    role is transferred to a scenario regardless of their status
+    as creator or not. The owner that does not create the project
+    would be mentioned just as "owner" or "other owner".
+  */
+  await fixtures.GivenProjectWasCreated();
+  const creatorToken = await fixtures.GivenUserIsLoggedIn('owner');
+  await fixtures.GivenOwnerWasAddedToProject();
+  await fixtures.GivenContributorWasAddedToProject();
+  await fixtures.GivenViewerWasAddedToProject();
+
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+
+  const response = await fixtures.WhenGettingScenarioUsers(
+    scenarioId,
+    creatorToken,
+  );
+
+  fixtures.ThenAllUsersInProjectAreReturnedWithTheProperRoleInScenario(
+    response,
+  );
+});
+
+test(`All users roles in scenario should be revoked when revoked in project`, async () => {
+  await fixtures.GivenProjectWasCreated();
+  const creatorToken = await fixtures.GivenUserIsLoggedIn('owner');
+
+  await fixtures.GivenOwnerWasAddedToProject();
+  await fixtures.GivenContributorWasAddedToProject();
+  await fixtures.GivenViewerWasAddedToProject();
+
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+
+  await fixtures.WhenDeletingAllUsersExceptCreatorFromProject();
+
+  const response = await fixtures.WhenGettingScenarioUsers(
+    scenarioId,
+    creatorToken,
+  );
+  fixtures.ThenOnlyCreatorIsReturned(response);
+});
+
+test(`All changes in roles at project level should also be done at scenario level`, async () => {
+  await fixtures.GivenProjectWasCreated();
+  const creatorToken = await fixtures.GivenUserIsLoggedIn('owner');
+
+  await fixtures.GivenOwnerWasAddedToProject();
+  await fixtures.GivenContributorWasAddedToProject();
+  await fixtures.GivenViewerWasAddedToProject();
+
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+
+  await fixtures.WhenChangingAllUsersRole();
+  const response = await fixtures.WhenGettingScenarioUsers(
+    scenarioId,
+    creatorToken,
+  );
+  fixtures.ThenUsersWithChangedRolesShouldBeReturned(response);
+});
+
+test(`All project users added after a scenario is created should be included in the scenario`, async () => {
+  await fixtures.GivenProjectWasCreated();
+  const creatorToken = await fixtures.GivenUserIsLoggedIn('owner');
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+
+  let response = await fixtures.WhenGettingScenarioUsers(
+    scenarioId,
+    creatorToken,
+  );
+  fixtures.ThenOnlyCreatorIsReturned(response);
+
+  await fixtures.GivenOwnerWasAddedToProject();
+  await fixtures.GivenContributorWasAddedToProject();
+  await fixtures.GivenViewerWasAddedToProject();
+
+  response = await fixtures.WhenGettingScenarioUsers(scenarioId, creatorToken);
+
+  fixtures.ThenAllUsersInProjectAreReturnedWithTheProperRoleInScenario(
+    response,
+  );
+});

--- a/api/apps/api/test/implicit-permissions/implicit-permissions.e2e-spec.ts
+++ b/api/apps/api/test/implicit-permissions/implicit-permissions.e2e-spec.ts
@@ -56,6 +56,22 @@ test(`All users roles in scenario should be revoked when revoked in project`, as
   fixtures.ThenOnlyCreatorIsReturned(response);
 });
 
+test(`It fails to change the scenario owner role of the creator of the scenario as it is a explicit role`, async () => {
+  await fixtures.GivenProjectWasCreated();
+  const creatorToken = await fixtures.GivenUserIsLoggedIn('owner');
+
+  await fixtures.GivenOwnerWasAddedToProject();
+
+  const scenarioId = await fixtures.GivenScenarioWasCreated();
+
+  await fixtures.WhenChangingCreatorRoleInProject();
+  const response = await fixtures.WhenGettingScenarioUsers(
+    scenarioId,
+    creatorToken,
+  );
+  fixtures.ThenBothOwnersShouldBeReturned(response);
+});
+
 test(`All changes in roles at project level should also be done at scenario level`, async () => {
   await fixtures.GivenProjectWasCreated();
   const creatorToken = await fixtures.GivenUserIsLoggedIn('owner');
@@ -66,7 +82,7 @@ test(`All changes in roles at project level should also be done at scenario leve
 
   const scenarioId = await fixtures.GivenScenarioWasCreated();
 
-  await fixtures.WhenChangingAllUsersRole();
+  await fixtures.WhenChangingAllUsersExceptCreatorRole();
   const response = await fixtures.WhenGettingScenarioUsers(
     scenarioId,
     creatorToken,

--- a/api/apps/api/test/implicit-permissions/implicit-permissions.fixtures.ts
+++ b/api/apps/api/test/implicit-permissions/implicit-permissions.fixtures.ts
@@ -1,0 +1,212 @@
+import * as request from 'supertest';
+import { bootstrapApplication } from '../utils/api-application';
+import { GivenUserIsLoggedIn, userObj } from '../steps/given-user-is-logged-in';
+import { GivenUserIsCreated } from '../steps/given-user-is-created';
+import { ScenariosTestUtils } from '../utils/scenarios.test.utils';
+import { ScenarioType } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { GivenUserExists } from '../steps/given-user-exists';
+import { GivenProjectExists } from '../steps/given-project';
+import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
+import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
+import { ProjectsTestUtils } from '../utils/projects.test.utils';
+import { User } from '@marxan-api/modules/users/user.api.entity';
+import { assertDefined } from '@marxan/utils';
+import { ScenarioRoles } from '@marxan-api/modules/access-control/scenarios-acl/dto/user-role-scenario.dto';
+
+export async function getFixtures() {
+  const app = await bootstrapApplication();
+  const creatorToken = await GivenUserIsLoggedIn(app, 'aa');
+  const viewerToken = await GivenUserIsLoggedIn(app, 'cc');
+  const creatorUserId = await GivenUserExists(app, 'aa');
+  const contributorUserId = await GivenUserExists(app, 'bb');
+  const viewerUserId = await GivenUserExists(app, 'cc');
+  const ownerUserId = await GivenUserExists(app, 'dd');
+
+  const randomUserInfo = await GivenUserIsCreated(app);
+  assertDefined(randomUserInfo.user.id);
+  const randomUserId = randomUserInfo.user.id;
+
+  const projectOwnerRole = ProjectRoles.project_owner;
+  const projectContributorRole = ProjectRoles.project_contributor;
+  const projectViewerRole = ProjectRoles.project_viewer;
+
+  const scenarioOwnerRole = ScenarioRoles.scenario_owner;
+  const scenarioContributorRole = ScenarioRoles.scenario_contributor;
+  const scenarioViewerRole = ScenarioRoles.scenario_viewer;
+
+  const { projectId } = await GivenProjectExists(app, creatorToken);
+
+  let scenarioId: string;
+
+  const userProjectsRepo: Repository<UsersProjectsApiEntity> = app.get(
+    getRepositoryToken(UsersProjectsApiEntity),
+  );
+  const usersRepo: Repository<User> = app.get(getRepositoryToken(User));
+
+  const cleanups: (() => Promise<void>)[] = [];
+
+  return {
+    cleanup: async () => {
+      await ScenariosTestUtils.deleteScenario(app, creatorToken, scenarioId);
+      await ProjectsTestUtils.deleteProject(app, creatorToken, projectId);
+      for (const cleanup of cleanups.reverse()) {
+        await cleanup();
+      }
+      await app.close();
+    },
+
+    GivenUserIsLoggedIn: async (user: string) => {
+      if (user === 'random') {
+        return randomUserInfo.accessToken;
+      }
+      const userToken = userObj[user as keyof typeof userObj];
+      return await GivenUserIsLoggedIn(app, userToken);
+    },
+
+    GivenProjectWasCreated: async () => projectId,
+
+    GivenScenarioWasCreated: async () => {
+      const result = await ScenariosTestUtils.createScenario(
+        app,
+        creatorToken,
+        {
+          name: `Test scenario`,
+          type: ScenarioType.marxan,
+          projectId,
+        },
+      );
+      scenarioId = result.data.id;
+
+      return scenarioId;
+    },
+
+    GivenOwnerWasAddedToProject: async () =>
+      await userProjectsRepo.save({
+        projectId,
+        roleName: projectOwnerRole,
+        userId: ownerUserId,
+      }),
+
+    GivenContributorWasAddedToProject: async () =>
+      await userProjectsRepo.save({
+        projectId,
+        roleName: projectContributorRole,
+        userId: contributorUserId,
+      }),
+
+    GivenViewerWasAddedToProject: async () =>
+      await userProjectsRepo.save({
+        projectId,
+        roleName: projectViewerRole,
+        userId: viewerUserId,
+      }),
+
+    GivenUserWasAddedToProject: async () => {
+      await userProjectsRepo.save({
+        projectId,
+        userId: randomUserInfo.user.id,
+        roleName: projectContributorRole,
+      });
+      cleanups.push(async () => {
+        await usersRepo.delete({ id: randomUserInfo.user.id });
+        return;
+      });
+      return randomUserId;
+    },
+
+    WhenDeletingAllUsersExceptCreatorFromProject: async () => {
+      await userProjectsRepo.delete({ userId: contributorUserId, projectId });
+      await userProjectsRepo.delete({ userId: viewerUserId, projectId });
+      await userProjectsRepo.delete({ userId: ownerUserId, projectId });
+    },
+
+    WhenChangingAllUsersRole: async () => {
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/projects/${projectId}/users`)
+        .set('Authorization', `Bearer ${creatorToken}`)
+        .send({ projectId, userId: viewerUserId, roleName: projectOwnerRole });
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/projects/${projectId}/users`)
+        .set('Authorization', `Bearer ${creatorToken}`)
+        .send({
+          projectId,
+          userId: contributorUserId,
+          roleName: projectViewerRole,
+        });
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/projects/${projectId}/users`)
+        .set('Authorization', `Bearer ${creatorToken}`)
+        .send({
+          projectId,
+          userId: ownerUserId,
+          roleName: projectContributorRole,
+        });
+      await request(app.getHttpServer())
+        .patch(`/api/v1/roles/projects/${projectId}/users`)
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({
+          projectId,
+          userId: creatorUserId,
+          roleName: projectContributorRole,
+        });
+    },
+
+    WhenGettingScenarioUsers: async (scenarioId: string, token: string) =>
+      await request(app.getHttpServer())
+        .get(`/api/v1/roles/scenarios/${scenarioId}/users`)
+        .set('Authorization', `Bearer ${token}`),
+
+    ThenAllUsersInProjectAreReturnedWithTheProperRoleInScenario: (
+      response: request.Response,
+    ) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(4);
+      const creatorUser = response.body.data.find(
+        (user: any) => user.user.id === creatorUserId,
+      );
+      expect(creatorUser.roleName).toEqual(scenarioOwnerRole);
+      const ownerUser = response.body.data.find(
+        (user: any) => user.user.id === ownerUserId,
+      );
+      expect(ownerUser.roleName).toEqual(scenarioOwnerRole);
+      const contributorUser = response.body.data.find(
+        (user: any) => user.user.id === contributorUserId,
+      );
+      expect(contributorUser.roleName).toEqual(scenarioContributorRole);
+      const viewerUser = response.body.data.find(
+        (user: any) => user.user.id === viewerUserId,
+      );
+      expect(viewerUser.roleName).toEqual(scenarioViewerRole);
+    },
+    ThenOnlyCreatorIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(1);
+      const creatorUser = response.body.data.find(
+        (user: any) => user.user.id === creatorUserId,
+      );
+      expect(creatorUser.roleName).toEqual(scenarioOwnerRole);
+    },
+    ThenUsersWithChangedRolesShouldBeReturned: (response: request.Response) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data).toHaveLength(4);
+      const creatorUser = response.body.data.find(
+        (user: any) => user.user.id === creatorUserId,
+      );
+      expect(creatorUser.roleName).toEqual(scenarioOwnerRole);
+      const contributorUser = response.body.data.find(
+        (user: any) => user.user.id === contributorUserId,
+      );
+      expect(contributorUser.roleName).toEqual(scenarioViewerRole);
+      const viewerUser = response.body.data.find(
+        (user: any) => user.user.id === viewerUserId,
+      );
+      expect(viewerUser.roleName).toEqual(scenarioContributorRole);
+      const ownerUser = response.body.data.find(
+        (user: any) => user.user.id === ownerUserId,
+      );
+      expect(ownerUser.roleName).toEqual(scenarioContributorRole);
+    },
+  };
+}

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -51,6 +51,7 @@ describe('ScenariosModule (e2e)', () => {
   });
 
   it('Creating a scenario will fail because the user is a project viewer', async () => {
+    await fixtures.GivenViewerWasAddedToProject();
     const response = await fixtures.WhenCreatingAScenarioAsAProjectViewer();
     fixtures.ThenForbiddenIsReturned(response);
   });
@@ -137,6 +138,7 @@ async function getFixtures() {
   const scenarioViewerRole = ScenarioRoles.scenario_viewer;
 
   const projectContributorRole = ProjectRoles.project_contributor;
+  const projectViewerRole = ProjectRoles.project_viewer;
 
   const { projectId } = await GivenProjectExists(app, ownerToken);
 
@@ -152,6 +154,8 @@ async function getFixtures() {
 
   let scenarioId: string;
   const seedScenarioNames = [
+    'Example scenario 1 Project 1 Org 1',
+    'Example scenario 2 Project 1 Org 1',
     'Example scenario 1 Project 2 Org 2',
     'Example scenario 2 Project 2 Org 2',
   ];
@@ -196,6 +200,13 @@ async function getFixtures() {
         projectId,
         roleName: projectContributorRole,
         userId: contributorUserId,
+      }),
+
+    GivenViewerWasAddedToProject: async () =>
+      await userProjectsRepo.save({
+        projectId,
+        roleName: projectViewerRole,
+        userId: viewerUserId,
       }),
 
     GivenContributorWasAddedToScenario: async () =>

--- a/api/apps/api/test/project-scenarios.e2e-spec.ts
+++ b/api/apps/api/test/project-scenarios.e2e-spec.ts
@@ -130,7 +130,6 @@ async function getFixtures() {
   const contributorUserId = await GivenUserExists(app, 'bb');
   const viewerToken = await GivenUserIsLoggedIn(app, 'cc');
   const viewerUserId = await GivenUserExists(app, 'cc');
-  const noScenariosUserToken = await GivenUserIsLoggedIn(app, 'dd');
 
   const randomUserInfo = await GivenUserIsCreated(app);
   const queue = FakeQueue.getByName(queueName);
@@ -299,7 +298,7 @@ async function getFixtures() {
     WhenGettingScenariosAsUserWithNoScenarios: async () =>
       await request(app.getHttpServer())
         .get('/api/v1/scenarios')
-        .set('Authorization', `Bearer ${noScenariosUserToken}`),
+        .set('Authorization', `Bearer ${randomUserInfo.accessToken}`),
 
     WhenGettingPaginatedScenariosAsOwner: async () =>
       await request(app.getHttpServer())


### PR DESCRIPTION
-Adds migration to include triggers on `users_projects` changes and `scenarios` creation.
-Tweaks some differences in tests due to not-slightly-accurate test data.
-Changes columns definition in `user-scenarios` API entity to avoid duplicate key errors.
-Tests for implicit-permissions. [WIP]