### PR TITLE
MARXAN-1415-isAdmin-users-me-endpoint

### DIFF
--- a/api/apps/api/src/modules/users/user.api.entity.ts
+++ b/api/apps/api/src/modules/users/user.api.entity.ts
@@ -87,6 +87,9 @@ export class User {
   @Column('boolean', { name: 'is_deleted' })
   isDeleted!: boolean;
 
+  @ApiPropertyOptional()
+  isAdmin?: boolean;
+
   @ApiProperty({ type: () => Project, isArray: true })
   @ManyToMany((_type) => Project, (project) => project.users, { eager: false })
   @JoinTable({

--- a/api/apps/api/src/modules/users/users.service.ts
+++ b/api/apps/api/src/modules/users/users.service.ts
@@ -61,6 +61,7 @@ export class UsersService extends AppBaseService<
         'isActive',
         'isBlocked',
         'isDeleted',
+        'isAdmin',
         'metadata',
         'projects',
         'scenarios',
@@ -230,6 +231,14 @@ export class UsersService extends AppBaseService<
 
   private hash(password: string) {
     return hash(password, 10);
+  }
+
+  async extendGetByIdResult(entity: User): Promise<User> {
+    const isAdmin = await this.isPlatformAdmin(entity.id);
+
+    entity.isAdmin = isAdmin;
+
+    return entity;
   }
 
   async isPlatformAdmin(userId: string): Promise<boolean> {

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -355,17 +355,35 @@ describe('UsersModule (e2e)', () => {
   describe('Users - Platform admins', () => {
     let adminToken: string;
     let adminUserId: string;
+    let nonAdminToken: string;
     const cleanups: (() => Promise<void>)[] = [];
 
     beforeAll(async () => {
       adminToken = await GivenUserIsLoggedIn(app, 'dd');
       adminUserId = await GivenUserExists(app, 'dd');
+      nonAdminToken = await GivenUserIsLoggedIn(app, 'aa');
     });
 
     afterEach(async () => {
       for (const cleanup of cleanups.reverse()) {
         await cleanup();
       }
+    });
+
+    test('A platform admin should be able to identify itself as admin on /me endpoint', async () => {
+      const WhenGettingOwnInfo = await request(app.getHttpServer())
+        .get('/api/v1/users/me')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(WhenGettingOwnInfo.body.data.attributes.isAdmin).toBe(true);
+    });
+
+    test('A non platform admin should be not able to identify itself as admin on /me endpoint', async () => {
+      const WhenGettingOwnInfo = await request(app.getHttpServer())
+        .get('/api/v1/users/me')
+        .set('Authorization', `Bearer ${nonAdminToken}`);
+
+      expect(WhenGettingOwnInfo.body.data.attributes.isAdmin).toBe(false);
     });
 
     test('A platform admin should be able to get the list of admins in the app after seed (just 1)', async () => {


### PR DESCRIPTION
-Adds `isAdmin` flag to users/me endpoint.
-Adds small tests for this new flag.