### PR TITLE
MARXAN-1361-block-users

### DIFF
--- a/api/apps/api/src/migrations/api/1646666092302-AddsIsBlockedColumnToUsers.ts
+++ b/api/apps/api/src/migrations/api/1646666092302-AddsIsBlockedColumnToUsers.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddsIsBlockedColumnToUsers1646666092302
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+        ALTER TABLE users
+            ADD COLUMN is_blocked boolean NOT NULL DEFAULT false;
+    `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+        ALTER TABLE users_scenarios
+            DROP COLUMN is_blocked;
+          `,
+    );
+  }
+}

--- a/api/apps/api/src/modules/authentication/authentication.service.ts
+++ b/api/apps/api/src/modules/authentication/authentication.service.ts
@@ -96,7 +96,8 @@ export class AuthenticationService {
     password: string;
   }): Promise<User | null> {
     const user = await this.usersService.findByEmail(email);
-    const isUserActive = user && user.isActive && !user.isDeleted;
+    const isUserActive =
+      user && user.isActive && !user.isDeleted && !user.isBlocked;
 
     if (user && isUserActive && (await compare(password, user.passwordHash))) {
       return user;

--- a/api/apps/api/src/modules/users/dto/update.user.dto.ts
+++ b/api/apps/api/src/modules/users/dto/update.user.dto.ts
@@ -1,4 +1,12 @@
 import { PartialType } from '@nestjs/swagger';
+import { IsArray, IsString, IsUUID } from 'class-validator';
 import { CreateUserDTO } from './create.user.dto';
 
 export class UpdateUserDTO extends PartialType(CreateUserDTO) {}
+
+export class BlockUsersBatchDTO {
+  @IsArray()
+  @IsString({ each: true })
+  @IsUUID('all', { each: true })
+  userIds!: string[];
+}

--- a/api/apps/api/src/modules/users/user.api.entity.ts
+++ b/api/apps/api/src/modules/users/user.api.entity.ts
@@ -73,6 +73,13 @@ export class User {
   isActive!: boolean;
 
   /**
+   * Whether this user is blocked by a platform admin.
+   */
+  @ApiProperty()
+  @Column('boolean', { name: 'is_blocked' })
+  isBlocked!: boolean;
+
+  /**
    * Whether the user should be considered as deleted. This is used to implement
    * a grace period before full deletion.
    */

--- a/api/apps/api/src/modules/users/users.controller.ts
+++ b/api/apps/api/src/modules/users/users.controller.ts
@@ -36,7 +36,7 @@ import {
   FetchSpecification,
   ProcessFetchSpecification,
 } from 'nestjs-base-service';
-import { UpdateUserDTO } from './dto/update.user.dto';
+import { BlockUsersBatchDTO, UpdateUserDTO } from './dto/update.user.dto';
 import { UpdateUserPasswordDTO } from './dto/update.user-password';
 import { IsMissingAclImplementation } from '@marxan-api/decorators/acl.decorator';
 import { PlatformAdminEntity } from './platform-admin/admin.api.entity';
@@ -194,6 +194,23 @@ export class UsersController {
     @Param('id', ParseUUIDPipe) userIdToDelete: string,
   ): Promise<void> {
     const result = await this.service.deleteAdmin(req.user.id, userIdToDelete);
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
+  }
+
+  @ApiOperation({
+    description: 'Block users in a batch.',
+  })
+  @ApiOkResponse()
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Patch('admins/block-users')
+  async blockUsers(
+    @Request() req: RequestWithAuthenticatedUser,
+    @Body() dto: BlockUsersBatchDTO,
+  ): Promise<void> {
+    const result = await this.service.blockUsers(req.user.id, dto.userIds);
     if (isLeft(result)) {
       throw new ForbiddenException();
     }

--- a/api/apps/api/test/steps/given-user-is-created.ts
+++ b/api/apps/api/test/steps/given-user-is-created.ts
@@ -9,9 +9,11 @@ import { Repository } from 'typeorm';
 
 export const GivenUserIsCreated = async (
   app: INestApplication,
+  emailUsername?: string,
+  pass?: string,
 ): Promise<AccessToken> => {
-  const email = faker.internet.email();
-  const password = faker.internet.password();
+  const email = emailUsername || faker.internet.email();
+  const password = pass || faker.internet.password();
   const displayName = faker.name.firstName();
 
   const user = new User();

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -433,5 +433,30 @@ describe('UsersModule (e2e)', () => {
       expect(WhenGettingAdminListResponse.body).toHaveLength(1);
       expect(WhenGettingAdminListResponse.body[0].userId).toEqual(adminUserId);
     });
+
+    test('A platform admin should be able to block existing users', async () => {
+      const username = `${v4()}@example.com`;
+      const password = v4();
+      const { user } = await GivenUserIsCreated(app, username, password);
+
+      cleanups.push(async () => {
+        await usersRepo.delete({ id: user.id });
+        return;
+      });
+
+      const WhenBlockingAUser = await request(app.getHttpServer())
+        .patch(`/api/v1/users/admins/block-users`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ userIds: [user.id] });
+      expect(WhenBlockingAUser.status).toEqual(200);
+
+      const WhenLoginAsBlockedUser = await request(app.getHttpServer())
+        .post('/auth/sign-in')
+        .send({
+          username,
+          password,
+        });
+      expect(WhenLoginAsBlockedUser.status).toEqual(401);
+    });
   });
 });


### PR DESCRIPTION
-Adds flag `isBlocked` for users table.
-Adds endpoint to block users in batches using array of Ids.
-Modifies instances where users can't be logged in if they are blocked/deleted.
-Adds tests for blocking endpoint.