### PR TITLE
feat: export/import marxan settings

### DIFF
--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
@@ -63,22 +63,30 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
       throw new Error(errorMessage);
     }
 
-    const scenarioMetadata: ScenarioMetadataContent = JSON.parse(
+    const {
+      name,
+      blm,
+      description,
+      metadata,
+      numberOfRuns,
+    }: ScenarioMetadataContent = JSON.parse(
       stringScenarioMetadataOrError.right,
     );
 
-    await this.entityManager.query(
-      `
-      INSERT INTO scenarios(id, name, description, project_id)
-      VALUES ($1, $2, $3, $4)
-    `,
-      [
-        scenarioId,
-        scenarioMetadata.name,
-        scenarioMetadata.description,
-        projectId,
-      ],
-    );
+    await this.entityManager
+      .createQueryBuilder()
+      .insert()
+      .into('scenarios')
+      .values({
+        id: scenarioId,
+        name,
+        description,
+        blm,
+        number_of_runs: numberOfRuns,
+        metadata,
+        project_id: projectId,
+      })
+      .execute();
 
     return {
       importId: input.importId,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-metadata.ts
@@ -1,6 +1,11 @@
+import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
+
 export interface ScenarioMetadataContent {
   name: string;
   description?: string;
+  numberOfRuns?: number;
+  blm?: number;
+  metadata?: Scenario['metadata'];
 }
 
 export const scenarioMetadataRelativePath = {


### PR DESCRIPTION
This PR adds marxan settings export and import implementation. `ScenarioMetadataPieceExporter` adds `metadata`, `blm` and `number_of_runs` columns of `scenarios` table to `ScenarioMetadataContent` (file content of `scenario-metadata` clone piece) allowing `ScenarioMetadataPieceImporter` to import this data easily

### Feature relevant tickets

- [export piece (scenario): marxan settings](https://vizzuality.atlassian.net/browse/MARXAN-1352)
- [import piece (scenario): marxan settings](https://vizzuality.atlassian.net/browse/MARXAN-1353)