### PR TITLE
MARXAN-1374-BLMFinalResults-Puids-PNGdata

### DIFF
--- a/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.command.ts
+++ b/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.command.ts
@@ -1,9 +1,11 @@
+import { WebshotConfig } from '@marxan/webshot';
 import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class StartBlmCalibration extends Command<void> {
   constructor(
     public readonly scenarioId: string,
     public readonly blmValues: number[],
+    public readonly config: WebshotConfig,
   ) {
     super();
   }

--- a/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.handler.ts
+++ b/api/apps/api/src/modules/scenarios/blm-calibration/start-blm-calibration.handler.ts
@@ -22,7 +22,11 @@ export class StartBlmCalibrationHandler
     private readonly assets: AssetsService,
   ) {}
 
-  async execute({ scenarioId, blmValues }: StartBlmCalibration): Promise<void> {
+  async execute({
+    scenarioId,
+    blmValues,
+    config,
+  }: StartBlmCalibration): Promise<void> {
     // In order to ensure that boundary data is included in assets array
     // a non zero value should be provided to `forScenario` method of AssetsService
     const nonZeroBLMValue = 1;
@@ -32,6 +36,7 @@ export class StartBlmCalibrationHandler
       scenarioId,
       blmValues,
       assets,
+      config,
     });
 
     if (!job) {

--- a/api/apps/api/src/modules/scenarios/dto/start-scenario-blm-calibration.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/start-scenario-blm-calibration.dto.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsOptional } from 'class-validator';
+import { IsArray, IsOptional, ValidateNested } from 'class-validator';
 import { IsValidRange } from '@marxan-api/decorators/is-valid-range.decorator';
+import { WebshotConfig } from '@marxan/webshot';
+import { Type } from 'class-transformer';
 
 export class StartScenarioBlmCalibrationDto {
   @ApiProperty({ example: [0.001, 100], required: false })
@@ -8,4 +10,9 @@ export class StartScenarioBlmCalibrationDto {
   @IsArray()
   @IsValidRange()
   range?: [number, number];
+
+  @ApiProperty()
+  @ValidateNested({ each: true })
+  @Type(() => WebshotConfig)
+  config!: WebshotConfig;
 }

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -213,7 +213,7 @@ export class ScenariosController {
     required: true,
     example: 'e5c3b978-908c-49d3-b1e3-89727e9f999c',
   })
-  @Get(':id/calibration/tiles/:blmValues/:z/:x/:y.mvt')
+  @Get(':id/calibration/tiles/:blmValue/:z/:x/:y.mvt')
   async proxyPlanningUnitsBlmValuesTiles(
     @Req() req: RequestWithAuthenticatedUser,
     @Res() response: Response,

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1087,8 +1087,8 @@ export class ScenariosController {
   @Post(`:id/calibration`)
   async startCalibration(
     @Param('id', ParseUUIDPipe) id: string,
-    @Body() { range }: StartScenarioBlmCalibrationDto,
-    @Body() config: WebshotConfig,
+    @Body('range') { range }: StartScenarioBlmCalibrationDto,
+    @Body('config') config: WebshotConfig,
     @Req() req: RequestWithAuthenticatedUser,
     @AppSessionTokenCookie() appSessionTokenCookie: string,
   ): Promise<JsonApiAsyncJobMeta> {

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -101,7 +101,7 @@ import {
 } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
 import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
 import { BaseTilesOpenApi } from '@marxan/tiles';
-import { WebshotConfig, WebshotService } from '@marxan/webshot';
+import { WebshotConfig } from '@marxan/webshot';
 import { AppSessionTokenCookie } from '@marxan-api/decorators/app-session-token-cookie.decorator';
 import { setImagePngResponseHeadersForSuccessfulRequests } from '@marxan/utils';
 
@@ -131,7 +131,6 @@ export class ScenariosController {
     private readonly zipFilesSerializer: ZipFilesSerializer,
     private readonly planningUnitsSerializer: ScenarioPlanningUnitSerializer,
     private readonly scenarioAclService: ScenarioAccessControl,
-    private readonly webshotService: WebshotService,
   ) {}
 
   @ApiOperation({

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1087,11 +1087,11 @@ export class ScenariosController {
   @Post(`:id/calibration`)
   async startCalibration(
     @Param('id', ParseUUIDPipe) id: string,
-    @Body('range') { range }: StartScenarioBlmCalibrationDto,
-    @Body('config') config: WebshotConfig,
+    @Body() blmCalibrationConfig: StartScenarioBlmCalibrationDto,
     @Req() req: RequestWithAuthenticatedUser,
     @AppSessionTokenCookie() appSessionTokenCookie: string,
   ): Promise<JsonApiAsyncJobMeta> {
+    const { config, range } = blmCalibrationConfig;
     /**
      * If a frontend app session token was provided via cookie, use this to let
      * the webshot service authenticate to the app, otherwise fall back to

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -107,6 +107,7 @@ import { FeatureCollection } from 'geojson';
 import {
   unknownPdfWebshotError,
   WebshotConfig,
+  WebshotPdfConfig,
   WebshotService,
 } from '@marxan/webshot';
 import { blmImageMock } from './__mock__/blm-image-mock';
@@ -581,6 +582,7 @@ export class ScenariosService {
   async startBlmCalibration(
     id: string,
     userInfo: AppInfoDTO,
+    config: WebshotConfig,
     rangeToUpdate?: [number, number],
   ): Promise<
     Either<
@@ -616,7 +618,7 @@ export class ScenariosService {
     if (isLeft(scenarioBlmValues)) return scenarioBlmValues;
 
     await this.commandBus.execute(
-      new StartBlmCalibration(id, scenarioBlmValues.right.values),
+      new StartBlmCalibration(id, scenarioBlmValues.right.values, config),
     );
 
     return right(true);
@@ -1236,7 +1238,7 @@ export class ScenariosService {
   async getSummaryReportFor(
     scenarioId: string,
     userId: string,
-    configForWebshot: WebshotConfig,
+    configForWebshot: WebshotPdfConfig,
   ): Promise<
     Either<
       | typeof forbiddenError

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -1252,6 +1252,7 @@ export class ScenariosService {
     if (isLeft(scenario)) {
       return scenario;
     }
+    const webshotUrl = AppConfig.get('webshot.url') as string;
 
     /** @debt Refactor to use @nestjs/common's StreamableFile
      (https://docs.nestjs.com/techniques/streaming-files#streamable-file-class)
@@ -1260,6 +1261,7 @@ export class ScenariosService {
       scenarioId,
       scenario.right.projectId,
       configForWebshot,
+      webshotUrl,
     );
 
     return pdfStream;

--- a/api/apps/api/test/scenarios/get-scenario-blm-calibration-results.fixtures.ts
+++ b/api/apps/api/test/scenarios/get-scenario-blm-calibration-results.fixtures.ts
@@ -81,6 +81,7 @@ export const getFixtures = async () => {
         .set('Authorization', `Bearer ${ownerToken}`)
         .send({
           range: blmRange,
+          config: { baseUrl: 'example/png', cookie: 'randomCookie' },
         })
         .expect(HttpStatus.CREATED),
     WhenContributorLaunchesCalibration: async () => {
@@ -97,6 +98,7 @@ export const getFixtures = async () => {
         .set('Authorization', `Bearer ${viewerToken}`)
         .send({
           range: blmRange,
+          config: { baseUrl: 'example/png', cookie: 'randomCookie' },
         }),
     ThenCalibrationResultsShouldBeAvailable: async () => {
       const response: { body: BlmCalibrationRunResultDto[] } = await request(

--- a/api/apps/api/test/scenarios/get-scenario-blm-range.e2e-spec.ts
+++ b/api/apps/api/test/scenarios/get-scenario-blm-range.e2e-spec.ts
@@ -115,7 +115,10 @@ const getFixtures = async () => {
     GivenScenarioBlmWasUpdated: async () => {
       await request(app.getHttpServer())
         .post(`/api/v1/scenarios/${scenarioId}/calibration`)
-        .send({ range: updatedBlmRange })
+        .send({
+          range: updatedBlmRange,
+          config: { baseUrl: 'example/png', cookie: 'randomCookie' },
+        })
         .set('Authorization', `Bearer ${ownerToken}`);
     },
     WhenAskingForBlmRangeForScenario: () => {

--- a/api/apps/api/test/scenarios/start-scenario-calibration.fixtures.ts
+++ b/api/apps/api/test/scenarios/start-scenario-calibration.fixtures.ts
@@ -106,6 +106,7 @@ export const getFixtures = async () => {
           .set('Authorization', `Bearer ${ownerToken}`)
           .send({
             range: updatedRange,
+            config: { baseUrl: 'example/png', cookie: 'randomCookie' },
           }),
       WithoutRange: async () =>
         await request(app.getHttpServer())
@@ -119,6 +120,7 @@ export const getFixtures = async () => {
           .set('Authorization', `Bearer ${contributorToken}`)
           .send({
             range: updatedRange,
+            config: { baseUrl: 'example/png', cookie: 'randomCookie' },
           }),
       WithoutRange: async () =>
         await request(app.getHttpServer())
@@ -132,6 +134,7 @@ export const getFixtures = async () => {
           .set('Authorization', `Bearer ${viewerToken}`)
           .send({
             range: updatedRange,
+            config: { baseUrl: 'example/png', cookie: 'randomCookie' },
           }),
       WithoutRange: async () =>
         await request(app.getHttpServer())
@@ -158,6 +161,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${ownerToken}`)
             .send({
               range: [-1, -50],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RangeWithAMinGreaterThanMax: async () =>
           await request(app.getHttpServer())
@@ -165,6 +169,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${ownerToken}`)
             .send({
               range: [50, 1],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RangeWithValuesThatAreNotNumbers: async () =>
           await request(app.getHttpServer())
@@ -172,6 +177,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${ownerToken}`)
             .send({
               range: [1, '50'],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RunningExport: async () => {
           projectChecker.addPendingExportForProject(projectId);
@@ -180,6 +186,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${ownerToken}`)
             .send({
               range: [1, 50],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             });
         },
       };
@@ -192,6 +199,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${contributorToken}`)
             .send({
               range: [-1, -50],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RangeWithAMinGreaterThanMax: async () =>
           await request(app.getHttpServer())
@@ -199,6 +207,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${contributorToken}`)
             .send({
               range: [50, 1],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RangeWithValuesThatAreNotNumbers: async () =>
           await request(app.getHttpServer())
@@ -206,6 +215,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${contributorToken}`)
             .send({
               range: [1, '50'],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RunningExport: async () => {
           projectChecker.addPendingExportForProject(projectId);
@@ -214,6 +224,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${contributorToken}`)
             .send({
               range: [1, 50],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             });
         },
       };
@@ -226,6 +237,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${viewerToken}`)
             .send({
               range: [-1, -50],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RangeWithAMinGreaterThanMax: async () =>
           await request(app.getHttpServer())
@@ -233,6 +245,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${viewerToken}`)
             .send({
               range: [50, 1],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RangeWithValuesThatAreNotNumbers: async () =>
           await request(app.getHttpServer())
@@ -240,6 +253,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${viewerToken}`)
             .send({
               range: [1, '50'],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             }),
         RunningExport: async () => {
           projectChecker.addPendingExportForProject(projectId);
@@ -248,6 +262,7 @@ export const getFixtures = async () => {
             .set('Authorization', `Bearer ${viewerToken}`)
             .send({
               range: [1, 50],
+              config: { baseUrl: 'example/png', cookie: 'randomCookie' },
             });
         },
       };

--- a/api/apps/geoprocessing/config/default.json
+++ b/api/apps/geoprocessing/config/default.json
@@ -28,6 +28,9 @@
   "api": {
     "url": "http://api:3000"
   },
+  "webshot": {
+    "url": "http://webshot:3000"
+  },
   "geo": {
     "daemonListenPort": 3000
   },

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
@@ -15,6 +15,15 @@ export class BlmFinalResultsRepository {
     return Promise.resolve(undefined);
   }
 
+  async findOneByScenarioId(
+    scenarioId: string,
+  ): Promise<BlmFinalResultEntity | undefined> {
+    const result = await this.entityManager.findOne(BlmFinalResultEntity, {
+      where: { scenarioId },
+    });
+    return result;
+  }
+
   /**
    * clear previous results, move the new ones to target
    * table - everything within transaction

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
@@ -15,12 +15,13 @@ export class BlmFinalResultsRepository {
     return Promise.resolve(undefined);
   }
 
-  async findOneByScenarioId(
-    scenarioId: string,
-  ): Promise<BlmFinalResultEntity | undefined> {
-    const result = await this.entityManager.findOne(BlmFinalResultEntity, {
-      where: { scenarioId },
-    });
+  async findOneByScenarioId(scenarioId: string): Promise<BlmFinalResultEntity> {
+    const result = await this.entityManager.findOneOrFail(
+      BlmFinalResultEntity,
+      {
+        where: { scenarioId },
+      },
+    );
     return result;
   }
 

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-run-adapter.module.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-run-adapter.module.ts
@@ -27,6 +27,7 @@ import { RemovePreviousCalibrationPartialResultsHandler } from './cleanup/remove
 import { BlmCalibrationStartedSaga } from './cleanup/blm-calibration-started.saga';
 import { BlmFinalResultEntity } from '@marxan/blm-calibration';
 import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { WebshotModule } from '@marxan/webshot';
 
 export const blmSandboxRunner = Symbol(`blm sandbox runner`);
 
@@ -41,6 +42,7 @@ export const blmSandboxRunner = Symbol(`blm sandbox runner`);
       ProjectsPuEntity,
     ]),
     CqrsModule,
+    WebshotModule,
   ],
   providers: [
     MarxanConfig,

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -16,11 +16,13 @@ import { BlmFinalResultsRepository } from './blm-final-results.repository';
 import { BlmInputFiles } from './blm-input-files';
 import { BlmCalibrationStarted } from './events/blm-calibration-started.event';
 import { MarxanRunnerFactory } from './marxan-runner.factory';
+import { Logger } from '@nestjs/common';
 
 @Injectable()
 export class MarxanSandboxBlmRunnerService
   implements SandboxRunner<JobData, void> {
   readonly #controllers: Record<string, AbortController> = {};
+  private readonly logger: Logger = new Logger('Marxan Sandbox Blm Runner');
 
   constructor(
     private readonly moduleRef: ModuleRef,
@@ -125,7 +127,10 @@ export class MarxanSandboxBlmRunnerService
           );
 
           if (isLeft(pngStream)) {
-            throw new InternalServerErrorException();
+            this.logger.error(
+              `Could not add PNG data for blm run for scenario ID: ${scenarioId} and blmValue: ${blmValue}`,
+            );
+            continue;
           }
 
           await this.finalResultsRepository.updatePngDataOnFinalResults(

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -86,10 +86,33 @@ export class MarxanSandboxBlmRunnerService
           );
         }
         this.interruptIfKilled(scenarioId);
+
         await this.finalResultsRepository.saveFinalResults(
           scenarioId,
           calibrationId,
         );
+
+        const createdFinalResult = await this.finalResultsRepository.findOneByScenarioId(
+          scenarioId,
+        );
+
+        const puIds = createdFinalResult?.protected_pu_ids;
+
+        //-> I need to get the tiles for the APP(FE) to generate the maps.
+        // Once they are ready after the ¿proxy? request to API I need to
+        // request the webshot service png generation with those tiles.
+        // const proxyCall(puids)
+        // this.interruptIfKilled(scenarioId);
+
+        /*
+          Webshot call happens here with puIds.
+          This will return the PNG data, that needs to be inserted in next call to update finalResults.
+          await this.webshot.createScreenshot(puData, scenarioId, runId);
+          this.interruptIfKilled(scenarioId);
+        */
+
+        // When webshot call returns -> this.finalResultsRepository.updateFinalResults(scenarioId, pngData).
+
         this.clearAbortController(scenarioId);
         this.interruptIfKilled(scenarioId);
       } catch (err) {

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -136,8 +136,6 @@ export class MarxanSandboxBlmRunnerService
         }
         this.interruptIfKilled(scenarioId);
 
-        // When webshot call returns -> this.finalResultsRepository.updateFinalResults(scenarioId, pngData).
-
         this.clearAbortController(scenarioId);
         this.interruptIfKilled(scenarioId);
       } catch (err) {

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -1,14 +1,15 @@
 import { Cancellable } from '@marxan-geoprocessing/marxan-sandboxed-runner/ports/cancellable';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
-import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { AppConfig } from '@marxan-geoprocessing/utils/config.utils';
 import { JobData } from '@marxan/blm-calibration';
 import { WebshotService } from '@marxan/webshot';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { EventBus } from '@nestjs/cqrs';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import AbortController from 'abort-controller';
-import { EntityManager, getManager } from 'typeorm';
+import { isLeft } from 'fp-ts/lib/Either';
+import { EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
 import { SandboxRunner } from '../ports/sandbox-runner';
 import { BlmFinalResultsRepository } from './blm-final-results.repository';
@@ -57,6 +58,15 @@ export class MarxanSandboxBlmRunnerService
     const { blmValues, scenarioId } = input;
     const calibrationId = v4();
 
+    const projectId = await this.apiEntityManager
+      .createQueryBuilder()
+      .select(['project_id'])
+      .from('scenarios', 's')
+      .where('id = :scenarioId', { scenarioId })
+      .execute();
+
+    const webshotUrl = AppConfig.get('webshot.url') as string;
+
     this.eventBus.publish(new BlmCalibrationStarted(scenarioId, calibrationId));
 
     const inputFilesHandler = await this.moduleRef.create(BlmInputFiles);
@@ -100,36 +110,30 @@ export class MarxanSandboxBlmRunnerService
           calibrationId,
         );
 
-        // This won't work because every run has same scenarioId
-        const createdFinalResult = await this.finalResultsRepository.findOneByScenarioId(
-          scenarioId,
-        );
+        for (const { blmValue } of workspaces) {
+          const pngStream = await this.webshotService.getBlmValuesImage(
+            scenarioId,
+            projectId,
+            {
+              ...input.config,
+              screenshotOptions: {
+                clip: { x: 0, y: 0, width: 500, height: 500 },
+              },
+            },
+            blmValue,
+            webshotUrl,
+          );
 
-        const { blmValue } = createdFinalResult;
+          if (isLeft(pngStream)) {
+            throw new InternalServerErrorException();
+          }
 
-        //array of uuid of project_pu table entities included in best solution
-        //need to be joined with scenario_pu_data and planning_units_geom
-        const puIds = createdFinalResult?.protected_pu_ids;
-
-        const projectId = await this.apiEntityManager
-          .createQueryBuilder()
-          .select(['project_id'])
-          .from('scenarios', 's')
-          .where('id = :scenarioId', { scenarioId })
-          .execute();
-
-        /*
-          Webshot call happens here with puIds.
-          This will return the PNG data, that needs to be inserted in next call to update finalResults.
-          await this.webshot.createScreenshot(puData, scenarioId, runId);
-          this.interruptIfKilled(scenarioId);
-        */
-        // const pngStream = await this.webshotService.getBlmValuesImage(
-        //   scenarioId,
-        //   projectId,
-        //   configForWebshot,
-        //   blmValue,
-        // );
+          await this.finalResultsRepository.updatePngDataOnFinalResults(
+            scenarioId,
+            blmValue,
+            pngStream.right,
+          );
+        }
         this.interruptIfKilled(scenarioId);
 
         // When webshot call returns -> this.finalResultsRepository.updateFinalResults(scenarioId, pngData).

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1648559688744-AddProtectedPUIdsPngColumnToBlmFinalResults.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1648559688744-AddProtectedPUIdsPngColumnToBlmFinalResults.ts
@@ -5,7 +5,7 @@ export class AddProtectedPUIdsPngColumnToBlmFinalResults1648570380744
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
           ALTER TABLE blm_final_results
-              ADD COLUMN protected_pu_ids uuid[]
+              ADD COLUMN protected_pu_ids uuid[],
               ADD COLUMN png_data bytea;
           `);
   }
@@ -13,7 +13,7 @@ export class AddProtectedPUIdsPngColumnToBlmFinalResults1648570380744
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
           ALTER TABLE blm_partial_results
-              DROP COLUMN protected_pu_ids
+              DROP COLUMN protected_pu_ids,
               DROP COLUMN png_data;
           `);
   }

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1648559688744-AddProtectedPUIdsPngColumnToBlmFinalResults.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1648559688744-AddProtectedPUIdsPngColumnToBlmFinalResults.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProtectedPUIdsPngColumnToBlmFinalResults1648570380744
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+          ALTER TABLE blm_final_results
+              ADD COLUMN protected_pu_ids uuid[]
+              ADD COLUMN png_data bytea;
+          `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+          ALTER TABLE blm_partial_results
+              DROP COLUMN protected_pu_ids
+              DROP COLUMN png_data;
+          `);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/geoprocessing/src/modules/scenarios/scenarios.controller.ts
@@ -39,9 +39,10 @@ export class ScenariosController {
   @Get('/:id/planning-units/tiles/:z/:x/:y.mvt')
   async getPuTile(
     @Param() tileRequest: ScenariosTileRequest,
+    @Query() filters: ScenariosPUFilters,
     @Res() response: Response,
   ): Promise<void> {
-    const tile = await this.service.findTile(tileRequest);
+    const tile = await this.service.findTile(tileRequest, filters);
 
     setTileResponseHeadersForSuccessfulRequests(response);
     response.send(tile);
@@ -59,20 +60,11 @@ export class ScenariosController {
     example: 'e5c3b978-908c-49d3-b1e3-89727e9f999c',
   })
   @Get(':id/calibration/tiles/:blmValues/:z/:x/:y.mvt')
-  @ApiParam({
-    name: 'id',
-    description: 'scenario id',
-    type: String,
-    required: true,
-    example: 'e5c3b978-908c-49d3-b1e3-89727e9f999c',
-  })
-  @Get(':id/calibration/tiles/:blmValues/:z/:x/:y.mvt')
   async getPlanningUnitsBlmValuesTiles(
     @Param() tileRequest: ScenariosWithBlmValueRequest,
-    @Query() filters: ScenariosPUFilters,
     @Res() response: Response,
   ): Promise<void> {
-    const tile = await this.service.findTile(tileRequest, filters);
+    const tile = await this.service.findTileWithBlmValue(tileRequest);
 
     setTileResponseHeadersForSuccessfulRequests(response);
     response.send(tile);

--- a/api/apps/geoprocessing/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/geoprocessing/src/modules/scenarios/scenarios.controller.ts
@@ -3,6 +3,7 @@ import {
   ScenariosPUFilters,
   ScenariosService,
   ScenariosTileRequest,
+  ScenariosWithBlmValueRequest,
 } from './scenarios.service';
 import { apiGlobalPrefixes } from '@marxan-geoprocessing/api.config';
 import { ApiOperation, ApiParam } from '@nestjs/swagger';
@@ -38,6 +39,36 @@ export class ScenariosController {
   @Get('/:id/planning-units/tiles/:z/:x/:y.mvt')
   async getPuTile(
     @Param() tileRequest: ScenariosTileRequest,
+    @Res() response: Response,
+  ): Promise<void> {
+    const tile = await this.service.findTile(tileRequest);
+
+    setTileResponseHeadersForSuccessfulRequests(response);
+    response.send(tile);
+  }
+
+  @BaseTilesOpenApi()
+  @ApiOperation({
+    description: 'Get tiles for a scenario blm values to generate maps.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'scenario id',
+    type: String,
+    required: true,
+    example: 'e5c3b978-908c-49d3-b1e3-89727e9f999c',
+  })
+  @Get(':id/calibration/tiles/:blmValues/:z/:x/:y.mvt')
+  @ApiParam({
+    name: 'id',
+    description: 'scenario id',
+    type: String,
+    required: true,
+    example: 'e5c3b978-908c-49d3-b1e3-89727e9f999c',
+  })
+  @Get(':id/calibration/tiles/:blmValues/:z/:x/:y.mvt')
+  async getPlanningUnitsBlmValuesTiles(
+    @Param() tileRequest: ScenariosWithBlmValueRequest,
     @Query() filters: ScenariosPUFilters,
     @Res() response: Response,
   ): Promise<void> {

--- a/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
@@ -19,7 +19,6 @@ import {
 } from '@marxan/marxan-output';
 import { getEntityManagerToken, getRepositoryToken } from '@nestjs/typeorm';
 import { readFileSync } from 'fs';
-import { Geometry } from 'geojson';
 import { last } from 'lodash';
 import * as nock from 'nock';
 import { EntityManager, In, Repository } from 'typeorm';
@@ -182,6 +181,7 @@ const getFixtures = async () => {
             url: host + resource.assetUrl,
             relativeDestination: resource.targetRelativeDestination,
           })),
+          config: { baseUrl: 'example/png', cookie: 'randomPngCookie' },
         },
         (value) => {
           this.progressMock(value);

--- a/api/apps/geoprocessing/test/jest-e2e.json
+++ b/api/apps/geoprocessing/test/jest-e2e.json
@@ -72,6 +72,8 @@
     "@marxan/cloning/(.*)": "<rootDir>/../../libs/cloning/src/$1",
     "@marxan/cloning": "<rootDir>/../../libs/cloning/src",
     "@marxan/geofeatures/(.*)": "<rootDir>/../../libs/geofeatures/src/$1",
-    "@marxan/geofeatures": "<rootDir>/../../libs/geofeatures/src"
+    "@marxan/geofeatures": "<rootDir>/../../libs/geofeatures/src",
+    "@marxan/webshot/(.*)": "<rootDir>../../libs/webshot/src/$1",
+    "@marxan/webshot": "<rootDir>../../libs/webshot/src"
   }
 }

--- a/api/libs/blm-calibration/src/blm-final-results.geo.entity.ts
+++ b/api/libs/blm-calibration/src/blm-final-results.geo.entity.ts
@@ -42,4 +42,17 @@ export class BlmFinalResultEntity {
     type: 'float',
   })
   boundaryLength!: number;
+
+  @Column({
+    name: `protected_pu_ids`,
+    type: 'uuid',
+    array: true,
+  })
+  protected_pu_ids!: string[];
+
+  @Column({
+    name: `png_data`,
+    type: 'bytea',
+  })
+  pngData!: Buffer;
 }

--- a/api/libs/blm-calibration/src/calibration-job-input.ts
+++ b/api/libs/blm-calibration/src/calibration-job-input.ts
@@ -1,3 +1,5 @@
+import { WebshotConfig } from '@marxan/webshot';
+
 export type Assets = {
   url: string;
   relativeDestination: string;
@@ -7,6 +9,7 @@ export type JobData = {
   scenarioId: string;
   assets: Assets;
   blmValues: number[];
+  config: WebshotConfig;
 };
 
 export type ProgressData =

--- a/api/libs/webshot/src/index.ts
+++ b/api/libs/webshot/src/index.ts
@@ -5,4 +5,8 @@ export {
   unknownPngWebshotError,
 } from './webshot.service';
 
-export { WebshotConfig } from './webshot.dto';
+export {
+  WebshotConfig,
+  WebshotPdfConfig,
+  WebshotPngConfig,
+} from './webshot.dto';

--- a/api/libs/webshot/src/webshot.dto.ts
+++ b/api/libs/webshot/src/webshot.dto.ts
@@ -22,14 +22,18 @@ export class WebshotConfig {
   @ApiPropertyOptional()
   @IsOptional()
   cookie?: string;
+}
 
-  @ApiPropertyOptional()
-  @IsOptional()
-  pdfOptions?: PDFOptions;
-
+export class WebshotPngConfig extends WebshotConfig {
   @ApiPropertyOptional()
   @IsOptional()
   screenshotOptions?: ScreenshotOptions;
+}
+
+export class WebshotPdfConfig extends WebshotConfig {
+  @ApiPropertyOptional()
+  @IsOptional()
+  pdfOptions?: PDFOptions;
 
   @ValidateNested()
   @IsObject()

--- a/api/libs/webshot/src/webshot.service.ts
+++ b/api/libs/webshot/src/webshot.service.ts
@@ -1,7 +1,7 @@
 import { HttpService, Injectable } from '@nestjs/common';
 import { Readable } from 'stream';
 import { Either, left, right } from 'fp-ts/lib/Either';
-import { WebshotConfig } from './webshot.dto';
+import { WebshotPdfConfig, WebshotPngConfig } from './webshot.dto';
 
 export const unknownPdfWebshotError = Symbol(`unknown pdf webshot error`);
 export const unknownPngWebshotError = Symbol(`unknown png webshot error`);
@@ -13,7 +13,7 @@ export class WebshotService {
   async getSummaryReportForScenario(
     scenarioId: string,
     projectId: string,
-    config: WebshotConfig,
+    config: WebshotPdfConfig,
     webshotUrl: string,
   ): Promise<Either<typeof unknownPdfWebshotError, Readable>> {
     try {
@@ -43,10 +43,10 @@ export class WebshotService {
   async getBlmValuesImage(
     scenarioId: string,
     projectId: string,
-    config: WebshotConfig,
+    config: WebshotPngConfig,
     blmValue: number,
     webshotUrl: string,
-  ): Promise<Either<typeof unknownPngWebshotError, Readable>> {
+  ): Promise<Either<typeof unknownPngWebshotError, string>> {
     try {
       const pngBuffer = await this.httpService
         .post(
@@ -60,12 +60,9 @@ export class WebshotService {
           throw new Error(error);
         });
 
-      const stream = new Readable();
+      const pngBase64String = Buffer.from(pngBuffer).toString('base64');
 
-      stream.push(pngBuffer);
-      stream.push(null);
-
-      return right(stream);
+      return right(pngBase64String);
     } catch (error) {
       return left(unknownPngWebshotError);
     }

--- a/api/libs/webshot/src/webshot.service.ts
+++ b/api/libs/webshot/src/webshot.service.ts
@@ -1,5 +1,4 @@
 import { HttpService, Injectable } from '@nestjs/common';
-import { AppConfig } from '@marxan-api/utils/config.utils';
 import { Readable } from 'stream';
 import { Either, left, right } from 'fp-ts/lib/Either';
 import { WebshotConfig } from './webshot.dto';
@@ -9,19 +8,18 @@ export const unknownPngWebshotError = Symbol(`unknown png webshot error`);
 
 @Injectable()
 export class WebshotService {
-  private webshotServiceUrl: string = AppConfig.get('webshot.url') as string;
-
   constructor(private readonly httpService: HttpService) {}
 
   async getSummaryReportForScenario(
     scenarioId: string,
     projectId: string,
     config: WebshotConfig,
+    webshotUrl: string,
   ): Promise<Either<typeof unknownPdfWebshotError, Readable>> {
     try {
       const pdfBuffer = await this.httpService
         .post(
-          `${this.webshotServiceUrl}/projects/${projectId}/scenarios/${scenarioId}/solutions/report`,
+          `${webshotUrl}/projects/${projectId}/scenarios/${scenarioId}/solutions/report`,
           config,
           { responseType: 'arraybuffer' },
         )
@@ -47,11 +45,12 @@ export class WebshotService {
     projectId: string,
     config: WebshotConfig,
     blmValue: number,
+    webshotUrl: string,
   ): Promise<Either<typeof unknownPngWebshotError, Readable>> {
     try {
       const pngBuffer = await this.httpService
         .post(
-          `${this.webshotServiceUrl}/projects/${projectId}/scenarios/${scenarioId}/calibration/maps/preview/${blmValue}`,
+          `${webshotUrl}/projects/${projectId}/scenarios/${scenarioId}/calibration/maps/preview/${blmValue}`,
           config,
           { responseType: 'arraybuffer' },
         )


### PR DESCRIPTION
-Adds a migration for the new two columns in `blm_final_results` table: `protected_pu_ids` and `png_data`.
-Adds new columns in entity to be used in update method on `blm_final_results` repo.


WIP: Sending png generation request to webshot-service + tile generation endpoint. Tests.