### PR TITLE
enforce dependent properties when creating or updating projects [MARXAN-1290]

### DIFF
--- a/api/apps/api/src/modules/projects/dto/create.project.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/create.project.dto.ts
@@ -12,6 +12,7 @@ import {
 } from 'class-validator';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { ProjectHasPlanningAreaIdOrGadmIdIfGridIsGenerated } from '../validators/grid-shape.validator';
+import { HasCountryId, HasLevel1AreaId } from '../validators/gadm-id.validator';
 
 /**
  * @todo We have this dto partially duplicated in the geoprocessing service
@@ -47,11 +48,13 @@ export class CreateProjectDTO {
 
   @ApiPropertyOptional()
   @IsString()
+  @HasCountryId()
   @IsOptional()
   adminAreaLevel1Id?: string;
 
   @ApiPropertyOptional()
   @IsString()
+  @HasLevel1AreaId()
   @IsOptional()
   adminAreaLevel2Id?: string;
 

--- a/api/apps/api/src/modules/projects/dto/create.project.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/create.project.dto.ts
@@ -11,6 +11,7 @@ import {
   Length,
 } from 'class-validator';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
+import { ProjectHasPlanningAreaIdOrGadmIdIfGridIsGenerated } from '../validators/grid-shape.validator';
 
 /**
  * @todo We have this dto partially duplicated in the geoprocessing service
@@ -57,6 +58,7 @@ export class CreateProjectDTO {
   @ApiPropertyOptional()
   @IsOptional()
   @IsEnum(Object.values(PlanningUnitGridShape))
+  @ProjectHasPlanningAreaIdOrGadmIdIfGridIsGenerated()
   planningUnitGridShape?: PlanningUnitGridShape;
 
   @ApiPropertyOptional()

--- a/api/apps/api/src/modules/projects/validators/gadm-id.validator.ts
+++ b/api/apps/api/src/modules/projects/validators/gadm-id.validator.ts
@@ -1,0 +1,46 @@
+import { registerDecorator, ValidationArguments } from 'class-validator';
+import { CreateProjectDTO } from '../dto/create.project.dto';
+
+export function HasCountryId() {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'hasCountryId',
+      target: object.constructor,
+      propertyName: propertyName,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          const { countryId } = args.object as CreateProjectDTO;
+          if (value) {
+            return Boolean(countryId);
+          }
+          return true;
+        },
+        defaultMessage(_args: ValidationArguments) {
+          return 'A level 1 admin area id was specified but a matching country id was not provided.';
+        },
+      },
+    });
+  };
+}
+
+export function HasLevel1AreaId() {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'hasLevel1AreaId',
+      target: object.constructor,
+      propertyName: propertyName,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          const { adminAreaLevel1Id } = args.object as CreateProjectDTO;
+          if (value) {
+            return Boolean(adminAreaLevel1Id);
+          }
+          return true;
+        },
+        defaultMessage(_args: ValidationArguments) {
+          return 'A level 2 admin area id was specified but a matching level 1 admin area id was not provided.';
+        },
+      },
+    });
+  };
+}

--- a/api/apps/api/src/modules/projects/validators/grid-shape.validator.ts
+++ b/api/apps/api/src/modules/projects/validators/grid-shape.validator.ts
@@ -1,0 +1,41 @@
+import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
+import { registerDecorator, ValidationArguments } from 'class-validator';
+import { CreateProjectDTO } from '../dto/create.project.dto';
+
+export function ProjectHasPlanningAreaIdOrGadmIdIfGridIsGenerated() {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'hasPlanningAreaIdOrGadmId',
+      target: object.constructor,
+      propertyName: propertyName,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          const {
+            planningAreaId,
+            countryId,
+            adminAreaLevel1Id,
+            adminAreaLevel2Id,
+          } = args.object as CreateProjectDTO;
+          if (
+            value &&
+            [
+              PlanningUnitGridShape.Hexagon,
+              PlanningUnitGridShape.Square,
+            ].includes(value)
+          ) {
+            return Boolean(
+              planningAreaId ||
+                countryId ||
+                (countryId && adminAreaLevel1Id) ||
+                (countryId && adminAreaLevel1Id && adminAreaLevel2Id),
+            );
+          }
+          return true;
+        },
+        defaultMessage(_args: ValidationArguments) {
+          return 'When a regular planning grid is requested (hexagon or square) either a custom planning area or a GADM area gid must be provided.';
+        },
+      },
+    });
+  };
+}

--- a/api/apps/api/src/modules/projects/validators/grid-shape.validator.ts
+++ b/api/apps/api/src/modules/projects/validators/grid-shape.validator.ts
@@ -1,4 +1,5 @@
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
+import { Logger } from '@nestjs/common';
 import { registerDecorator, ValidationArguments } from 'class-validator';
 import { CreateProjectDTO } from '../dto/create.project.dto';
 
@@ -23,12 +24,16 @@ export function ProjectHasPlanningAreaIdOrGadmIdIfGridIsGenerated() {
               PlanningUnitGridShape.Square,
             ].includes(value)
           ) {
-            return Boolean(
+            const validationResult = Boolean(
               planningAreaId ||
                 countryId ||
                 (countryId && adminAreaLevel1Id) ||
                 (countryId && adminAreaLevel1Id && adminAreaLevel2Id),
             );
+            Logger.debug(`grid shape: ${value}`);
+            Logger.debug(`gids: ${planningAreaId} - ${countryId} - ${adminAreaLevel1Id} - ${adminAreaLevel2Id}`);
+            Logger.debug(`validationResult: ${validationResult}`);
+            return validationResult;
           }
           return true;
         },

--- a/api/apps/api/src/modules/projects/validators/grid-shape.validator.ts
+++ b/api/apps/api/src/modules/projects/validators/grid-shape.validator.ts
@@ -33,7 +33,7 @@ export function ProjectHasPlanningAreaIdOrGadmIdIfGridIsGenerated() {
           return true;
         },
         defaultMessage(_args: ValidationArguments) {
-          return 'When a regular planning grid is requested (hexagon or square) either a custom planning area or a GADM area gid must be provided.';
+          return 'When a regular planning grid is requested (hexagon or square) either a custom planning area id or a GADM area gid must be provided (including upper levels, if relevant).';
         },
       },
     });

--- a/api/apps/api/src/modules/users/users.controller.ts
+++ b/api/apps/api/src/modules/users/users.controller.ts
@@ -38,12 +38,15 @@ import {
   FetchSpecification,
   ProcessFetchSpecification,
 } from 'nestjs-base-service';
-import { BlockUsersBatchDTO, ExactEmailParamsDTO, UpdateUserDTO } from './dto/update.user.dto';
+import {
+  BlockUsersBatchDTO,
+  ExactEmailParamsDTO,
+  UpdateUserDTO,
+} from './dto/update.user.dto';
 import { UpdateUserPasswordDTO } from './dto/update.user-password';
 import { IsMissingAclImplementation } from '@marxan-api/decorators/acl.decorator';
 import { PlatformAdminEntity } from './platform-admin/admin.api.entity';
 import { isLeft } from 'fp-ts/lib/Either';
-import { assertDefined } from '@marxan/utils';
 
 @IsMissingAclImplementation()
 @UseGuards(JwtAuthGuard)

--- a/api/apps/api/test/e2e.config.ts
+++ b/api/apps/api/test/e2e.config.ts
@@ -132,8 +132,10 @@ export const E2E_CONFIG: {
         countryId: options?.countryCode,
         adminAreaLevel1Id: options?.adminAreaLevel1Id,
         adminAreaLevel2Id: options?.adminAreaLevel2Id,
-        planningUnitGridShape: PlanningUnitGridShape.Hexagon,
-        planningUnitAreakm2: 10,
+        planningUnitGridShape: options?.countryCode
+          ? PlanningUnitGridShape.Hexagon
+          : undefined,
+        planningUnitAreakm2: options?.countryCode ? 10 : undefined,
       }),
       complete: (options: CountryCodeInput): CreateProjectDTO => ({
         name: faker.random.words(5),

--- a/api/apps/api/test/e2e.config.ts
+++ b/api/apps/api/test/e2e.config.ts
@@ -118,11 +118,12 @@ export const E2E_CONFIG: {
       minimal: () => ({
         name: faker.random.words(5),
         organizationId: faker.random.uuid(),
+        countryId: 'BWA',
         planningUnitGridShape: PlanningUnitGridShape.Hexagon,
         planningUnitAreakm2: 10,
       }),
       minimalInGivenAdminArea: (options?: {
-        countryCode?: string;
+        countryCode: string;
         adminAreaLevel1Id?: string;
         adminAreaLevel2Id?: string;
         name?: string;

--- a/api/apps/api/test/implicit-permissions/implicit-permissions.fixtures.ts
+++ b/api/apps/api/test/implicit-permissions/implicit-permissions.fixtures.ts
@@ -36,7 +36,9 @@ export async function getFixtures() {
   const scenarioContributorRole = ScenarioRoles.scenario_contributor;
   const scenarioViewerRole = ScenarioRoles.scenario_viewer;
 
-  const { projectId } = await GivenProjectExists(app, creatorToken);
+  const { projectId } = await GivenProjectExists(app, creatorToken, {
+    countryCode: 'BWA',
+  });
 
   let scenarioId: string;
 

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -50,6 +50,9 @@ export const getFixtures = async () => {
       const { projectId, cleanup } = await GivenProjectExists(
         app,
         randomUserToken,
+        {
+          countryCode: 'BWA',
+        },
       );
       await publishedProjectsRepo.save({
         id: projectId,
@@ -85,7 +88,7 @@ export const getFixtures = async () => {
             adminAreaLevel1Id: null,
             adminAreaLevel2Id: null,
             bbox: null,
-            countryId: null,
+            countryId: expect.any(String),
             description: null,
             createdAt: expect.any(String),
             customProtectedAreas: [],


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1290

- when project grid shape is set to hex or square (for a generated regular grid), enforce that either a planning area id or a GADM id has been provided
- when a level1 GADM id is provided, a country id must also be provided
- when a level2 GADM id is provided, a level1 id must also be provided