### PR TITLE
ref: use query builder in piece exporters

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom-geojson.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-custom-geojson.piece-exporter.ts
@@ -3,7 +3,7 @@ import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
 import { FileRepository } from '@marxan/files-repository';
-import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
+import { PlanningArea } from '@marxan/planning-area-repository/planning-area.geo.entity';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/Either';
@@ -26,8 +26,6 @@ export class PlanningAreaCustomGeojsonPieceExporter
     private readonly fileRepository: FileRepository,
     @InjectEntityManager(geoprocessingConnections.default)
     private readonly geoprocessingEntityManager: EntityManager,
-    @InjectEntityManager(geoprocessingConnections.apiDB)
-    private readonly apiEntityManager: EntityManager,
     private readonly logger: Logger,
   ) {
     this.logger.setContext(PlanningAreaCustomGeojsonPieceExporter.name);
@@ -41,19 +39,18 @@ export class PlanningAreaCustomGeojsonPieceExporter
   }
 
   async run(input: ExportJobInput): Promise<ExportJobOutput> {
+    const projectId = input.resourceId;
     const [planningArea]: [
       PlanningAreaGeojsonSelectResult,
-    ] = await this.geoprocessingEntityManager.query(
-      `
-        SELECT ST_AsGeoJSON(the_geom) as geojson
-        FROM planning_areas
-        WHERE project_id = $1
-      `,
-      [input.resourceId],
-    );
+    ] = await this.geoprocessingEntityManager
+      .createQueryBuilder()
+      .select('ST_AsGeoJSON(the_geom)', 'geojson')
+      .from(PlanningArea, 'pa')
+      .where('project_id = :projectId', { projectId })
+      .execute();
 
     if (!planningArea) {
-      const errorMessage = `Custom planning area not found for project with ID: ${input.resourceId}`;
+      const errorMessage = `Custom planning area not found for project with ID: ${projectId}`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);
     }

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
@@ -153,7 +153,12 @@ class FakeEntityManager {
     },
   ];
 
-  async query(): Promise<PlanningAreaGadmContent[]> {
+  createQueryBuilder = () => this;
+  select = () => this;
+  addSelect = () => this;
+  from = () => this;
+  where = () => this;
+  async execute() {
     return this.data;
   }
 }

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.ts
@@ -43,27 +43,27 @@ export class PlanningAreaGadmPieceExporter implements ExportPieceProcessor {
   }
 
   async run(input: ExportJobInput): Promise<ExportJobOutput> {
+    const projectId = input.resourceId;
     if (input.resourceKind === ResourceKind.Scenario) {
       throw new Error(`Exporting scenario is not yet supported.`);
     }
 
-    const [gadm]: [QueryResult] = await this.entityManager.query(
-      `
-        SELECT 
-          country_id, 
-          admin_area_l1_id, 
-          admin_area_l2_id, 
-          planning_unit_grid_shape, 
-          planning_unit_area_km2,
-          bbox
-        FROM projects
-        WHERE id = $1
-      `,
-      [input.resourceId],
-    );
+    const [gadm]: [
+      QueryResult,
+    ] = await this.entityManager
+      .createQueryBuilder()
+      .select('country_id')
+      .addSelect('admin_area_l1_id')
+      .addSelect('admin_area_l2_id')
+      .addSelect('planning_unit_grid_shape')
+      .addSelect('planning_unit_area_km2')
+      .addSelect('bbox')
+      .from('projects', 'p')
+      .where('id = :projectId', { projectId })
+      .execute();
 
     if (!gadm) {
-      const errorMessage = `Gadm data not found for project with ID: ${input.resourceId}`;
+      const errorMessage = `Gadm data not found for project with ID: ${projectId}`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);
     }

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
@@ -34,17 +34,20 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
   }
 
   async run(input: ExportJobInput): Promise<ExportJobOutput> {
+    const projectId = input.resourceId;
     const [projectData]: {
       name: string;
       description: string;
       planning_unit_grid_shape: PlanningUnitGridShape;
-    }[] = await this.entityManager.query(
-      `SELECT name, description, planning_unit_grid_shape FROM projects WHERE projects.id = $1`,
-      [input.resourceId],
-    );
+    }[] = await this.entityManager
+      .createQueryBuilder()
+      .select(['name', 'description', 'planning_unit_grid_shape'])
+      .from('projects', 'p')
+      .where('id = :projectId', { projectId })
+      .execute();
 
     if (!projectData) {
-      const errorMessage = `${ProjectMetadataPieceExporter.name} - Project ${input.resourceId} does not exist.`;
+      const errorMessage = `${ProjectMetadataPieceExporter.name} - Project ${projectId} does not exist.`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);
     }


### PR DESCRIPTION
This PR refactors some part exporters that used the entityManager query method, now these queries have been replaced by using queryBuilder methods.