### PR TITLE
avoid possible fk constraint violations

### DIFF
--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.ts
@@ -57,7 +57,6 @@ export class ExportPieceEventsHandler
     return {
       topic: data.componentId,
       kind,
-      externalId: ApiEventsService.composeExternalId(data.componentId, kind),
       data: {
         kind,
         ...output,
@@ -80,7 +79,6 @@ export class ExportPieceEventsHandler
     return {
       topic: componentId,
       kind,
-      externalId: ApiEventsService.composeExternalId(componentId, kind),
       data: {
         exportId,
         resourceId,

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
@@ -37,7 +37,6 @@ export class MarkExportAsFailedHandler
     await this.apiEvents.createIfNotExists({
       kind,
       topic: resourceId.value,
-      externalId: ApiEventsService.composeExternalId(exportId.value, kind),
       data: {
         exportId: exportId.value,
         resourceId: resourceId.value,

--- a/api/apps/api/src/modules/clone/infra/import/import-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import-piece.events-handler.ts
@@ -51,7 +51,6 @@ export class ImportPieceEventsHandler
     return {
       topic: data.componentId,
       kind,
-      externalId: ApiEventsService.composeExternalId(data.componentId, kind),
       data: {
         kind,
         ...output,
@@ -75,7 +74,6 @@ export class ImportPieceEventsHandler
     return {
       topic: componentId,
       kind,
-      externalId: ApiEventsService.composeExternalId(componentId, kind),
       data: {
         importId,
         pieceResourceId,

--- a/api/apps/api/src/modules/geo-features/processing/run.service.ts
+++ b/api/apps/api/src/modules/geo-features/processing/run.service.ts
@@ -78,9 +78,6 @@ export class RunService {
   ) {
     const job = await queue.add(`run`, data);
     await this.apiEvents.create({
-      // @todo: remove dependency on job.id - may lead to FK constraint
-      // violations as job ids are not guaranteed to be forever monotonic
-      externalId: job.id + kind,
       kind,
       topic: data.scenarioId,
       data: {

--- a/api/apps/api/src/modules/geo-features/processing/run.service.ts
+++ b/api/apps/api/src/modules/geo-features/processing/run.service.ts
@@ -78,6 +78,8 @@ export class RunService {
   ) {
     const job = await queue.add(`run`, data);
     await this.apiEvents.create({
+      // @todo: remove dependency on job.id - may lead to FK constraint
+      // violations as job ids are not guaranteed to be forever monotonic
       externalId: job.id + kind,
       kind,
       topic: data.scenarioId,

--- a/api/apps/api/src/modules/scenarios-features/intersect-with-pu/intersect-with-pu.handler.ts
+++ b/api/apps/api/src/modules/scenarios-features/intersect-with-pu/intersect-with-pu.handler.ts
@@ -35,6 +35,8 @@ export class IntersectWithPuHandler
       kind:
         API_EVENT_KINDS.scenario__featuresWithPuIntersection__submitted__v1__alpha1,
       topic: scenarioId,
+      // @todo: remove dependency on job.id - may lead to FK constraint
+      // violations as job ids are not guaranteed to be forever monotonic
       externalId: id,
       data: {},
     });

--- a/api/apps/api/src/modules/scenarios-features/intersect-with-pu/intersect-with-pu.handler.ts
+++ b/api/apps/api/src/modules/scenarios-features/intersect-with-pu/intersect-with-pu.handler.ts
@@ -35,9 +35,6 @@ export class IntersectWithPuHandler
       kind:
         API_EVENT_KINDS.scenario__featuresWithPuIntersection__submitted__v1__alpha1,
       topic: scenarioId,
-      // @todo: remove dependency on job.id - may lead to FK constraint
-      // violations as job ids are not guaranteed to be forever monotonic
-      externalId: id,
       data: {},
     });
   }

--- a/api/apps/api/src/modules/scenarios/blm-calibration/blm-calibration-events.service.ts
+++ b/api/apps/api/src/modules/scenarios/blm-calibration/blm-calibration-events.service.ts
@@ -29,7 +29,6 @@ export class BlmCalibrationEventsService implements EventFactory<JobData> {
     return {
       topic: data.scenarioId,
       kind: API_EVENT_KINDS.scenario__calibration__finished_v1_alpha1,
-      externalId: eventData.eventId,
     };
   }
 
@@ -40,7 +39,6 @@ export class BlmCalibrationEventsService implements EventFactory<JobData> {
     return {
       topic: data.scenarioId,
       kind: API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1,
-      externalId: eventData.eventId,
     };
   }
 }

--- a/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.handler.ts
+++ b/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.handler.ts
@@ -46,6 +46,8 @@ export class StartBlmCalibrationHandler
     await this.apiEvents.create({
       kind,
       topic: scenarioId,
+      // @todo: remove dependency on job.id - may lead to FK constraint
+      // violations as job ids are not guaranteed to be forever monotonic
       externalId: job.id + kind,
       data: {
         blmValues,

--- a/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.handler.ts
+++ b/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.handler.ts
@@ -46,9 +46,6 @@ export class StartBlmCalibrationHandler
     await this.apiEvents.create({
       kind,
       topic: scenarioId,
-      // @todo: remove dependency on job.id - may lead to FK constraint
-      // violations as job ids are not guaranteed to be forever monotonic
-      externalId: job.id + kind,
       data: {
         blmValues,
       },

--- a/api/apps/api/src/modules/scenarios/marxan-run/run.handler.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/run.handler.ts
@@ -46,9 +46,6 @@ export class RunHandler {
     await this.apiEvents.create({
       topic: scenario.id,
       kind,
-      // @todo: remove dependency on job.id - may lead to FK constraint
-      // violations as job ids are not guaranteed to be forever monotonic
-      externalId: job.id + kind,
     });
   }
 }

--- a/api/apps/api/src/modules/scenarios/marxan-run/run.handler.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/run.handler.ts
@@ -46,6 +46,8 @@ export class RunHandler {
     await this.apiEvents.create({
       topic: scenario.id,
       kind,
+      // @todo: remove dependency on job.id - may lead to FK constraint
+      // violations as job ids are not guaranteed to be forever monotonic
       externalId: job.id + kind,
     });
   }

--- a/api/apps/api/src/modules/scenarios/marxan-run/run.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/run.service.spec.ts
@@ -448,7 +448,6 @@ async function getFixtures() {
       expect(fixtures.fakeApiEvents.create).toBeCalledWith({
         topic: `scenario-1`,
         kind: API_EVENT_KINDS.scenario__run__submitted__v1__alpha1,
-        externalId: `${id}${API_EVENT_KINDS.scenario__run__submitted__v1__alpha1}`,
       });
     },
     ThenShouldAddJob() {

--- a/api/apps/api/src/modules/scenarios/protected-area/protected-area.service.ts
+++ b/api/apps/api/src/modules/scenarios/protected-area/protected-area.service.ts
@@ -52,7 +52,6 @@ export class ProtectedAreaService {
     const kind = API_EVENT_KINDS.scenario__protectedAreas__submitted__v1__alpha;
     try {
       await this.apiEvents.create({
-        externalId: job.id + kind,
         kind,
         topic: scenarioId,
         data: {


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1367

using BullMQ job ids to assemble `externalId` values for API events may lead to FK constraint violations as these job ids cannot be guaranteed to be forever monotonic.

This PR removes the use of `externalId` altogether for one kind of API events where this should not be needed, and adds `@todo` annotations to remove the dependency on job ids in other relevant code paths.