### PR TITLE
MARXAN-1380-unpublish-public-project

### DIFF
--- a/api/apps/api/src/modules/published-project/controllers/publish-project.controller.ts
+++ b/api/apps/api/src/modules/published-project/controllers/publish-project.controller.ts
@@ -2,7 +2,6 @@ import {
   BadRequestException,
   Controller,
   DefaultValuePipe,
-  Delete,
   ForbiddenException,
   Get,
   InternalServerErrorException,
@@ -96,7 +95,7 @@ export class PublishProjectController {
     return;
   }
 
-  @Delete(':id/unpublish')
+  @Post(':id/unpublish')
   @ApiNoContentResponse()
   @ApiNotFoundResponse()
   @ApiForbiddenResponse()
@@ -177,14 +176,14 @@ export class PublishProjectController {
   async clearUnderModeration(
     @Param('id') id: string,
     @Request() req: RequestWithAuthenticatedUser,
-    @Query('withUnpublish', new DefaultValuePipe(false), ParseBoolPipe)
-    withUnpublish: boolean,
+    @Query('alsoUnpublish', new DefaultValuePipe(false), ParseBoolPipe)
+    alsoUnpublish: boolean,
   ): Promise<void> {
     const result = await this.publishedProjectService.changeModerationStatus(
       id,
       req.user.id,
       false,
-      withUnpublish,
+      alsoUnpublish,
     );
 
     if (isLeft(result)) {

--- a/api/apps/api/src/modules/published-project/controllers/publish-project.controller.ts
+++ b/api/apps/api/src/modules/published-project/controllers/publish-project.controller.ts
@@ -229,7 +229,7 @@ export class PublishProjectController {
     description: `A free search over names`,
   })
   @Get('published-projects/by-admin')
-  async findOneByAdmin(
+  async findAllByAdmin(
     @ProcessFetchSpecification() fetchSpecification: FetchSpecification,
     @Req() req: RequestWithAuthenticatedUser,
     @Query('q') namesSearch?: string,
@@ -250,7 +250,7 @@ export class PublishProjectController {
   @ApiOperation({ description: 'Find public project by id for admins.' })
   @ApiOkResponse({ type: PublishedProjectResultSingular })
   @Get('published-projects/:id/by-admin')
-  async findAll(
+  async findOneByAdmin(
     @Req() req: RequestWithAuthenticatedUser,
     @Param('id') id: string,
   ): Promise<PublishedProjectResultSingular> {

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -48,15 +48,16 @@ export class PublishedProjectCrudService extends AppBaseService<
     fetchSpecification: FetchSpecification,
     info?: ProjectsRequest,
   ): Promise<SelectQueryBuilder<PublishedProject>> {
-    let showUnderModerationPublishedProjects = false;
     const id = info?.authenticatedUser?.id;
-    if (id && (await this.usersService.isPlatformAdmin(id))) {
-      showUnderModerationPublishedProjects = true;
-    }
 
-    query.andWhere('published_project.underModeration = :underModeration', {
-      underModeration: showUnderModerationPublishedProjects,
-    });
+    /*
+      If we are listing projects for non-authenticated requests or for
+      authenticated users who are not admin, projects under moderation
+      will be hiding from the listing.
+    */
+    if (!id || !(await this.usersService.isPlatformAdmin(id))) {
+      query.andWhere('published_project.underModeration is false');
+    }
 
     return query;
   }

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -48,14 +48,14 @@ export class PublishedProjectCrudService extends AppBaseService<
     fetchSpecification: FetchSpecification,
     info?: ProjectsRequest,
   ): Promise<SelectQueryBuilder<PublishedProject>> {
-    const id = info?.authenticatedUser?.id;
+    const userId = info?.authenticatedUser?.id;
 
     /*
       If we are listing projects for non-authenticated requests or for
       authenticated users who are not admin, projects under moderation
       will be hiding from the listing.
     */
-    if (!id || !(await this.usersService.isPlatformAdmin(id))) {
+    if (!userId || !(await this.usersService.isPlatformAdmin(userId))) {
       query.andWhere('published_project.underModeration is false');
     }
 

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -100,7 +100,7 @@ export class PublishedProjectService {
     id: string,
     requestingUserId: string,
     status: boolean,
-    withUnpublish?: boolean,
+    alsoUnpublish?: boolean,
   ): Promise<Either<errors | typeof sameUnderModerationStatus, true>> {
     const existingPublicProject = await this.crudService.getById(
       id,
@@ -123,7 +123,7 @@ export class PublishedProjectService {
       underModeration: !existingPublicProject.underModeration,
     });
 
-    if (withUnpublish) {
+    if (alsoUnpublish) {
       await this.unpublish(id, requestingUserId);
     }
 

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -98,6 +98,9 @@ export const getFixtures = async () => {
     ThenNoContentIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(204);
     },
+    ThenBadRequestIsReturned: (response: request.Response) => {
+      expect(response.status).toEqual(400);
+    },
     ThenNotFoundIsReturned: (response: request.Response) => {
       expect(response.status).toEqual(404);
     },
@@ -176,6 +179,10 @@ export const getFixtures = async () => {
       await request(app.getHttpServer())
         .post(`/api/v1/projects/${projectId}/publish`)
         .set('Authorization', `Bearer ${randomUserToken}`),
+    WhenUnpublishingAProjectAsProjectOwner: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .delete(`/api/v1/projects/${projectId}/unpublish`)
+        .set('Authorization', `Bearer ${randomUserToken}`),
     WhenPlacingAPublicProjectUnderModerationAsAdmin: async (
       projectId: string,
     ) =>
@@ -193,6 +200,14 @@ export const getFixtures = async () => {
     ) =>
       await request(app.getHttpServer())
         .patch(`/api/v1/projects/${projectId}/moderation-status/clear`)
+        .set('Authorization', `Bearer ${adminUserToken}`),
+    WhenClearingUnderModerationStatusAndUnpublishingAsAdmin: async (
+      projectId: string,
+    ) =>
+      await request(app.getHttpServer())
+        .patch(
+          `/api/v1/projects/${projectId}/moderation-status/clear?withUnpublish=true`,
+        )
         .set('Authorization', `Bearer ${adminUserToken}`),
     WhenClearingUnderModerationStatusFromAPublicProjectNotAsAdmin: async (
       projectId: string,

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -181,7 +181,7 @@ export const getFixtures = async () => {
         .set('Authorization', `Bearer ${randomUserToken}`),
     WhenUnpublishingAProjectAsProjectOwner: async (projectId: string) =>
       await request(app.getHttpServer())
-        .delete(`/api/v1/projects/${projectId}/unpublish`)
+        .post(`/api/v1/projects/${projectId}/unpublish`)
         .set('Authorization', `Bearer ${randomUserToken}`),
     WhenPlacingAPublicProjectUnderModerationAsAdmin: async (
       projectId: string,
@@ -206,7 +206,7 @@ export const getFixtures = async () => {
     ) =>
       await request(app.getHttpServer())
         .patch(
-          `/api/v1/projects/${projectId}/moderation-status/clear?withUnpublish=true`,
+          `/api/v1/projects/${projectId}/moderation-status/clear?alsoUnpublish=true`,
         )
         .set('Authorization', `Bearer ${adminUserToken}`),
     WhenClearingUnderModerationStatusFromAPublicProjectNotAsAdmin: async (

--- a/api/apps/api/test/project/public-projects.e2e-spec.ts
+++ b/api/apps/api/test/project/public-projects.e2e-spec.ts
@@ -123,7 +123,7 @@ test(`when unpublishing a public project as a project owner`, async () => {
   fixtures.ThenCreatedIsReturned(response);
 
   response = await fixtures.WhenUnpublishingAProjectAsProjectOwner(projectId);
-  fixtures.ThenOkIsReturned(response);
+  fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenGettingPublicProjects();
   fixtures.ThenNoProjectIsAvailable(response);
 });

--- a/api/apps/api/test/project/public-projects.e2e-spec.ts
+++ b/api/apps/api/test/project/public-projects.e2e-spec.ts
@@ -123,7 +123,7 @@ test(`when unpublishing a public project as a project owner`, async () => {
   fixtures.ThenCreatedIsReturned(response);
 
   response = await fixtures.WhenUnpublishingAProjectAsProjectOwner(projectId);
-  fixtures.ThenNoContentIsReturned(response);
+  fixtures.ThenOkIsReturned(response);
   response = await fixtures.WhenGettingPublicProjects();
   fixtures.ThenNoProjectIsAvailable(response);
 });
@@ -155,7 +155,7 @@ test(`when unpublishing a public project that is under moderation as a platform 
   response = await fixtures.WhenClearingUnderModerationStatusAndUnpublishingAsAdmin(
     projectId,
   );
-  fixtures.ThenBadRequestIsReturned(response);
+  fixtures.ThenOkIsReturned(response);
   response = await fixtures.WhenGettingPublicProjects();
   fixtures.ThenNoProjectIsAvailable(response);
 });

--- a/api/apps/api/test/project/public-projects.e2e-spec.ts
+++ b/api/apps/api/test/project/public-projects.e2e-spec.ts
@@ -116,3 +116,46 @@ test(`when clearing under moderation status from a public project not as platfor
   response = await fixtures.WhenGettingPublicProject(projectId);
   fixtures.ThenForbiddenIsReturned(response);
 });
+
+test(`when unpublishing a public project as a project owner`, async () => {
+  const projectId = await fixtures.GivenPrivateProjectWasCreated();
+  let response = await fixtures.WhenPublishingAProject(projectId);
+  fixtures.ThenCreatedIsReturned(response);
+
+  response = await fixtures.WhenUnpublishingAProjectAsProjectOwner(projectId);
+  fixtures.ThenNoContentIsReturned(response);
+  response = await fixtures.WhenGettingPublicProjects();
+  fixtures.ThenNoProjectIsAvailable(response);
+});
+
+test(`when unpublishing a public project that is under moderation as a project owner`, async () => {
+  const projectId = await fixtures.GivenPrivateProjectWasCreated();
+  let response = await fixtures.WhenPublishingAProject(projectId);
+  fixtures.ThenCreatedIsReturned(response);
+  response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
+    projectId,
+  );
+  fixtures.ThenOkIsReturned(response);
+
+  response = await fixtures.WhenUnpublishingAProjectAsProjectOwner(projectId);
+  fixtures.ThenBadRequestIsReturned(response);
+  response = await fixtures.WhenGettingPublicProjects();
+  fixtures.ThenNoProjectIsAvailable(response);
+});
+
+test(`when unpublishing a public project that is under moderation as a platform admin`, async () => {
+  const projectId = await fixtures.GivenPrivateProjectWasCreated();
+  let response = await fixtures.WhenPublishingAProject(projectId);
+  fixtures.ThenCreatedIsReturned(response);
+  response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
+    projectId,
+  );
+  fixtures.ThenOkIsReturned(response);
+
+  response = await fixtures.WhenClearingUnderModerationStatusAndUnpublishingAsAdmin(
+    projectId,
+  );
+  fixtures.ThenBadRequestIsReturned(response);
+  response = await fixtures.WhenGettingPublicProjects();
+  fixtures.ThenNoProjectIsAvailable(response);
+});


### PR DESCRIPTION
-Adds endpoint for `project_owners` to unpublish a public project.
-Adds conditions to when clearing a project from under moderation to be able to outright unpublish the project straightaway.
-Adds tests for the new endpoint and changes in the workflow.


Depends on #896 being closed beforehand.