### PR TITLE
Fix/png blm image from database

### DIFF
--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1322,7 +1322,6 @@ export class ScenariosController {
     pdfStream.right.pipe(res);
   }
 
-  // @debt Refactor to use the correct blm PNG data from table.
   @ApiOperation({ description: 'Get PNG for BLM values for scenario' })
   @ApiOkResponse()
   @Get('/:scenarioId/calibration/maps/preview/:blmValue')

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -112,6 +112,7 @@ import {
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { apiConnections } from '@marxan-api/ormconfig';
 import { EntityManager } from 'typeorm';
+import { blmImageMock } from './__mock__/blm-image-mock';
 
 /** @debt move to own module */
 const EmptyGeoFeaturesSpecification: GeoFeatureSetSpecification = {
@@ -1294,24 +1295,16 @@ export class ScenariosService {
       return left(forbiddenError);
     }
 
-    // PngData is stored as bytea array in Postgres, here we are converting it
-    // using the btoa function so in the end we have a base64 string.
-    const pngData = await this.geoEntityManager
+    const result = await this.geoEntityManager
       .createQueryBuilder()
       .select(['png_data'])
       .from('blm_final_results', 'bfr')
       .where('scenario_id = :scenarioId', { scenarioId })
       .andWhere('blm_value = :blmValue', { blmValue })
-      .execute();
+      .getRawOne();
 
-    const base64PngData = btoa(
-      pngData
-        .replace('\\x', '')
-        .match(/\w{2}/g)
-        .map((a: any) => String.fromCharCode(parseInt(a, 16)))
-        .join(''),
-    );
+    const pngData = result.png_data;
 
-    return right(Buffer.from(base64PngData, 'base64'));
+    return right(Buffer.from(pngData, 'base64'));
   }
 }

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
@@ -53,9 +53,8 @@ export class BlmFinalResultsRepository {
         where blm_final_results.scenario_id = $1 and blm_final_results.blm_value = $2`;
       await txManager.query(query, [scenarioId, blmValue]);
 
-      const pngDataParsedBuffer = Buffer.from(
-        '\\x' + Buffer.from(pngData, 'base64').toString('hex'),
-      );
+      const pngDataParsedBuffer = Buffer.from(pngData, 'base64');
+
       await txManager.update(
         BlmFinalResultEntity,
         { scenarioId, blmValue },

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -3,7 +3,7 @@ import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { AppConfig } from '@marxan-geoprocessing/utils/config.utils';
 import { JobData } from '@marxan/blm-calibration';
 import { WebshotService } from '@marxan/webshot';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { EventBus } from '@nestjs/cqrs';
 import { InjectEntityManager } from '@nestjs/typeorm';

--- a/api/libs/blm-calibration/src/blm-final-results.geo.entity.ts
+++ b/api/libs/blm-calibration/src/blm-final-results.geo.entity.ts
@@ -47,6 +47,7 @@ export class BlmFinalResultEntity {
     name: `protected_pu_ids`,
     type: 'uuid',
     array: true,
+    nullable: true,
   })
   protected_pu_ids!: string[];
 


### PR DESCRIPTION
- Fixes images not saving in database properly.
- Fixes GET endpoint for blm images inside final_results using mock images.
- Improves specific test for GET endpoint of blm images process.