### PR TITLE
ref: use of query builder in piece importers

### DIFF
--- a/api/apps/api/src/modules/projects/project.api.entity.ts
+++ b/api/apps/api/src/modules/projects/project.api.entity.ts
@@ -31,7 +31,9 @@ export const projectResource: BaseServiceResource = {
   entitiesAllowedAsIncludes: ['scenarios', 'users'],
 };
 
-@Entity('projects')
+export const projectTableName = 'projects' as const;
+
+@Entity(projectTableName)
 export class Project extends TimeUserEntityMetadata {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')

--- a/api/apps/api/src/modules/projects/project.api.entity.ts
+++ b/api/apps/api/src/modules/projects/project.api.entity.ts
@@ -31,9 +31,7 @@ export const projectResource: BaseServiceResource = {
   entitiesAllowedAsIncludes: ['scenarios', 'users'],
 };
 
-export const projectTableName = 'projects' as const;
-
-@Entity(projectTableName)
+@Entity('projects')
 export class Project extends TimeUserEntityMetadata {
   @ApiProperty()
   @PrimaryGeneratedColumn('uuid')

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-area-custom.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-area-custom.piece-importer.ts
@@ -1,4 +1,3 @@
-import { projectTableName } from '@marxan-api/modules/projects/project.api.entity';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
@@ -88,7 +87,7 @@ export class PlanningAreaCustomPieceImporter implements ImportPieceProcessor {
 
       await this.apiEntityManager
         .createQueryBuilder()
-        .update(projectTableName)
+        .update(`projects`)
         .set({
           planning_unit_area_km2: planningAreaGadm.puAreaKm2,
           bbox: JSON.stringify(planningArea.bbox),

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-area-custom.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-area-custom.piece-importer.ts
@@ -1,8 +1,10 @@
+import { projectTableName } from '@marxan-api/modules/projects/project.api.entity';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
 import { PlanningAreaCustomContent } from '@marxan/cloning/infrastructure/clone-piece-data/planning-area-custom';
 import { FileRepository } from '@marxan/files-repository';
+import { PlanningArea } from '@marxan/planning-area-repository/planning-area.geo.entity';
 import { extractFile } from '@marxan/utils';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
@@ -67,38 +69,33 @@ export class PlanningAreaCustomPieceImporter implements ImportPieceProcessor {
     );
 
     await this.geoprocessingEntityManager.transaction(async (em) => {
-      await em.query(
-        `
-        INSERT INTO planning_areas(project_id, the_geom)
-        VALUES ($1, ST_GeomFromEWKB($2))
-      `,
-        [importResourceId, Buffer.from(planningAreaGadm.planningAreaGeom)],
-      );
-      const [planningArea]: [{ id: string; bbox: number[] }] = await em.query(
-        `
-        SELECT id, bbox
-        FROM planning_areas
-        WHERE project_id = $1
-      `,
-        [importResourceId],
-      );
+      const geoQb = em.createQueryBuilder();
+      const planningAreaGeom = Buffer.from(
+        planningAreaGadm.planningAreaGeom,
+      ).toString('hex');
 
-      await this.apiEntityManager.query(
-        `
-        UPDATE projects
-        SET
-          planning_unit_area_km2 = $2,
-          bbox = $3,
-          planning_area_geometry_id = $4
-        WHERE id = $1
-      `,
-        [
-          importResourceId,
-          planningAreaGadm.puAreaKm2,
-          JSON.stringify(planningArea.bbox),
-          planningArea.id,
-        ],
-      );
+      const result = await geoQb
+        .insert()
+        .into(PlanningArea)
+        .values({
+          projectId: importResourceId,
+          theGeom: () => `'${planningAreaGeom}'`,
+        })
+        .returning(['id', 'bbox'])
+        .execute();
+
+      const [planningArea] = result.raw as [{ id: string; bbox: number[] }];
+
+      await this.apiEntityManager
+        .createQueryBuilder()
+        .update(projectTableName)
+        .set({
+          planning_unit_area_km2: planningAreaGadm.puAreaKm2,
+          bbox: JSON.stringify(planningArea.bbox),
+          planning_area_geometry_id: planningArea.id,
+        })
+        .where('id = :importResourceId', { importResourceId })
+        .execute();
     });
 
     return {

--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-area-gadm.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-area-gadm.piece-importer.ts
@@ -1,4 +1,3 @@
-import { projectTableName } from '@marxan-api/modules/projects/project.api.entity';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
@@ -67,7 +66,7 @@ export class PlanningAreaGadmPieceImporter implements ImportPieceProcessor {
 
     await this.entityManager
       .createQueryBuilder()
-      .update(projectTableName)
+      .update(`projects`)
       .set({
         country_id: planningAreaGadm.country,
         admin_area_l1_id: planningAreaGadm.l1,

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
@@ -12,6 +12,7 @@ import {
   ImportPieceProcessor,
   PieceImportProvider,
 } from '../pieces/import-piece-processor';
+import { projectTableName } from '../../../../api/src/modules/projects/project.api.entity';
 
 @Injectable()
 @PieceImportProvider()
@@ -77,19 +78,18 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
       stringProjectMetadataOrError.right,
     );
 
-    await this.entityManager.query(
-      `
-      INSERT INTO projects(id, name, description, organization_id, planning_unit_grid_shape)
-      VALUES ($1, $2, $3, $4, $5)
-    `,
-      [
-        importResourceId,
-        projectMetadata.name,
-        projectMetadata.description,
-        organizationId,
-        projectMetadata.planningUnitGridShape,
-      ],
-    );
+    await this.entityManager
+      .createQueryBuilder()
+      .insert()
+      .into(projectTableName)
+      .values({
+        id: importResourceId,
+        name: projectMetadata.name,
+        description: projectMetadata.description,
+        organization_id: organizationId,
+        planning_unit_grid_shape: projectMetadata.planningUnitGridShape,
+      })
+      .execute();
 
     return {
       importId: input.importId,

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
@@ -12,7 +12,6 @@ import {
   ImportPieceProcessor,
   PieceImportProvider,
 } from '../pieces/import-piece-processor';
-import { projectTableName } from '../../../../api/src/modules/projects/project.api.entity';
 
 @Injectable()
 @PieceImportProvider()
@@ -81,7 +80,7 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
     await this.entityManager
       .createQueryBuilder()
       .insert()
-      .into(projectTableName)
+      .into(`projects`)
       .values({
         id: importResourceId,
         name: projectMetadata.name,


### PR DESCRIPTION
This PR refactors some piece importers to use query builders instead of `query` method of `EntityManager`s