### PR TITLE
fix: planning units grid piece importer and scenario protected areas piece exporter

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
@@ -4,6 +4,7 @@ import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { ProjectMetadataContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-metadata';
 import { FileRepository } from '@marxan/files-repository';
+import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
@@ -36,8 +37,9 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
     const [projectData]: {
       name: string;
       description: string;
+      planning_unit_grid_shape: PlanningUnitGridShape;
     }[] = await this.entityManager.query(
-      `SELECT projects.name, projects.description FROM projects WHERE projects.id = $1`,
+      `SELECT name, description, planning_unit_grid_shape FROM projects WHERE projects.id = $1`,
       [input.resourceId],
     );
 
@@ -50,6 +52,7 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
     const fileContent: ProjectMetadataContent = {
       name: projectData.name,
       description: projectData.description,
+      planningUnitGridShape: projectData.planning_unit_grid_shape,
     };
 
     const outputFile = await this.fileRepository.save(

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-protected-areas.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-protected-areas.piece-exporter.ts
@@ -68,7 +68,10 @@ export class ScenarioProtectedAreasPieceExporter
     }
 
     const geoQb = this.geoprocessingEntityManager.createQueryBuilder();
-    const protectedAreas: SelectWdpaResult[] = scenario.protectedAreasIds
+
+    const scenarioHasProtectedAreas =
+      scenario.protectedAreasIds && scenario.protectedAreasIds.length > 0;
+    const protectedAreas: SelectWdpaResult[] = scenarioHasProtectedAreas
       ? await geoQb
           .select('wdpaid')
           .addSelect('ST_AsEWKB(the_geom)', 'ewkb')

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-area-custom.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-area-custom.piece-importer.ts
@@ -87,15 +87,13 @@ export class PlanningAreaCustomPieceImporter implements ImportPieceProcessor {
         `
         UPDATE projects
         SET
-          planning_unit_grid_shape = $2,
-          planning_unit_area_km2 = $3,
-          bbox = $4,
-          planning_area_geometry_id = $5
+          planning_unit_area_km2 = $2,
+          bbox = $3,
+          planning_area_geometry_id = $4
         WHERE id = $1
       `,
         [
           importResourceId,
-          planningAreaGadm.puGridShape,
           planningAreaGadm.puAreaKm2,
           JSON.stringify(planningArea.bbox),
           planningArea.id,

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-area-gadm.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-area-gadm.piece-importer.ts
@@ -71,9 +71,8 @@ export class PlanningAreaGadmPieceImporter implements ImportPieceProcessor {
           country_id = $2, 
           admin_area_l1_id = $3, 
           admin_area_l2_id = $4,
-          planning_unit_grid_shape = $5,
-          planning_unit_area_km2 = $6,
-          bbox = $7
+          planning_unit_area_km2 = $5,
+          bbox = $6
         WHERE id = $1
       `,
       [
@@ -81,7 +80,6 @@ export class PlanningAreaGadmPieceImporter implements ImportPieceProcessor {
         planningAreaGadm.country,
         planningAreaGadm.l1,
         planningAreaGadm.l2,
-        planningAreaGadm.puGridShape,
         planningAreaGadm.planningUnitAreakm2,
         JSON.stringify(planningAreaGadm.bbox),
       ],

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-units-grid.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-units-grid.piece-importer.ts
@@ -141,7 +141,7 @@ export class PlanningUnitsGridPieceImporter implements ImportPieceProcessor {
               try {
                 const geomPUs = processableData
                   .split('\n')
-                  .map(this.parseGridFileLine);
+                  .map((pu) => this.parseGridFileLine(pu));
 
                 const geometries: {
                   id: string;

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-units-grid.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-units-grid.piece-importer.ts
@@ -18,6 +18,10 @@ import {
   PieceImportProvider,
 } from '../pieces/import-piece-processor';
 
+type ProjectSelectResult = {
+  geomType: PlanningUnitGridShape;
+};
+
 @Injectable()
 @PieceImportProvider()
 export class PlanningUnitsGridPieceImporter implements ImportPieceProcessor {
@@ -25,6 +29,8 @@ export class PlanningUnitsGridPieceImporter implements ImportPieceProcessor {
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.default)
     private readonly geoprocessingEntityManager: EntityManager,
+    @InjectEntityManager(geoprocessingConnections.apiDB)
+    private readonly apiEntityManager: EntityManager,
     private readonly logger: Logger,
   ) {
     this.logger.setContext(PlanningUnitsGridPieceImporter.name);
@@ -84,7 +90,9 @@ export class PlanningUnitsGridPieceImporter implements ImportPieceProcessor {
         geom: '\\x' + Buffer.from(JSON.parse(geom) as number[]).toString('hex'),
       };
     }
-    throw new Error('unknown line format');
+    const message = 'unknown line format';
+    this.logger.error(message);
+    throw new Error(message);
   }
 
   private async processGridFile(
@@ -93,6 +101,21 @@ export class PlanningUnitsGridPieceImporter implements ImportPieceProcessor {
     projectId: string,
     transactionalEntityManager: EntityManager,
   ) {
+    const [{ geomType }]: [
+      ProjectSelectResult,
+    ] = await this.apiEntityManager
+      .createQueryBuilder()
+      .select('planning_unit_grid_shape', 'geomType')
+      .from('projects', 'p')
+      .where('id = :projectId', { projectId })
+      .execute();
+
+    if (!geomType) {
+      const errorMessage = `Project with id ${projectId} has undefined planning unit grid shape`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
     return new Promise<void>((resolve, reject) => {
       let lastChunkIncompletedData = '';
 
@@ -139,17 +162,14 @@ export class PlanningUnitsGridPieceImporter implements ImportPieceProcessor {
                     FROM uuid_geom
                       LEFT JOIN puid_geom ON ST_Equals(uuid_geom.the_geom, puid_geom.geom)
                   `,
-                  [
-                    PlanningUnitGridShape.FromShapefile,
-                    JSON.stringify(geomPUs),
-                  ],
+                  [geomType, JSON.stringify(geomPUs)],
                 );
 
                 transactionalEntityManager.save(
                   ProjectsPuEntity,
                   geometries.map((geom) => ({
                     projectId,
-                    geomType: PlanningUnitGridShape.FromShapefile,
+                    geomType,
                     puid: geom.puid,
                     geomId: geom.id,
                   })),

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
@@ -79,14 +79,15 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
 
     await this.entityManager.query(
       `
-      INSERT INTO projects(id, name, description, organization_id)
-      VALUES ($1, $2, $3, $4)
+      INSERT INTO projects(id, name, description, organization_id, planning_unit_grid_shape)
+      VALUES ($1, $2, $3, $4, $5)
     `,
       [
         importResourceId,
         projectMetadata.name,
         projectMetadata.description,
         organizationId,
+        projectMetadata.planningUnitGridShape,
       ],
     );
 

--- a/api/apps/geoprocessing/test/integration/clonning/planning-units-grid.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-units-grid.piece-importer.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { PlanningUnitsGridPieceImporter } from '@marxan-geoprocessing/import/pieces-importers/planning-units-grid.piece-importer';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import {
   PlanningUnitsGeom,
@@ -11,15 +12,19 @@ import {
 } from '@marxan/cloning/domain';
 import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { FileRepository, FileRepositoryModule } from '@marxan/files-repository';
+import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import {
+  getEntityManagerToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
 import * as archiver from 'archiver';
 import { isLeft } from 'fp-ts/lib/Either';
 import { In, Repository } from 'typeorm';
 import { v4 } from 'uuid';
-import { PlanningUnitsGridPieceImporter } from '../../../src/import/pieces-importers/planning-units-grid.piece-importer';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -86,6 +91,10 @@ const getFixtures = async () => {
     providers: [
       PlanningUnitsGridPieceImporter,
       { provide: Logger, useValue: { error: () => {}, setContext: () => {} } },
+      {
+        provide: getEntityManagerToken(geoprocessingConnections.apiDB.name),
+        useClass: FakeEntityManager,
+      },
     ],
   }).compile();
 
@@ -235,3 +244,13 @@ const getFixtures = async () => {
     },
   };
 };
+
+class FakeEntityManager {
+  createQueryBuilder = () => this;
+  select = () => this;
+  from = () => this;
+  where = () => this;
+  async execute() {
+    return [{ geomType: PlanningUnitGridShape.Square }];
+  }
+}

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
@@ -1,6 +1,9 @@
+import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
+
 export type ProjectMetadataContent = {
   name: string;
   description?: string;
+  planningUnitGridShape?: PlanningUnitGridShape;
 };
 
 export const projectMetadataRelativePath = 'project-metadata.json';


### PR DESCRIPTION
This PR fixes `PlanningUnitsGrid` piece importer and `ScenarioProtectedAreas` piece exporter:

- `PlanningUnitsGridPieceImporter` was not taking into consideration the type of planning units geometries . It was setting `FromShapefile` by default. `type` column of `planning_units_geom` table was containing incorrect values for that reason
- `ScenarioProtectedAreasPieceExporter` was not working when array of protected areas ids was empty (PostgreSQL `IN` operator doesn't support empty arrays)
- `ProjectMetadataContent` now contains the type of planning units geometries. `PlanningAreaGadmPieceImporter` and `PlanningAreaCustomPieceImporter` no longer updates this field of `projects` table.