### PR TITLE
fix: add fake project id to planning area when uploading planning area

### DIFF
--- a/api/apps/geoprocessing/test/integration/planning-areas/custom-planning-area.repository.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/planning-areas/custom-planning-area.repository.e2e-spec.ts
@@ -46,10 +46,20 @@ describe(`when entity created`, () => {
         38.20365531807149,
         29.22889003019423,
       ],
-      id: expect.any(String),
+      id: result.id,
       maxPuAreaSize: 940152,
       minPuAreaSize: 103,
     });
+  });
+
+  it('should have equal id and project_id', async () => {
+    const [planning_area] = await fixtures
+      .getTypeormRepository()
+      .find({ id: result.id });
+
+    expect(planning_area).toBeDefined();
+
+    expect(planning_area.id).toEqual(planning_area.projectId);
   });
 
   it(`should find a bbox of entity`, async () => {

--- a/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
+++ b/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
@@ -89,7 +89,7 @@ INSERT INTO "planning_areas"("the_geom","project_id","id")
     return this.planningAreas
       .createQueryBuilder()
       .where('id = project_id')
-      .andWhere('created_at < :unsassignedPlanningAreaDate', {
+      .andWhere('created_at < :unassignedPlanningAreaDate', {
         unsassignedPlanningAreaDate: new Date(+now - maxAgeInMs),
       })
       .delete()

--- a/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
+++ b/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { BBox, GeoJSON } from 'geojson';
 import { isDefined } from '@marxan/utils';
 import { PlanningArea } from './planning-area.geo.entity';
+import { v4 } from 'uuid';
 
 export const geoEntityManagerToken = Symbol('geo entity manager token');
 
@@ -22,13 +23,14 @@ export class CustomPlanningAreaRepository {
 
   async saveGeoJson(data: GeoJSON): Promise<SaveGeoJsonResult> {
     const resultKey = (key: keyof SaveGeoJsonResult) => key;
+    const fakeProjectId = v4();
     const result: SaveGeoJsonResult[] = await this.planningAreas.query(
       `
-INSERT INTO "planning_areas"("the_geom")
+INSERT INTO "planning_areas"("the_geom","project_id","id")
   SELECT ST_SetSRID(
     ST_CollectionExtract(ST_Collect(
       ST_GeomFromGeoJSON(features->>'geometry')
-    ),3), 4326)::geometry
+    ),3), 4326)::geometry , $2 , $2
   FROM (
     SELECT json_array_elements($1::json->'features') AS features
   ) AS f RETURNING
@@ -41,7 +43,7 @@ INSERT INTO "planning_areas"("the_geom")
         `minPuAreaSize`,
       )}";
     `,
-      [data],
+      [data, fakeProjectId],
     );
     return result[0];
   }

--- a/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
+++ b/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
@@ -90,7 +90,7 @@ INSERT INTO "planning_areas"("the_geom","project_id","id")
       .createQueryBuilder()
       .where('id = project_id')
       .andWhere('created_at < :unassignedPlanningAreaDate', {
-        unsassignedPlanningAreaDate: new Date(+now - maxAgeInMs),
+        unassignedPlanningAreaDate: new Date(+now - maxAgeInMs),
       })
       .delete()
       .execute();

--- a/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
+++ b/api/libs/planning-area-repository/src/custom-planning-area.repository.ts
@@ -86,10 +86,14 @@ INSERT INTO "planning_areas"("the_geom","project_id","id")
   ): Promise<{
     affected?: number | null;
   }> {
-    return await this.planningAreas.delete({
-      projectId: null,
-      createdAt: LessThan(new Date(+now - maxAgeInMs)),
-    });
+    return this.planningAreas
+      .createQueryBuilder()
+      .where('id = project_id')
+      .andWhere('created_at < :unsassignedPlanningAreaDate', {
+        unsassignedPlanningAreaDate: new Date(+now - maxAgeInMs),
+      })
+      .delete()
+      .execute();
   }
 
   private transaction<T>(


### PR DESCRIPTION
This PR fixes inconsistent `project_id` in `planning_areas` table value when uploading planning area. Now the id of the newly planning area and its associated project_id are the same.