### PR TITLE
feat: include id of imported project in the response

### DIFF
--- a/api/apps/api/src/modules/clone/import/application/import-project.command.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.command.ts
@@ -6,7 +6,14 @@ import { SaveError } from './import.repository.port';
 
 export type ImportProjectError = SaveError | ArchiveReadError;
 
-export class ImportProject extends Command<Either<ImportProjectError, string>> {
+export type ImportProjectCommandResult = {
+  importId: string;
+  projectId: string;
+};
+
+export class ImportProject extends Command<
+  Either<ImportProjectError, ImportProjectCommandResult>
+> {
   constructor(public readonly archiveLocation: ArchiveLocation) {
     super();
   }

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
@@ -29,7 +29,10 @@ import {
 import { ImportResourcePieces } from './import-resource-pieces.port';
 import { ImportRepository } from './import.repository.port';
 import { ImportProjectHandler } from './import-project.handler';
-import { ImportProject } from './import-project.command';
+import {
+  ImportProject,
+  ImportProjectCommandResult,
+} from './import-project.command';
 import { ImportComponentStatuses } from '../domain/import/import-component-status';
 
 let fixtures: FixtureType<typeof getFixtures>;
@@ -111,7 +114,7 @@ const getFixtures = async () => {
       );
       if (isRight(importResult))
         resourceId = new ResourceId(
-          repo.entities[importResult.right].resourceId,
+          repo.entities[importResult.right.importId].resourceId,
         );
       return importResult;
     },
@@ -120,7 +123,9 @@ const getFixtures = async () => {
     ) => {
       expect(isRight(importResult)).toBeTruthy();
       expect(
-        repo.entities[(importResult as Right<string>).right],
+        repo.entities[
+          (importResult as Right<ImportProjectCommandResult>).right.importId
+        ],
       ).toBeDefined();
     },
     ThenImportFails: (

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.ts
@@ -8,7 +8,11 @@ import {
 import { Either, isLeft, right } from 'fp-ts/Either';
 import { Import } from '../domain/import/import';
 import { ExportConfigReader } from './export-config-reader';
-import { ImportProject, ImportProjectError } from './import-project.command';
+import {
+  ImportProject,
+  ImportProjectCommandResult,
+  ImportProjectError,
+} from './import-project.command';
 import { ImportResourcePieces } from './import-resource-pieces.port';
 import { ImportRepository } from './import.repository.port';
 
@@ -24,7 +28,9 @@ export class ImportProjectHandler
 
   async execute({
     archiveLocation,
-  }: ImportProject): Promise<Either<ImportProjectError, string>> {
+  }: ImportProject): Promise<
+    Either<ImportProjectError, ImportProjectCommandResult>
+  > {
     const exportConfigOrError = await this.exportConfigReader.read(
       archiveLocation,
     );
@@ -58,6 +64,9 @@ export class ImportProjectHandler
 
     importRequest.commit();
 
-    return right(importRequest.importId.value);
+    return right({
+      importId: importRequest.importId.value,
+      projectId: projectId.value,
+    });
   }
 }

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.command.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.command.ts
@@ -6,8 +6,13 @@ import { SaveError } from './import.repository.port';
 
 export type ImportScenarioError = SaveError | ArchiveReadError;
 
+export type ImportScenarioCommandResult = {
+  importId: string;
+  scenarioId: string;
+};
+
 export class ImportScenario extends Command<
-  Either<ImportScenarioError, string>
+  Either<ImportScenarioError, ImportScenarioCommandResult>
 > {
   constructor(public readonly archiveLocation: ArchiveLocation) {
     super();

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
@@ -30,7 +30,10 @@ import {
 import { ImportComponentStatuses } from '../domain/import/import-component-status';
 import { ExportConfigReader } from './export-config-reader';
 import { ImportResourcePieces } from './import-resource-pieces.port';
-import { ImportScenario } from './import-scenario.command';
+import {
+  ImportScenario,
+  ImportScenarioCommandResult,
+} from './import-scenario.command';
 import { ImportScenarioHandler } from './import-scenario.handler';
 import { ImportRepository } from './import.repository.port';
 
@@ -113,7 +116,7 @@ const getFixtures = async () => {
       );
       if (isRight(importResult))
         resourceId = new ResourceId(
-          repo.entities[importResult.right].resourceId,
+          repo.entities[importResult.right.importId].resourceId,
         );
       return importResult;
     },
@@ -122,7 +125,9 @@ const getFixtures = async () => {
     ) => {
       expect(isRight(importResult)).toBeTruthy();
       expect(
-        repo.entities[(importResult as Right<string>).right],
+        repo.entities[
+          (importResult as Right<ImportScenarioCommandResult>).right.importId
+        ],
       ).toBeDefined();
     },
     ThenImportFails: (

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.ts
@@ -9,7 +9,11 @@ import { Either, isLeft, right } from 'fp-ts/Either';
 import { Import } from '../domain/import/import';
 import { ExportConfigReader } from './export-config-reader';
 import { ImportResourcePieces } from './import-resource-pieces.port';
-import { ImportScenario, ImportScenarioError } from './import-scenario.command';
+import {
+  ImportScenario,
+  ImportScenarioCommandResult,
+  ImportScenarioError,
+} from './import-scenario.command';
 import { ImportRepository } from './import.repository.port';
 
 @CommandHandler(ImportScenario)
@@ -24,7 +28,9 @@ export class ImportScenarioHandler
 
   async execute({
     archiveLocation,
-  }: ImportScenario): Promise<Either<ImportScenarioError, string>> {
+  }: ImportScenario): Promise<
+    Either<ImportScenarioError, ImportScenarioCommandResult>
+  > {
     const exportConfigOrError = await this.exportConfigReader.read(
       archiveLocation,
     );
@@ -59,6 +65,9 @@ export class ImportScenarioHandler
 
     importRequest.commit();
 
-    return right(importRequest.importId.value);
+    return right({
+      importId: importRequest.importId.value,
+      scenarioId: importResourceId.value,
+    });
   }
 }

--- a/api/apps/api/src/modules/projects/dto/import.project.response.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/import.project.response.dto.ts
@@ -6,4 +6,10 @@ export class RequestProjectImportResponseDto {
     example: '6fbec34e-04a7-4131-be14-c245f2435a6c',
   })
   importId!: string;
+
+  @ApiProperty({
+    description: 'ID of the new project',
+    example: 'dbe1a039-44d1-4e66-a02d-a3cadf691892',
+  })
+  projectId!: string;
 }

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -747,10 +747,10 @@ export class ProjectsController {
   async importProject(
     @UploadedFile() file: Express.Multer.File,
   ): Promise<RequestProjectImportResponseDto> {
-    const importIdOrError = await this.projectsService.importProject(file);
+    const idsOrError = await this.projectsService.importProject(file);
 
-    if (isLeft(importIdOrError)) {
-      switch (importIdOrError.left) {
+    if (isLeft(idsOrError)) {
+      switch (idsOrError.left) {
         case archiveCorrupted:
           throw new BadRequestException('Missing export config file');
         case invalidFiles:
@@ -763,6 +763,9 @@ export class ProjectsController {
       }
     }
 
-    return { importId: importIdOrError.right };
+    return {
+      importId: idsOrError.right.importId,
+      projectId: idsOrError.right.projectId,
+    };
   }
 }

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -55,6 +55,7 @@ import { UploadExportFile } from '../clone/infra/import/upload-export-file.comma
 import { unknownError } from '@marxan/files-repository';
 import {
   ImportProject,
+  ImportProjectCommandResult,
   ImportProjectError,
 } from '../clone/import/application/import-project.command';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
@@ -465,7 +466,9 @@ export class ProjectsService {
 
   async importProject(
     exportFile: Express.Multer.File,
-  ): Promise<Either<typeof unknownError | ImportProjectError, string>> {
+  ): Promise<
+    Either<typeof unknownError | ImportProjectError, ImportProjectCommandResult>
+  > {
     const archiveLocationOrError = await this.commandBus.execute(
       new UploadExportFile(exportFile),
     );
@@ -474,15 +477,15 @@ export class ProjectsService {
       return archiveLocationOrError;
     }
 
-    const importIdOrError = await this.commandBus.execute(
+    const idsOrError = await this.commandBus.execute(
       new ImportProject(archiveLocationOrError.right),
     );
 
-    if (isLeft(importIdOrError)) {
-      return importIdOrError;
+    if (isLeft(idsOrError)) {
+      return idsOrError;
     }
 
-    return right(importIdOrError.right);
+    return right(idsOrError.right);
   }
 
   /**


### PR DESCRIPTION
This PR adds `projectId` property to import project endpoint response

### Feature relevant tickets

[Include id of new (cloned/imported) project in the response of POST /api/v1/projects/import](https://vizzuality.atlassian.net/browse/MARXAN-1444)