### PR TITLE
Ref/planning units creation

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1647859641978-AddProjectsPuPlanningAreaIdColumn.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1647859641978-AddProjectsPuPlanningAreaIdColumn.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectsPuPlanningAreaIdColumn1647859641978
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE projects_pu
+      ADD COLUMN planning_area_id uuid;
+    `);
+    await queryRunner.query(`
+      ALTER TABLE projects_pu
+      ALTER COLUMN project_id DROP NOT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE projects_pu
+      DROP COLUMN planning_area_id;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE projects_pu
+      ALTER COLUMN project_id SET NOT NULL;
+    `);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/planning-area/planning-area-garbage-collector.service.ts
+++ b/api/apps/geoprocessing/src/modules/planning-area/planning-area-garbage-collector.service.ts
@@ -35,7 +35,7 @@ export class PlanningAreaGarbageCollector {
 
       const projectsPuRepo = em.getRepository(ProjectsPuEntity);
       await projectsPuRepo.delete({
-        projectId: In(deletedPlanningAreasIds),
+        planningAreaId: In(deletedPlanningAreasIds),
       });
     });
   }

--- a/api/apps/geoprocessing/src/modules/planning-area/planning-units-grid/planning-area-grid-tiles.service.ts
+++ b/api/apps/geoprocessing/src/modules/planning-area/planning-units-grid/planning-area-grid-tiles.service.ts
@@ -21,14 +21,14 @@ export class PlanningAreaGridTilesService {
    */
   public findTile(tileSpecification: TileSpecification): Promise<Buffer> {
     const { z, x, y, planningAreaId } = tileSpecification;
-    const attributes = 'project_id as planningAreaId';
+    const attributes = 'planning_area_id as planningAreaId';
 
     const qb = this.repository
       .createQueryBuilder('pug')
-      .select('ppu.project_id', 'project_id')
+      .select('ppu.planning_area_id', 'planning_area_id')
       .addSelect('pug.the_geom', 'the_geom')
       .innerJoin('projects_pu', 'ppu', 'pug.id = ppu.geom_id')
-      .where(`ppu.project_id = '${planningAreaId}'`);
+      .where(`ppu.planning_area_id = '${planningAreaId}'`);
     const table = `(${qb.getSql()})`;
     return this.tileService.getTile({
       z,

--- a/api/apps/geoprocessing/src/modules/planning-area/planning-units-grid/planning-units-grid.processor.ts
+++ b/api/apps/geoprocessing/src/modules/planning-area/planning-units-grid/planning-units-grid.processor.ts
@@ -37,7 +37,7 @@ export class PlanningUnitsGridProcessor {
         const geometries: { id: string }[] = await manager.query(
           `
             INSERT INTO "planning_units_geom"("the_geom", "type")
-            SELECT 
+            SELECT
               ST_SetSRID(ST_GeomFromGeoJSON(features ->> 'geometry'), 4326)::geometry,
               $2::planning_unit_grid_shape
             FROM (SELECT json_array_elements($1::json -> 'features') AS features) AS f
@@ -54,7 +54,7 @@ export class PlanningUnitsGridProcessor {
             geomId: id,
             geomType: PlanningUnitGridShape.FromShapefile,
             puid: index + 1,
-            projectId: planningAreaId,
+            planningAreaId: planningAreaId,
           })),
         );
 
@@ -70,7 +70,7 @@ export class PlanningUnitsGridProcessor {
                     (SELECT ST_MULTI(ST_UNION(the_geom))
                      FROM "planning_units_geom" pug
                       INNER JOIN "projects_pu" ppu on pug.id = ppu.geom_id
-                     WHERE ppu.project_id = $1))
+                     WHERE ppu.planning_area_id = $1))
             RETURNING "id", "bbox"
           `,
           [planningAreaId],

--- a/api/apps/geoprocessing/src/modules/planning-units/planning-units.job.ts
+++ b/api/apps/geoprocessing/src/modules/planning-units/planning-units.job.ts
@@ -177,6 +177,7 @@ export class PlanningUnitsJobProcessor {
             geomType: job.data.planningUnitGridShape,
             puid: index + 1,
             projectId: job.data.projectId,
+            planningAreaId: job.data.planningAreaId,
           })),
         );
 

--- a/api/apps/geoprocessing/test/integration/planning-unit-grid/planning-units-grid.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-grid/planning-units-grid.e2e-spec.ts
@@ -8,7 +8,7 @@ beforeEach(async () => {
 });
 
 test(`uploading shapefile as planning units`, async () => {
-  const shapefile = await fixtures.GivenShapefileWasUploaded();
+  const shapefile = fixtures.GivenShapefileWasUploaded();
   const output = await fixtures.WhenConvertingShapefileToPlanningUnits(
     shapefile,
   );

--- a/api/apps/geoprocessing/test/integration/planning-unit-grid/planning-units-grid.fixtures.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-grid/planning-units-grid.fixtures.ts
@@ -79,7 +79,7 @@ export const getFixtures = async () => {
                    select pug.the_geom
                    from planning_units_geom pug inner join projects_pu ppu on pug.id = ppu.geom_id
                    where type = 'from_shapefile'
-                     and ppu.project_id = $1
+                     and ppu.planning_area_id = $1
                  ) as t(geom)
           `,
           [output.id],

--- a/api/libs/planning-unit-geometry/src/projects-pu.geo.entity.ts
+++ b/api/libs/planning-unit-geometry/src/projects-pu.geo.entity.ts
@@ -13,8 +13,11 @@ export class ProjectsPuEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column('uuid', { name: 'project_id' })
-  projectId!: string;
+  @Column('uuid', { name: 'project_id', nullable: true })
+  projectId?: string;
+
+  @Column('uuid', { name: 'planning_area_id', nullable: true })
+  planningAreaId?: string;
 
   @Column('int')
   puid!: number;


### PR DESCRIPTION
This PR refactors projects planning units creation process. `project_id` column of `projects_pu` table no longer contains planning area id either way if the project is being created from a shapefile or the project is being created with a regular grid:

- Added `planning_area_id` column to `projects_pu`
- Now `SetProjectGridFromShapefileHandler` updates `projects_pu` `project_id` column based on `planning_area_id` value
- Now `PlanningAreaGarbageCollector` deletes `projects_pu` filtering by `planning_area_id` instead of `project_id` column
- Now if the project has a regular planning units grid and a custom planning area, `projects_pu` records will be inserted with values in both columns (`project_id`, `planning_area_id`). If the project has a gadm planning area `planning_area_id` columns will contain null values.