### PR TITLE
feat: scenario planning units data piece exporter

### DIFF
--- a/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.spec.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.spec.ts
@@ -96,7 +96,7 @@ const getFixtures = async () => {
     const pieces = [
       ClonePiece.ScenarioMetadata,
       ClonePiece.ScenarioProtectedAreas,
-      ClonePiece.ScenarioRunResults,
+      ClonePiece.ScenarioPlanningUnitsData,
     ];
     if (!projectExport) pieces.push(ClonePiece.ExportConfig);
     return pieces;

--- a/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.ts
@@ -75,7 +75,7 @@ export class ExportResourcePiecesAdapter implements ExportResourcePieces {
     const pieces: ExportComponent[] = [
       ExportComponent.newOne(id, ClonePiece.ScenarioMetadata),
       ExportComponent.newOne(id, ClonePiece.ScenarioProtectedAreas),
-      ExportComponent.newOne(id, ClonePiece.ScenarioRunResults),
+      ExportComponent.newOne(id, ClonePiece.ScenarioPlanningUnitsData),
     ];
 
     if (kind === ResourceKind.Scenario) {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
@@ -11,9 +11,10 @@ import { PlanningUnitsGridGeojsonPieceExporter } from './planning-units-grid-geo
 import { PlanningUnitsGridPieceExporter } from './planning-units-grid.piece-exporter';
 import { ProjectCustomProtectedAreasPieceExporter } from './project-custom-protected-areas.piece-exporter';
 import { ProjectMetadataPieceExporter } from './project-metadata.piece-exporter';
-import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-exporter';
 import { ScenarioMetadataPieceExporter } from './scenario-metadata.piece-exporter';
+import { ScenarioPlanningUnitsDataPieceExporter } from './scenario-planning-units-data.piece-exporter';
 import { ScenarioProtectedAreasPieceExporter } from './scenario-protected-areas.piece-exporter';
+import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-exporter';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { ScenarioProtectedAreasPieceExporter } from './scenario-protected-areas.
     ScenarioMetadataPieceExporter,
     ScenarioProtectedAreasPieceExporter,
     ScenarioRunResultsPieceExporter,
+    ScenarioPlanningUnitsDataPieceExporter,
     Logger,
   ],
 })

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom-geojson.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom-geojson.piece-exporter.ts
@@ -14,9 +14,9 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface PlanningAreaGeojsonSelectResult {
+type PlanningAreaGeojsonSelectResult = {
   geojson: string;
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom.piece-exporter.ts
@@ -15,14 +15,14 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface PlanningAreaSelectResult {
+type PlanningAreaSelectResult = {
   ewkb: Buffer;
-}
+};
 
-interface ProjectSelectResult {
+type ProjectSelectResult = {
   planning_unit_grid_shape: PlanningUnitGridShape;
   planning_unit_area_km2: number;
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.ts
@@ -15,14 +15,14 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface QueryResult {
+type QueryResult = {
   country_id: string;
   admin_area_l1_id?: string;
   admin_area_l2_id?: string;
   planning_unit_grid_shape: PlanningUnitGridShape;
   planning_unit_area_km2: number;
   bbox: number[];
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-units-grid-geojson.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-units-grid-geojson.piece-exporter.ts
@@ -14,10 +14,10 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface ProjectSelectResult {
+type ProjectSelectResult = {
   id: string;
   bbox: BBox;
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-units-grid.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-units-grid.piece-exporter.ts
@@ -14,10 +14,10 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface ProjectSelectResult {
+type ProjectSelectResult = {
   id: string;
   bbox: BBox;
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-custom-protected-areas.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-custom-protected-areas.piece-exporter.ts
@@ -15,10 +15,10 @@ import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-pie
 import { ProjectCustomProtectedAreasContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-custom-protected-areas';
 import { ProtectedArea } from '@marxan/protected-areas';
 
-interface ProjectCustomProtectedAreasSelectResult {
+type ProjectCustomProtectedAreasSelectResult = {
   fullName: string;
   ewkb: Buffer;
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-metadata.piece-exporter.ts
@@ -14,13 +14,13 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface SelectScenarioResult {
+type SelectScenarioResult = {
   name: string;
   description?: string;
   blm?: number;
   number_of_runs?: number;
   metadata?: Scenario['metadata'];
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
@@ -14,7 +14,7 @@ import {
 } from '../pieces/export-piece-processor';
 
 interface SelectResult {
-  lockin_status?: number;
+  lockin_status?: 1 | 2;
   xloc?: number;
   yloc?: number;
   protected_area?: number;

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
@@ -13,7 +13,7 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface SelectResult {
+type SelectResult = {
   lockin_status?: 1 | 2;
   xloc?: number;
   yloc?: number;
@@ -22,7 +22,7 @@ interface SelectResult {
   feature_list: string[];
   puid: number;
   cost: number;
-}
+};
 
 @Injectable()
 @PieceExportProvider()

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
@@ -1,0 +1,102 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
+import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
+import { ScenarioPlanningUnitsDataContent } from '@marxan/cloning/infrastructure/clone-piece-data/scenario-planning-units-data';
+import { FileRepository } from '@marxan/files-repository';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/Either';
+import { Readable } from 'stream';
+import { EntityManager } from 'typeorm';
+import {
+  ExportPieceProcessor,
+  PieceExportProvider,
+} from '../pieces/export-piece-processor';
+
+interface SelectResult {
+  lockin_status?: number;
+  xloc?: number;
+  yloc?: number;
+  protected_area?: number;
+  protected_by_default: boolean;
+  feature_list: string[];
+  puid: number;
+  cost: number;
+}
+
+@Injectable()
+@PieceExportProvider()
+export class ScenarioPlanningUnitsDataPieceExporter
+  implements ExportPieceProcessor {
+  constructor(
+    private readonly fileRepository: FileRepository,
+    @InjectEntityManager(geoprocessingConnections.default)
+    private readonly entityManager: EntityManager,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ScenarioPlanningUnitsDataPieceExporter.name);
+  }
+
+  isSupported(piece: ClonePiece): boolean {
+    return piece === ClonePiece.ScenarioPlanningUnitsData;
+  }
+
+  async run(input: ExportJobInput): Promise<ExportJobOutput> {
+    const result: SelectResult[] = await this.entityManager
+      .createQueryBuilder()
+      .select('*')
+      .from(
+        (qb) =>
+          qb
+            .select('*')
+            .from('scenarios_pu_data', 'inner_spd')
+            .where('scenario_id = :scenarioId', {
+              scenarioId: input.resourceId,
+            }),
+        'spd',
+      )
+      .innerJoin('projects_pu', 'ppu', 'ppu.id = spd.project_pu_id')
+      .innerJoin(
+        'scenarios_pu_cost_data',
+        'spcd',
+        'spd.id = spcd.scenarios_pu_data_id',
+      )
+      .execute();
+
+    const fileContent: ScenarioPlanningUnitsDataContent = {
+      planningUnitsData: result.map((row) => ({
+        cost: row.cost,
+        featureList: row.feature_list,
+        protectedArea: row.protected_area,
+        protectedByDefault: row.protected_by_default,
+        puid: row.puid,
+        lockinStatus: row.lockin_status,
+        xloc: row.xloc,
+        yloc: row.yloc,
+      })),
+    };
+
+    const outputFile = await this.fileRepository.save(
+      Readable.from(JSON.stringify(fileContent)),
+      `json`,
+    );
+
+    if (isLeft(outputFile)) {
+      const errorMessage = `${ScenarioPlanningUnitsDataPieceExporter.name} - Scenario - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return {
+      ...input,
+      uris: ClonePieceUrisResolver.resolveFor(
+        ClonePiece.ScenarioPlanningUnitsData,
+        outputFile.right,
+        {
+          kind: input.resourceKind,
+          scenarioId: input.resourceId,
+        },
+      ),
+    };
+  }
+}

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-protected-areas.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-protected-areas.piece-exporter.ts
@@ -14,21 +14,21 @@ import {
   PieceExportProvider,
 } from '../pieces/export-piece-processor';
 
-interface SelectScenarioResult {
+type SelectScenarioResult = {
   id: string;
   protectedAreasIds?: string[];
   wdpaThreshold?: number;
-}
+};
 
-interface CustomProtectedArea {
+type CustomProtectedArea = {
   ewkb: Buffer;
   name: string;
-}
+};
 
-interface WdpaProtectedArea {
+type WdpaProtectedArea = {
   ewkb: Buffer;
   wdpaid: number;
-}
+};
 
 type SelectWdpaResult = WdpaProtectedArea | CustomProtectedArea;
 

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/planning-area-custom.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/planning-area-custom.ts
@@ -1,9 +1,9 @@
 import { PlanningUnitGridShape } from '../../../../scenarios-planning-unit/src';
 
-export interface PlanningAreaCustomContent {
+export type PlanningAreaCustomContent = {
   planningAreaGeom: number[];
   puGridShape: PlanningUnitGridShape;
   puAreaKm2: number;
-}
+};
 
 export const planningAreaCustomRelativePath = 'planning-area.json';

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/planning-area-gadm.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/planning-area-gadm.ts
@@ -1,12 +1,12 @@
 import { PlanningUnitGridShape } from '../../../../scenarios-planning-unit/src';
 
-export interface PlanningAreaGadmContent {
+export type PlanningAreaGadmContent = {
   country?: string;
   l1?: string;
   l2?: string;
   puGridShape: PlanningUnitGridShape;
   planningUnitAreakm2: number;
   bbox: number[];
-}
+};
 
 export const planningAreaGadmRelativePath = 'planning-area.json';

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-custom-protected-areas.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-custom-protected-areas.ts
@@ -1,7 +1,7 @@
 export const projectCustomProtectedAreasRelativePath =
   'project-custom-protected-areas.json';
 
-export interface ProjectCustomProtectedAreasContent {
+export type ProjectCustomProtectedAreasContent = {
   fullName: string;
   ewkb: number[];
-}
+};

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
@@ -1,6 +1,6 @@
-export interface ProjectMetadataContent {
+export type ProjectMetadataContent = {
   name: string;
   description?: string;
-}
+};
 
 export const projectMetadataRelativePath = 'project-metadata.json';

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-metadata.ts
@@ -1,12 +1,12 @@
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 
-export interface ScenarioMetadataContent {
+export type ScenarioMetadataContent = {
   name: string;
   description?: string;
   numberOfRuns?: number;
   blm?: number;
   metadata?: Scenario['metadata'];
-}
+};
 
 export const scenarioMetadataRelativePath = {
   scenarioImport: `scenario-metadata.json`,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
@@ -4,7 +4,7 @@ export const scenarioPlanningUnitsDataRelativePath = {
     `scenarios/${oldScenarioId}/scenario-pu-data.json`,
 };
 
-interface PlanningUnitData {
+type PlanningUnitData = {
   puid: number;
   cost: number;
   lockinStatus?: 1 | 2;
@@ -13,8 +13,8 @@ interface PlanningUnitData {
   protectedArea?: number;
   protectedByDefault: boolean;
   featureList: string[];
-}
+};
 
-export interface ScenarioPlanningUnitsDataContent {
+export type ScenarioPlanningUnitsDataContent = {
   planningUnitsData: PlanningUnitData[];
-}
+};

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
@@ -3,3 +3,18 @@ export const scenarioPlanningUnitsDataRelativePath = {
   projectImport: (oldScenarioId: string) =>
     `scenarios/${oldScenarioId}/scenario-pu-data.json`,
 };
+
+interface PlanningUnitData {
+  puid: number;
+  cost: number;
+  lockinStatus?: number;
+  xloc?: number;
+  yloc?: number;
+  protectedArea?: number;
+  protectedByDefault: boolean;
+  featureList: string[];
+}
+
+export interface ScenarioPlanningUnitsDataContent {
+  planningUnitsData: PlanningUnitData[];
+}

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
@@ -7,7 +7,7 @@ export const scenarioPlanningUnitsDataRelativePath = {
 interface PlanningUnitData {
   puid: number;
   cost: number;
-  lockinStatus?: number;
+  lockinStatus?: 1 | 2;
   xloc?: number;
   yloc?: number;
   protectedArea?: number;

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-protected-areas.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-protected-areas.ts
@@ -4,11 +4,11 @@ export const scenarioProtectedAreasRelativePath = {
     `scenarios/${oldScenarioId}/scenario-protected-areas.json`,
 };
 
-export interface ScenarioProtectedAreasContent {
+export type ScenarioProtectedAreasContent = {
   wdpa: number[];
   customProtectedAreas: {
     name: string;
     geom: number[];
   }[];
   threshold?: number;
-}
+};


### PR DESCRIPTION
This PR adds piece exporter for `ScenarioPlanningUnitsData` `ClonePiece`. Scenario planning units data is composed by the following items:

- lock status
- cost
- feature list
- protected area percentage and if it is protected by default

### Feature relevant tickets

- [export piece (scenario): lock status (locked by default, or manually locked in or out) per planning unit](https://vizzuality.atlassian.net/browse/MARXAN-1350)
- [export piece (scenario): cost data per planning unit](https://vizzuality.atlassian.net/browse/MARXAN-1348)