### PR TITLE
feat: scenario planning units data piece importer

### DIFF
--- a/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
@@ -2,12 +2,13 @@ import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { FileRepositoryModule } from '@marxan/files-repository';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { PlanningAreaGadmPieceImporter } from './planning-area-gadm.piece-importer';
 import { PlanningAreaCustomPieceImporter } from './planning-area-custom.piece-importer';
-import { ProjectMetadataPieceImporter } from './project-metadata.piece-importer';
-import { ScenarioMetadataPieceImporter } from './scenario-metadata.piece-importer';
+import { PlanningAreaGadmPieceImporter } from './planning-area-gadm.piece-importer';
 import { PlanningUnitsGridPieceImporter } from './planning-units-grid.piece-importer';
 import { ProjectCustomProtectedAreasPieceImporter } from './project-custom-protected-areas.piece-importer';
+import { ProjectMetadataPieceImporter } from './project-metadata.piece-importer';
+import { ScenarioMetadataPieceImporter } from './scenario-metadata.piece-importer';
+import { ScenarioPlanningUnitsDataPieceImporter } from './scenario-planning-units-data.piece-importer';
 import { ScenarioProtectedAreasPieceImporter } from './scenario-protected-areas.piece-importer';
 
 @Module({
@@ -23,6 +24,7 @@ import { ScenarioProtectedAreasPieceImporter } from './scenario-protected-areas.
     PlanningUnitsGridPieceImporter,
     ProjectCustomProtectedAreasPieceImporter,
     ScenarioProtectedAreasPieceImporter,
+    ScenarioPlanningUnitsDataPieceImporter,
     { provide: Logger, useClass: Logger, scope: Scope.TRANSIENT },
   ],
 })

--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-planning-units-data.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-planning-units-data.piece-importer.ts
@@ -1,0 +1,116 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
+import { ScenarioPlanningUnitsDataContent } from '@marxan/cloning/infrastructure/clone-piece-data/scenario-planning-units-data';
+import { FileRepository } from '@marxan/files-repository';
+import { ScenariosPuPaDataGeo } from '@marxan/scenarios-planning-unit';
+import { toLockEnum } from '@marxan/scenarios-planning-unit/scenarios-planning-unit.geo.entity';
+import { extractFile } from '@marxan/utils';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/lib/Either';
+import { EntityManager } from 'typeorm';
+import {
+  ImportPieceProcessor,
+  PieceImportProvider,
+} from '../pieces/import-piece-processor';
+
+@Injectable()
+@PieceImportProvider()
+export class ScenarioPlanningUnitsDataPieceImporter
+  implements ImportPieceProcessor {
+  constructor(
+    private readonly fileRepository: FileRepository,
+    @InjectEntityManager(geoprocessingConnections.default)
+    private readonly entityManager: EntityManager,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ScenarioPlanningUnitsDataPieceImporter.name);
+  }
+
+  isSupported(piece: ClonePiece): boolean {
+    return piece === ClonePiece.ScenarioPlanningUnitsData;
+  }
+
+  async run(input: ImportJobInput): Promise<ImportJobOutput> {
+    const {
+      importResourceId: projectId,
+      componentResourceId: scenarioId,
+      uris,
+      piece,
+    } = input;
+
+    if (uris.length !== 1) {
+      const errorMessage = `uris array has an unexpected amount of elements: ${uris.length}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    const [scenarioPlanningUnitsDataLocation] = uris;
+
+    const readableOrError = await this.fileRepository.get(
+      scenarioPlanningUnitsDataLocation.uri,
+    );
+
+    if (isLeft(readableOrError)) {
+      const errorMessage = `File with piece data for ${piece}/${scenarioId} is not available at ${scenarioPlanningUnitsDataLocation.uri}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const stringScenarioPlanningUnitsDataOrError = await extractFile(
+      readableOrError.right,
+      scenarioPlanningUnitsDataLocation.relativePath,
+    );
+    if (isLeft(stringScenarioPlanningUnitsDataOrError)) {
+      const errorMessage = `Scenario planning units data file extraction failed: ${scenarioPlanningUnitsDataLocation.relativePath}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const scenariosPlanningUnitsData: ScenarioPlanningUnitsDataContent = JSON.parse(
+      stringScenarioPlanningUnitsDataOrError.right,
+    );
+
+    await this.entityManager.transaction(async (em) => {
+      const projectPuIdByPuid: Record<number, string> = {};
+      const projectPus = await em
+        .getRepository(ProjectsPuEntity)
+        .find({ projectId });
+      projectPus.forEach((pu) => {
+        projectPuIdByPuid[pu.puid] = pu.id;
+      });
+
+      await em.getRepository(ScenariosPuPaDataGeo).save(
+        scenariosPlanningUnitsData.planningUnitsData.map((puData) => ({
+          featureList: puData.featureList,
+          projectPuId: projectPuIdByPuid[puData.puid],
+          lockStatus: toLockEnum[puData.lockinStatus ?? 0],
+          protectedArea: puData.protectedArea,
+          protectedByDefault: puData.protectedByDefault,
+          xloc: puData.xloc,
+          yloc: puData.yloc,
+          scenarioId,
+        })),
+      );
+
+      const scenarioPus = await em.getRepository(ScenariosPuPaDataGeo).find({
+        where: {
+          scenarioId,
+        },
+        relations: ['projectPu'],
+      });
+      const scenarioPuIdByPuid: Record<number, string> = {};
+      scenarioPus.forEach((pu) => {
+        scenarioPuIdByPuid[pu.projectPu.puid] = pu.id;
+      });
+    });
+
+    return {
+      importId: input.importId,
+      componentId: input.componentId,
+      importResourceId: input.importResourceId,
+      componentResourceId: input.componentResourceId,
+      piece: input.piece,
+    };
+  }
+}

--- a/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
+++ b/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
@@ -3,7 +3,7 @@ import { LockStatus } from './lock-status.enum';
 
 const scenariosPuDataEntityName = 'scenarios_pu_data';
 
-const toLockEnum: Record<0 | 1 | 2, LockStatus> = Object.freeze({
+export const toLockEnum: Record<0 | 1 | 2, LockStatus> = Object.freeze({
   0: LockStatus.Unstated,
   1: LockStatus.LockedIn,
   2: LockStatus.LockedOut,


### PR DESCRIPTION
This PR adds `ScenarioPlanningUnitsData` piece importer

### Feature relevant tickets

- [import piece (scenario): cost data per planning unit](https://vizzuality.atlassian.net/browse/MARXAN-1349)
- [import piece (scenario): lock status (locked by default, or manually locked in or out) per planning unit](https://vizzuality.atlassian.net/browse/MARXAN-1351)