### PR TITLE
Feat/marxan 1445 grant project owner role on imported cloned project to user

### DIFF
--- a/api/apps/api/src/migrations/api/1649329520250-AddOwnerIdColumnToImportsTable.ts
+++ b/api/apps/api/src/migrations/api/1649329520250-AddOwnerIdColumnToImportsTable.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOwnerIdColumnToImportsTable1649329520250
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE imports ADD COLUMN owner_id uuid NOT NULL;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE imports 
+        ADD CONSTRAINT imports_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users(id);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE imports DROP COLUMN owner_id;
+    `);
+  }
+}

--- a/api/apps/api/src/modules/clone/import/adapters/entities/imports.api.entity.ts
+++ b/api/apps/api/src/modules/clone/import/adapters/entities/imports.api.entity.ts
@@ -1,5 +1,13 @@
 import { ResourceKind } from '@marxan/cloning/domain';
-import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+} from 'typeorm';
+import { User } from '../../../../users/user.api.entity';
 import { Import } from '../../domain';
 import { ImportComponentEntity } from './import-components.api.entity';
 
@@ -13,6 +21,9 @@ export class ImportEntity {
 
   @Column({ type: 'uuid', name: 'project_id' })
   projectId!: string;
+
+  @Column({ type: 'uuid', name: 'owner_id' })
+  ownerId!: string;
 
   @Column({
     type: 'enum',
@@ -32,6 +43,15 @@ export class ImportEntity {
   })
   components!: ImportComponentEntity[];
 
+  @ManyToOne(() => User, (user) => user.id, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'owner_id',
+    referencedColumnName: 'id',
+  })
+  owner!: User;
+
   static fromAggregate(importAggregate: Import): ImportEntity {
     const snapshot = importAggregate.toSnapshot();
 
@@ -45,6 +65,7 @@ export class ImportEntity {
     entity.components = snapshot.importPieces.map(
       ImportComponentEntity.fromSnapshot,
     );
+    entity.ownerId = snapshot.ownerId;
 
     return entity;
   }
@@ -57,6 +78,7 @@ export class ImportEntity {
       resourceKind: this.resourceKind,
       archiveLocation: this.archiveLocation,
       importPieces: this.components.map((component) => component.toSnapshot()),
+      ownerId: this.ownerId,
     });
   }
 }

--- a/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.spec.ts
@@ -6,6 +6,7 @@ import {
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';
+import { UserId } from '@marxan/domain-ids';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Logger } from '@nestjs/common';
 import {
@@ -131,6 +132,8 @@ const getFixtures = async () => {
   }).compile();
   await sandbox.init();
 
+  const ownerId = UserId.create();
+
   const events: IEvent[] = [];
   const commands: ICommand[] = [];
 
@@ -156,6 +159,7 @@ const getFixtures = async () => {
         importResourceId,
         ResourceKind.Project,
         projectId,
+        ownerId,
         new ArchiveLocation('/tmp/location.zip'),
         pieces,
       );

--- a/api/apps/api/src/modules/clone/import/application/import-project.command.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.command.ts
@@ -1,5 +1,6 @@
 import { ArchiveLocation } from '@marxan/cloning/domain';
 import { Failure as ArchiveReadError } from '@marxan/cloning/infrastructure/archive-reader.port';
+import { UserId } from '@marxan/domain-ids';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { Either } from 'fp-ts/lib/Either';
 import { SaveError } from './import.repository.port';
@@ -14,7 +15,10 @@ export type ImportProjectCommandResult = {
 export class ImportProject extends Command<
   Either<ImportProjectError, ImportProjectCommandResult>
 > {
-  constructor(public readonly archiveLocation: ArchiveLocation) {
+  constructor(
+    public readonly archiveLocation: ArchiveLocation,
+    public readonly ownerId: UserId,
+  ) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
@@ -6,15 +6,19 @@ import {
   ResourceKind,
 } from '@marxan/cloning/domain';
 import {
+  Failure as ArchiveFailure,
+  invalidFiles,
+} from '@marxan/cloning/infrastructure/archive-reader.port';
+import {
   ExportConfigContent,
   ProjectExportConfigContent,
 } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
+import { UserId } from '@marxan/domain-ids';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
 import { Either, isLeft, isRight, left, Right, right } from 'fp-ts/Either';
 import { PromiseType } from 'utility-types';
-import { ExportConfigReader } from './export-config-reader';
 import { MemoryImportRepository } from '../adapters/memory-import.repository.adapter';
 import {
   ImportComponent,
@@ -22,18 +26,15 @@ import {
   ImportRequested,
   PieceImportRequested,
 } from '../domain';
-import {
-  Failure as ArchiveFailure,
-  invalidFiles,
-} from '@marxan/cloning/infrastructure/archive-reader.port';
-import { ImportResourcePieces } from './import-resource-pieces.port';
-import { ImportRepository } from './import.repository.port';
-import { ImportProjectHandler } from './import-project.handler';
+import { ImportComponentStatuses } from '../domain/import/import-component-status';
+import { ExportConfigReader } from './export-config-reader';
 import {
   ImportProject,
   ImportProjectCommandResult,
 } from './import-project.command';
-import { ImportComponentStatuses } from '../domain/import/import-component-status';
+import { ImportProjectHandler } from './import-project.handler';
+import { ImportResourcePieces } from './import-resource-pieces.port';
+import { ImportRepository } from './import.repository.port';
 
 let fixtures: FixtureType<typeof getFixtures>;
 
@@ -83,6 +84,7 @@ const getFixtures = async () => {
   await sandbox.init();
 
   let resourceId: ResourceId;
+  const ownerId = UserId.create();
 
   const events: IEvent[] = [];
   sandbox.get(EventBus).subscribe((event) => events.push(event));
@@ -110,7 +112,7 @@ const getFixtures = async () => {
     },
     WhenRequestingImport: async () => {
       const importResult = await sut.execute(
-        new ImportProject(new ArchiveLocation(`whatever`)),
+        new ImportProject(new ArchiveLocation(`whatever`), ownerId),
       );
       if (isRight(importResult))
         resourceId = new ResourceId(

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.ts
@@ -28,6 +28,7 @@ export class ImportProjectHandler
 
   async execute({
     archiveLocation,
+    ownerId,
   }: ImportProject): Promise<
     Either<ImportProjectError, ImportProjectCommandResult>
   > {
@@ -51,6 +52,7 @@ export class ImportProjectHandler
         importResourceId,
         ResourceKind.Project,
         projectId,
+        ownerId,
         archiveLocation,
         pieces,
       ),

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.command.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.command.ts
@@ -1,5 +1,6 @@
 import { ArchiveLocation } from '@marxan/cloning/domain';
 import { Failure as ArchiveReadError } from '@marxan/cloning/infrastructure/archive-reader.port';
+import { UserId } from '@marxan/domain-ids';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { Either } from 'fp-ts/lib/Either';
 import { SaveError } from './import.repository.port';
@@ -14,7 +15,10 @@ export type ImportScenarioCommandResult = {
 export class ImportScenario extends Command<
   Either<ImportScenarioError, ImportScenarioCommandResult>
 > {
-  constructor(public readonly archiveLocation: ArchiveLocation) {
+  constructor(
+    public readonly archiveLocation: ArchiveLocation,
+    public readonly ownerId: UserId,
+  ) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
@@ -14,6 +14,7 @@ import {
   ProjectExportConfigContent,
   ScenarioExportConfigContent,
 } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
+import { UserId } from '@marxan/domain-ids';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
@@ -85,6 +86,7 @@ const getFixtures = async () => {
   await sandbox.init();
 
   let resourceId: ResourceId;
+  const ownerId = UserId.create();
 
   const events: IEvent[] = [];
   sandbox.get(EventBus).subscribe((event) => events.push(event));
@@ -112,7 +114,7 @@ const getFixtures = async () => {
     },
     WhenRequestingImport: async () => {
       const importResult = await sut.execute(
-        new ImportScenario(new ArchiveLocation(`whatever`)),
+        new ImportScenario(new ArchiveLocation(`whatever`), ownerId),
       );
       if (isRight(importResult))
         resourceId = new ResourceId(

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.ts
@@ -28,6 +28,7 @@ export class ImportScenarioHandler
 
   async execute({
     archiveLocation,
+    ownerId,
   }: ImportScenario): Promise<
     Either<ImportScenarioError, ImportScenarioCommandResult>
   > {
@@ -52,6 +53,7 @@ export class ImportScenarioHandler
         importResourceId,
         ResourceKind.Scenario,
         new ResourceId(exportConfig.projectId),
+        ownerId,
         archiveLocation,
         pieces,
       ),

--- a/api/apps/api/src/modules/clone/import/domain/import/import.snapshot.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.snapshot.ts
@@ -8,4 +8,5 @@ export interface ImportSnapshot {
   archiveLocation: string;
   importPieces: ImportComponentSnapshot[];
   projectId: string;
+  ownerId: string;
 }

--- a/api/apps/api/src/modules/clone/import/domain/import/import.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.ts
@@ -6,6 +6,7 @@ import {
 } from '@marxan/cloning/domain';
 import { AggregateRoot } from '@nestjs/cqrs';
 import { Either, left, right } from 'fp-ts/Either';
+import { UserId } from '@marxan/domain-ids';
 import { AllPiecesImported } from '../events/all-pieces-imported.event';
 import { ImportBatchFailed } from '../events/import-batch-failed.event';
 import { ImportRequested } from '../events/import-requested.event';
@@ -33,6 +34,7 @@ export class Import extends AggregateRoot {
     private readonly resourceId: ResourceId,
     private readonly resourceKind: ResourceKind,
     private readonly projectId: ResourceId,
+    private readonly ownerId: UserId,
     private readonly archiveLocation: ArchiveLocation,
     private readonly pieces: ImportComponent[],
   ) {
@@ -60,6 +62,7 @@ export class Import extends AggregateRoot {
       new ResourceId(snapshot.resourceId),
       snapshot.resourceKind,
       new ResourceId(snapshot.projectId),
+      new UserId(snapshot.ownerId),
       new ArchiveLocation(snapshot.archiveLocation),
       snapshot.importPieces.map(ImportComponent.fromSnapshot),
     );
@@ -69,6 +72,7 @@ export class Import extends AggregateRoot {
     resourceId: ResourceId,
     kind: ResourceKind,
     projectId: ResourceId,
+    ownerId: UserId,
     archiveLocation: ArchiveLocation,
     pieces: ImportComponent[],
   ): Import {
@@ -78,6 +82,7 @@ export class Import extends AggregateRoot {
       resourceId,
       kind,
       projectId,
+      ownerId,
       archiveLocation,
       pieces,
     );
@@ -184,6 +189,7 @@ export class Import extends AggregateRoot {
       importPieces: this.pieces.map((piece) => piece.toSnapshot()),
       archiveLocation: this.archiveLocation.value,
       projectId: this.projectId.value,
+      ownerId: this.ownerId.value,
     };
   }
 }

--- a/api/apps/api/src/modules/clone/infra/import/import-piece.events-handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import-piece.events-handler.spec.ts
@@ -87,6 +87,7 @@ const getFixtures = async () => {
         projectId: v4(),
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: v4(),
       };
     },
     WhenJobFinishes: async (input: ImportJobInput) => {

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
@@ -6,6 +6,7 @@ import {
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';
+import { UserId } from '@marxan/domain-ids';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Logger } from '@nestjs/common';
 import { CommandBus, CommandHandler, CqrsModule, ICommand } from '@nestjs/cqrs';
@@ -113,6 +114,7 @@ const getFixtures = async () => {
   }).compile();
   await sandbox.init();
 
+  const ownerId = UserId.create();
   const commands: ICommand[] = [];
   sandbox.get(CommandBus).subscribe((command) => {
     commands.push(command);
@@ -136,6 +138,7 @@ const getFixtures = async () => {
         importResourceId,
         ResourceKind.Project,
         projectId,
+        ownerId,
         new ArchiveLocation('/tmp/foo.zip'),
         [importComponent],
       );

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.ts
@@ -54,6 +54,7 @@ export class SchedulePieceImportHandler
       resourceKind,
       projectId,
       importPieces,
+      ownerId,
     } = importInstance.toSnapshot();
 
     const component = importPieces.find(
@@ -74,6 +75,7 @@ export class SchedulePieceImportHandler
       componentId: componentId.value,
       pieceResourceId: resourceId,
       projectId,
+      ownerId,
       resourceKind,
       uris,
     });

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -746,11 +746,17 @@ export class ProjectsController {
   @UseInterceptors(FileInterceptor('file'))
   async importProject(
     @UploadedFile() file: Express.Multer.File,
+    @Req() req: RequestWithAuthenticatedUser,
   ): Promise<RequestProjectImportResponseDto> {
-    const idsOrError = await this.projectsService.importProject(file);
+    const idsOrError = await this.projectsService.importProject(
+      file,
+      req.user.id,
+    );
 
     if (isLeft(idsOrError)) {
       switch (idsOrError.left) {
+        case forbiddenError:
+          throw new ForbiddenException();
         case archiveCorrupted:
           throw new BadRequestException('Missing export config file');
         case invalidFiles:

--- a/api/apps/api/test/integration/typeorm-import.repository.integration.e2e-spec.ts
+++ b/api/apps/api/test/integration/typeorm-import.repository.integration.e2e-spec.ts
@@ -1,11 +1,11 @@
+import { ImportEntity } from '@marxan-api/modules/clone/import/adapters/entities/imports.api.entity';
+import { ImportAdaptersModule } from '@marxan-api/modules/clone/import/adapters/import-adapters.module';
+import { ImportRepository } from '@marxan-api/modules/clone/import/application/import.repository.port';
 import {
   Import,
   ImportComponent,
   ImportId,
 } from '@marxan-api/modules/clone/import/domain';
-import { ImportEntity } from '@marxan-api/modules/clone/import/adapters/entities/imports.api.entity';
-import { ImportAdaptersModule } from '@marxan-api/modules/clone/import/adapters/import-adapters.module';
-import { ImportRepository } from '@marxan-api/modules/clone/import/application/import.repository.port';
 import {
   ArchiveLocation,
   ClonePiece,
@@ -14,12 +14,13 @@ import {
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';
+import { UserId } from '@marxan/domain-ids';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Connection } from 'typeorm';
-import { apiConnections } from '../../src/ormconfig';
 import { ImportComponentStatuses } from '../../src/modules/clone/import/domain/import/import-component-status';
+import { apiConnections } from '../../src/ormconfig';
 
 describe('Typeorm import repository', () => {
   let fixtures: FixtureType<typeof getFixtures>;
@@ -66,6 +67,7 @@ const getFixtures = async () => {
   let importResourceId: ResourceId;
   let componentId: ComponentId;
   let archiveLocation: ArchiveLocation;
+  const ownerId = UserId.create();
 
   const testingModule = await Test.createTestingModule({
     imports: [
@@ -96,6 +98,7 @@ const getFixtures = async () => {
         importResourceId,
         ResourceKind.Project,
         projectId,
+        ownerId,
         archiveLocation,
         [
           ImportComponent.fromSnapshot({
@@ -136,6 +139,7 @@ const getFixtures = async () => {
         importResourceId,
         ResourceKind.Project,
         projectId,
+        ownerId,
         archiveLocation,
         components,
       );

--- a/api/apps/api/test/jest-e2e.json
+++ b/api/apps/api/test/jest-e2e.json
@@ -70,6 +70,8 @@
     "@marxan/webshot/(.*)": "<rootDir>../../../libs/webshot/src/$1",
     "@marxan/webshot": "<rootDir>../../../libs/webshot/src",
     "@marxan/geofeatures/(.*)": "<rootDir>/../../../libs/geofeatures/src/$1",
-    "@marxan/geofeatures": "<rootDir>/../../../libs/geofeatures/src"
+    "@marxan/geofeatures": "<rootDir>/../../../libs/geofeatures/src",
+    "@marxan/domain-ids/(.*)": "<rootDir>/../../../libs/domain-ids/src/$1",
+    "@marxan/domain-ids": "<rootDir>/../../../libs/domain-ids/src"
   }
 }

--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
@@ -1,5 +1,6 @@
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
+import { ResourceKind } from '@marxan/cloning/domain';
 import { ScenarioMetadataContent } from '@marxan/cloning/infrastructure/clone-piece-data/scenario-metadata';
 import { FileRepository } from '@marxan/files-repository';
 import { extractFile } from '@marxan/utils';
@@ -29,7 +30,14 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
   }
 
   async run(input: ImportJobInput): Promise<ImportJobOutput> {
-    const { pieceResourceId: scenarioId, projectId, uris, piece } = input;
+    const {
+      pieceResourceId: scenarioId,
+      projectId,
+      uris,
+      piece,
+      resourceKind,
+      ownerId,
+    } = input;
 
     if (uris.length !== 1) {
       const errorMessage = `uris array has an unexpected amount of elements: ${uris.length}`;
@@ -68,20 +76,42 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
       stringScenarioMetadataOrError.right,
     );
 
-    await this.entityManager
-      .createQueryBuilder()
-      .insert()
-      .into('scenarios')
-      .values({
-        id: scenarioId,
-        name,
-        description,
-        blm,
-        number_of_runs: numberOfRuns,
-        metadata,
-        project_id: projectId,
-      })
-      .execute();
+    await this.entityManager.transaction(async (em) => {
+      await em
+        .createQueryBuilder()
+        .insert()
+        .into('scenarios')
+        .values({
+          id: scenarioId,
+          name,
+          description,
+          blm,
+          number_of_runs: numberOfRuns,
+          metadata,
+          project_id: projectId,
+        })
+        .execute();
+
+      if (resourceKind === ResourceKind.Scenario) {
+        await em
+          .createQueryBuilder()
+          .insert()
+          .into(`users_scenarios`)
+          .values({
+            user_id: ownerId,
+            scenario_id: scenarioId,
+            // It would be great to use ScenarioRoles enum instead of having
+            // the role hardcoded. The thing is that Geoprocessing code shouldn't depend
+            // directly on elements of Api code, so there were two options:
+            // - Move ScenarioRoles enum to libs package
+            // - Harcode the rol
+            // We took the second approach because we are only referencing values from that enum
+            // here
+            role_id: 'scenario_owner',
+          })
+          .execute();
+      }
+    });
 
     return {
       importId: input.importId,

--- a/api/apps/geoprocessing/test/integration/clonning/fixtures.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/fixtures.ts
@@ -23,6 +23,7 @@ import { isLeft } from 'fp-ts/lib/Either';
 import { Readable, Transform } from 'stream';
 import { DeepPartial, EntityManager, In } from 'typeorm';
 import { v4 } from 'uuid';
+import { hash } from 'bcrypt';
 
 const randomGeometriesBoundary =
   '0103000020E6100000010000000A00000000000000602630C0A12CF6C9EE913C4000000000F46430C0C6D6EE9332863C4000000000C07A30C06718E5AE99673C40000000008ADD30C0AE5F48C4D85B3C40000000006EAE30C0EF8810F1D7033C4000000000DC7C30C0B0AB582D481D3C4000000000246230C0712DA50F7E533C4000000000086030C0323EBB984F6B3C40000000009E2430C03B55C7C9C18B3C4000000000602630C0A12CF6C9EE913C40';
@@ -70,6 +71,31 @@ export async function PrepareZipFile(
 
   if (isLeft(uriOrError)) throw new Error("couldn't save file");
   return new ArchiveLocation(uriOrError.right);
+}
+
+export function GivenUserExists(
+  em: EntityManager,
+  userId: string,
+  projectId: string,
+) {
+  return em
+    .createQueryBuilder()
+    .insert()
+    .into(`users`)
+    .values({
+      id: userId,
+      email: `${userId}@${projectId}.com`,
+      password_hash: hash('supersecretpassword', 10),
+    })
+    .execute();
+}
+
+export function DeleteUser(em: EntityManager, userId: string) {
+  return em
+    .createQueryBuilder()
+    .delete()
+    .from('user')
+    .where('id = :userId', { userId });
 }
 
 export function GivenOrganizationExists(

--- a/api/apps/geoprocessing/test/integration/clonning/fixtures.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/fixtures.ts
@@ -19,11 +19,11 @@ import {
   ScenariosPuPaDataGeo,
 } from '@marxan/scenarios-planning-unit';
 import * as archiver from 'archiver';
+import { hash } from 'bcrypt';
 import { isLeft } from 'fp-ts/lib/Either';
 import { Readable, Transform } from 'stream';
 import { DeepPartial, EntityManager, In } from 'typeorm';
 import { v4 } from 'uuid';
-import { hash } from 'bcrypt';
 
 const randomGeometriesBoundary =
   '0103000020E6100000010000000A00000000000000602630C0A12CF6C9EE913C4000000000F46430C0C6D6EE9332863C4000000000C07A30C06718E5AE99673C40000000008ADD30C0AE5F48C4D85B3C40000000006EAE30C0EF8810F1D7033C4000000000DC7C30C0B0AB582D481D3C4000000000246230C0712DA50F7E533C4000000000086030C0323EBB984F6B3C40000000009E2430C03B55C7C9C18B3C4000000000602630C0A12CF6C9EE913C40';
@@ -425,6 +425,17 @@ export async function GivenFeatures(
     customFeatures,
     platformFeatures,
   };
+}
+
+export async function DeleteFeatures(em: EntityManager, featureIds: string[]) {
+  if (featureIds.length === 0) return;
+
+  await em
+    .createQueryBuilder()
+    .delete()
+    .from('features')
+    .where('id IN (:...featureIds)', { featureIds })
+    .execute();
 }
 
 export async function GivenFeaturesData(

--- a/api/apps/geoprocessing/test/integration/clonning/planning-area-custom.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-area-custom.piece-importer.e2e-spec.ts
@@ -92,6 +92,7 @@ const getFixtures = async () => {
   await sandbox.init();
   const organizationId = v4();
   const projectId = v4();
+  const userId = v4();
 
   const entityManager = sandbox.get<EntityManager>(
     getEntityManagerToken(geoprocessingConnections.apiDB.name),
@@ -111,9 +112,8 @@ const getFixtures = async () => {
       );
       await planningAreaRepo.delete({ projectId });
     },
-    GivenProject: () => {
-      return GivenProjectExists(entityManager, projectId, organizationId);
-    },
+    GivenProject: () =>
+      GivenProjectExists(entityManager, projectId, organizationId),
     GivenJobInput: (archiveLocation: ArchiveLocation): ImportJobInput => {
       const [uri] = ClonePieceUrisResolver.resolveFor(
         ClonePiece.PlanningAreaCustom,
@@ -127,6 +127,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaCustom,
         resourceKind: ResourceKind.Project,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -138,6 +139,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaCustom,
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoCustomPlanningAreaFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/planning-area-gadm.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-area-gadm.piece-importer.e2e-spec.ts
@@ -85,6 +85,7 @@ const getFixtures = async () => {
   await sandbox.init();
   const organizationId = v4();
   const projectId = v4();
+  const userId = v4();
 
   const entityManager = sandbox.get<EntityManager>(
     getEntityManagerToken(geoprocessingConnections.apiDB.name),
@@ -124,6 +125,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceKind: ResourceKind.Project,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -135,6 +137,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoGadmPlanningAreaFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/planning-units-grid.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-units-grid.piece-importer.e2e-spec.ts
@@ -99,6 +99,7 @@ const getFixtures = async () => {
 
   await sandbox.init();
   const projectId = v4();
+  const userId = v4();
   const sut = sandbox.get(PlanningUnitsGridPieceImporter);
   const fileRepository = sandbox.get(FileRepository);
   const entityManager = sandbox.get<EntityManager>(getEntityManagerToken());
@@ -170,6 +171,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningUnitsGrid,
         resourceKind: ResourceKind.Project,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -181,6 +183,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningUnitsGrid,
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: userId,
       };
     },
     WhenPieceImporterIsInvoked: (input: ImportJobInput) => {

--- a/api/apps/geoprocessing/test/integration/clonning/project-custom-features.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/project-custom-features.piece-importer.e2e-spec.ts
@@ -93,6 +93,7 @@ const getFixtures = async () => {
   await sandbox.init();
   const projectId = v4();
   const organizationId = v4();
+  const userId = v4();
 
   const geoEntityManager = sandbox.get<EntityManager>(getEntityManagerToken());
   const apiEntityManager = sandbox.get<EntityManager>(
@@ -149,6 +150,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectCustomFeatures,
         resourceKind: ResourceKind.Project,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -160,6 +162,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectCustomFeatures,
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoProjectCustomFeaturesFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/project-custom-protected-areas.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/project-custom-protected-areas.piece-importer.e2e-spec.ts
@@ -76,6 +76,7 @@ const getFixtures = async () => {
 
   await sandbox.init();
   const projectId = v4();
+  const userId = v4();
 
   const entityManager = sandbox.get<EntityManager>(getEntityManagerToken());
   const protectedAreasRepo = sandbox.get<Repository<ProtectedArea>>(
@@ -104,6 +105,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectCustomProtectedAreas,
         resourceKind: ResourceKind.Project,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -115,6 +117,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectCustomProtectedAreas,
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoProjectCustomProtectedAreasFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/project-metadata.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/project-metadata.piece-importer.e2e-spec.ts
@@ -19,6 +19,7 @@ import { v4 } from 'uuid';
 import {
   DeleteProjectAndOrganization,
   GivenOrganizationExists,
+  GivenUserExists,
   PrepareZipFile,
 } from './fixtures';
 
@@ -57,6 +58,7 @@ describe(ProjectMetadataPieceImporter, () => {
   it('imports project metadata', async () => {
     // Piece importer picks a random organization
     await fixtures.GivenOrganization();
+    await fixtures.GivenUser();
 
     const archiveLocation = await fixtures.GivenValidProjectMetadataFile();
     const input = fixtures.GivenJobInput(archiveLocation);
@@ -85,6 +87,7 @@ const getFixtures = async () => {
   await sandbox.init();
   const projectId = v4();
   const organizationId = v4();
+  const userId = v4();
 
   const sut = sandbox.get(ProjectMetadataPieceImporter);
   const fileRepository = sandbox.get(FileRepository);
@@ -120,8 +123,10 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceKind: ResourceKind.Project,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
+    GivenUser: () => GivenUserExists(entityManager, userId, projectId),
     GivenOrganization: () => {
       return GivenOrganizationExists(entityManager, organizationId);
     },
@@ -134,6 +139,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceKind: ResourceKind.Project,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoProjectMetadataFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-exporter.e2e-spec.ts
@@ -14,6 +14,7 @@ import { Readable } from 'stream';
 import { EntityManager, In } from 'typeorm';
 import { v4 } from 'uuid';
 import {
+  DeleteFeatures,
   DeleteProjectAndOrganization,
   GivenFeatures,
   GivenOutputScenarioFeaturesData,
@@ -104,6 +105,7 @@ const getFixtures = async () => {
 
   return {
     cleanUp: async () => {
+      await DeleteFeatures(apiEntityManager, featureIds);
       await DeleteProjectAndOrganization(
         apiEntityManager,
         projectId,

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-importer.e2e-spec.ts
@@ -23,6 +23,7 @@ import {
   GivenFeatures,
   GivenFeaturesData,
   GivenScenarioExists,
+  GivenUserExists,
   PrepareZipFile,
 } from './fixtures';
 
@@ -111,6 +112,7 @@ const getFixtures = async () => {
   const scenarioId = v4();
   const projectId = v4();
   const organizationId = v4();
+  const userId = v4();
 
   const geoEntityManager = sandbox.get<EntityManager>(getEntityManagerToken());
   const apiEntityManager = sandbox.get<EntityManager>(
@@ -165,6 +167,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioFeaturesData,
         resourceKind,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -176,6 +179,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioFeaturesData,
         resourceKind,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoScenarioFeaturesDataFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-importer.e2e-spec.ts
@@ -19,11 +19,11 @@ import { getEntityManagerToken, TypeOrmModule } from '@nestjs/typeorm';
 import { EntityManager, In } from 'typeorm';
 import { v4 } from 'uuid';
 import {
+  DeleteFeatures,
   DeleteProjectAndOrganization,
   GivenFeatures,
   GivenFeaturesData,
   GivenScenarioExists,
-  GivenUserExists,
   PrepareZipFile,
 } from './fixtures';
 
@@ -137,6 +137,7 @@ const getFixtures = async () => {
 
   return {
     cleanUp: async () => {
+      await DeleteFeatures(apiEntityManager, featureIds);
       await DeleteProjectAndOrganization(
         apiEntityManager,
         projectId,

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-metadata.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-metadata.piece-importer.e2e-spec.ts
@@ -18,6 +18,7 @@ import { v4 } from 'uuid';
 import {
   DeleteProjectAndOrganization,
   GivenProjectExists,
+  GivenUserExists,
   PrepareZipFile,
 } from './fixtures';
 
@@ -56,6 +57,7 @@ describe(ScenarioMetadataPieceImporter, () => {
 
   it('imports scenario metadata', async () => {
     await fixtures.GivenProject();
+    await fixtures.GivenUser();
     const archiveLocation = await fixtures.GivenValidScenarioMetadataFile();
     const input = fixtures.GivenJobInput(archiveLocation);
     await fixtures
@@ -86,6 +88,7 @@ const getFixtures = async () => {
   const organizationId = v4();
   const resourceKind = ResourceKind.Project;
   const oldScenarioId = v4();
+  const userId = v4();
 
   const sut = sandbox.get(ScenarioMetadataPieceImporter);
   const fileRepository = sandbox.get(FileRepository);
@@ -109,6 +112,7 @@ const getFixtures = async () => {
         organizationId,
       );
     },
+    GivenUser: () => GivenUserExists(entityManager, userId, projectId),
     GivenProject: () => {
       return GivenProjectExists(entityManager, projectId, organizationId);
     },
@@ -128,6 +132,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioMetadata,
         resourceKind,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -139,6 +144,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioMetadata,
         resourceKind,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoScenarioMetadataFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-planning-units-data.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-planning-units-data.piece-importer.e2e-spec.ts
@@ -92,6 +92,7 @@ const getFixtures = async () => {
   const projectId = v4();
   const resourceKind = ResourceKind.Project;
   const oldScenarioId = v4();
+  const userId = v4();
 
   const sut = sandbox.get(ScenarioPlanningUnitsDataPieceImporter);
   const fileRepository = sandbox.get(FileRepository);
@@ -149,6 +150,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioPlanningUnitsData,
         resourceKind,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -160,6 +162,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioPlanningUnitsData,
         resourceKind,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoScenarioPlanningUnitsDataFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-protected-areas.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-protected-areas.piece-importer.e2e-spec.ts
@@ -125,6 +125,7 @@ const getFixtures = async () => {
   const organizationId = v4();
   const resourceKind = ResourceKind.Project;
   const oldScenarioId = v4();
+  const userId = v4();
 
   const sut = sandbox.get(ScenarioProtectedAreasPieceImporter);
   const fileRepository = sandbox.get(FileRepository);
@@ -204,6 +205,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioProtectedAreas,
         resourceKind,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -215,6 +217,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioProtectedAreas,
         resourceKind,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoScenarioProtectedAreasFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-run-results.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-run-results.piece-importer.e2e-spec.ts
@@ -105,6 +105,7 @@ const getFixtures = async () => {
   const projectId = v4();
   const resourceKind = ResourceKind.Project;
   const oldScenarioId = v4();
+  const userId = v4();
 
   const sut = sandbox.get(ScenarioRunResultsPieceImporter);
   const fileRepository = sandbox.get(FileRepository);
@@ -172,6 +173,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioRunResults,
         resourceKind,
         uris: [uri.toSnapshot()],
+        ownerId: userId,
       };
     },
     GivenJobInputWithoutUris: (): ImportJobInput => {
@@ -183,6 +185,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioRunResults,
         resourceKind,
         uris: [],
+        ownerId: userId,
       };
     },
     GivenNoScenarioRunResultsFileIsAvailable: () => {

--- a/api/apps/geoprocessing/test/jest-e2e.json
+++ b/api/apps/geoprocessing/test/jest-e2e.json
@@ -74,6 +74,8 @@
     "@marxan/geofeatures/(.*)": "<rootDir>/../../libs/geofeatures/src/$1",
     "@marxan/geofeatures": "<rootDir>/../../libs/geofeatures/src",
     "@marxan/webshot/(.*)": "<rootDir>../../libs/webshot/src/$1",
-    "@marxan/webshot": "<rootDir>../../libs/webshot/src"
+    "@marxan/webshot": "<rootDir>../../libs/webshot/src",
+    "@marxan/domain-ids/(.*)": "<rootDir>../../libs/domain-ids/src/$1",
+    "@marxan/domain-ids": "<rootDir>../../libs/domain-ids/src"
   }
 }

--- a/api/libs/cloning/src/job-input.ts
+++ b/api/libs/cloning/src/job-input.ts
@@ -15,6 +15,7 @@ export interface ImportJobInput {
   readonly componentId: string;
   readonly pieceResourceId: string;
   readonly projectId: string;
+  readonly ownerId: string;
   readonly resourceKind: ResourceKind;
   readonly piece: ClonePiece;
   readonly uris: ComponentLocationSnapshot[];

--- a/api/libs/domain-ids/src/index.ts
+++ b/api/libs/domain-ids/src/index.ts
@@ -1,0 +1,1 @@
+export { UserId } from './user-id';

--- a/api/libs/domain-ids/src/user-id.ts
+++ b/api/libs/domain-ids/src/user-id.ts
@@ -1,0 +1,14 @@
+import { v4, version, validate } from 'uuid';
+
+export class UserId {
+  private readonly _token = 'user-id';
+  constructor(public readonly value: string) {
+    if (!validate(value) || version(value) !== 4) {
+      throw new Error();
+    }
+  }
+
+  static create(): UserId {
+    return new UserId(v4());
+  }
+}

--- a/api/libs/domain-ids/tsconfig.lib.json
+++ b/api/libs/domain-ids/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/domain-ids"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/api/package.json
+++ b/api/package.json
@@ -236,7 +236,9 @@
       "@marxan/webshot/(.*)": "<rootDir>/libs/webshot/src/$1",
       "@marxan/webshot": "<rootDir>/libs/webshot/src",
       "@marxan/geofeatures/(.*)": "<rootDir>/libs/geofeatures/src/$1",
-      "@marxan/geofeatures": "<rootDir>/libs/geofeatures/src"
+      "@marxan/geofeatures": "<rootDir>/libs/geofeatures/src",
+      "@marxan/domain-ids/(.*)": "<rootDir>/libs/domain-ids/src/$1",
+      "@marxan/domain-ids": "<rootDir>/libs/domain-ids/src"
     }
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -180,6 +180,12 @@
 			],
 			"@marxan/geofeatures/*": [
         "libs/geofeatures/src/*"
+      ],
+			"@marxan/domain-ids": [
+        "libs/domain-ids/src"
+      ],
+      "@marxan/domain-ids/*": [
+        "libs/domain-ids/src/*"
       ]
     }
   },


### PR DESCRIPTION
This PR adds logic for granting project/scenario owner role to the user that schedules an import operation

### Feature relevant tickets

[grant project_owner role on new (cloned/imported) project to the user who requested the import/clone](https://vizzuality.atlassian.net/browse/MARXAN-1445)