### PR TITLE
make JSON payload size limit configurable for endpoint that allows setting planning unit lock status [MARXAN-1194]

### DIFF
--- a/api/apps/api/config/custom-environment-variables.json
+++ b/api/apps/api/config/custom-environment-variables.json
@@ -67,9 +67,9 @@
   },
   "fileUploads": {
     "limits": {
-      "singleGeometry": "API_UPLOAD_SINGLE_MAX_SIZE",
-      "complexGeometryWithoutProperties": "API_UPLOAD_COMPLEX_MAX_SIZE",
-      "complexGeometryWithProperties": "API_UPLOAD_COMPLEX_PROPERTIES_MAX_SIZE"
+      "singleGeometry": "API_UPLOAD_SINGLE_MAX_SIZE_MEBIBYTES",
+      "complexGeometryWithoutProperties": "API_UPLOAD_COMPLEX_MAX_SIZE_MEBIBYTES",
+      "complexGeometryWithProperties": "API_UPLOAD_COMPLEX_PROPERTIES_MAX_SIZE_MEBIBYTES"
     }
   },
   "sparkpost": {

--- a/api/apps/api/src/main.ts
+++ b/api/apps/api/src/main.ts
@@ -2,6 +2,8 @@ import { bootstrapSetUp } from '@marxan-api/bootstrap-app';
 import { addSwagger } from '@marxan-api/add-swagger';
 import { SwaggerModule } from '@nestjs/swagger';
 import { AppConfig } from '@marxan-api/utils/config.utils';
+import { json } from 'express';
+import { complexGeometry } from './modules/uploads';
 
 export async function bootstrap() {
   const app = await bootstrapSetUp();
@@ -9,6 +11,19 @@ export async function bootstrap() {
   const swaggerDocument = addSwagger(app);
 
   SwaggerModule.setup('/swagger', app, swaggerDocument);
+
+  // The endpoint through which users can supply planning unit lock in/out data
+  // via GeoJSON features will typically need to accept larger payloads than the
+  // default size limit for endpoints that accept JSON payloads.
+  // Here we use a larger limit than the one used for the shapefiles from which
+  // the GeoJSON payload for this endpoint is generated, to take into account
+  // the higher verbosity of JSON vs compressed Shapefile data.
+  app.use(
+    '/api/v1/scenarios/*/planning-units',
+    json({ limit: complexGeometry()?.fileSize }),
+  );
+  // For everything else, stick to the default
+  app.use(json({ limit: '100kb' }));
 
   await app.listen(AppConfig.get('api.daemonListenPort'));
 }

--- a/api/apps/api/src/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity.ts
+++ b/api/apps/api/src/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity.ts
@@ -1,5 +1,12 @@
 import { Role } from '@marxan-api/modules/access-control/role.api.entity';
-import { Check, Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+  Check,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
 import { User } from '@marxan-api/modules/users/user.api.entity';
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import { ScenarioRoles } from '@marxan-api/modules/access-control/scenarios-acl/dto/user-role-scenario.dto';
@@ -31,7 +38,6 @@ export class UsersScenariosApiEntity {
     default: false,
   })
   isImplicit!: boolean;
-
 
   @ManyToOne(() => Scenario, {
     onDelete: 'CASCADE',

--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -310,16 +310,17 @@ export class ProjectsCrudService extends AppBaseService<
     return entity;
   }
 
-  extendGetByIdQuery(query: SelectQueryBuilder<Project>, fetchSpecification?: FetchSpecification, info?: ProjectsRequest): SelectQueryBuilder<Project> {
+  extendGetByIdQuery(
+    query: SelectQueryBuilder<Project>,
+    fetchSpecification?: FetchSpecification,
+    info?: ProjectsRequest,
+  ): SelectQueryBuilder<Project> {
     /**
      * Bring in publicMetadata (if the project has been made public). This is
      * used in the `@AfterLoad()` event listener to set the `isPublic` property
      * to true for public projects.
      */
-    query.leftJoinAndSelect(
-      'project.publicMetadata',
-      'publicMetadata'
-    );
+    query.leftJoinAndSelect('project.publicMetadata', 'publicMetadata');
 
     return query;
   }
@@ -342,10 +343,7 @@ export class ProjectsCrudService extends AppBaseService<
     /**
      * @see extendGetByIdQuery()
      */
-    query.leftJoinAndSelect(
-      'project.publicMetadata',
-      'publicMetadata'
-    );
+    query.leftJoinAndSelect('project.publicMetadata', 'publicMetadata');
 
     if (namesSearch) {
       const nameSearchFilterField = 'nameSearchFilter' as const;

--- a/api/apps/api/src/modules/uploads/upload-limits.ts
+++ b/api/apps/api/src/modules/uploads/upload-limits.ts
@@ -1,16 +1,26 @@
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 
+/**
+ * Simple MiB to bytes conversion. Only for internal use:
+ */
+const mebibytesToBytes = (mebibytes: number): number => {
+  return mebibytes * 1024 * 1024;
+};
+
 export const simpleGeometry = (): MulterOptions['limits'] => ({
   fileSize: (() =>
-    AppConfig.get<number>('fileUploads.limits.singleGeometry', 1048576))(),
+    AppConfig.get<number>(
+      'fileUploads.limits.singleGeometry',
+      mebibytesToBytes(1),
+    ))(),
 });
 
 export const complexGeometry = (): MulterOptions['limits'] => ({
   fileSize: (() =>
     AppConfig.get<number>(
       'fileUploads.limits.complexGeometryWithoutProperties',
-      10485760,
+      mebibytesToBytes(10),
     ))(),
 });
 
@@ -18,6 +28,6 @@ export const complexGeometryWithProperties = (): MulterOptions['limits'] => ({
   fileSize: (() =>
     AppConfig.get<number>(
       'fileUploads.limits.complexGeometryWithProperties',
-      20971520,
+      mebibytesToBytes(20),
     ))(),
 });


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1194

Includes some lightweight refactor to use MiB as measurement unit - we won't need finer resolution (e.g. bytes) and using MiBs should, on the other hand, improve legibility of these bits of code.