### PR TITLE
fix :scenario run results piece exporter

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-run-results.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-run-results.piece-exporter.ts
@@ -66,12 +66,12 @@ export class ScenarioRunResultsPieceExporter implements ExportPieceProcessor {
             }),
         'spd',
       )
-      .leftJoin(
+      .innerJoin(
         'output_scenarios_pu_data',
         'results',
         'spd.id = results.scenario_pu_id',
       )
-      .leftJoin('projects_pu', 'ppu', 'ppu.id = spd.project_pu_id')
+      .innerJoin('projects_pu', 'ppu', 'ppu.id = spd.project_pu_id')
       .execute();
 
     const content: ScenarioRunResultsContent = { blmResults, marxanRunResults };


### PR DESCRIPTION
This PR fixes a problem detected when exporting scenario run results of a scenario. Now, scenario run results file will have an empty array in case no Marxan run has been executed in the scenario.