### PR TITLE
fix: scenario output folder piece exporter

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-input-folder.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-input-folder.piece-exporter.ts
@@ -60,20 +60,10 @@ export class ScenarioInputFolderPieceExporter implements ExportPieceProcessor {
             'x-api-key': AppConfig.get<string>('auth.xApiKey.secret'),
           },
           responseType: 'stream',
+          validateStatus: (status) => status === HttpStatus.OK,
         },
       )
       .toPromise();
-
-    if (status === HttpStatus.NOT_FOUND) {
-      return {
-        ...input,
-        uris: [],
-      };
-    }
-
-    if (status !== HttpStatus.OK) {
-      throw new Error(`Error obtaining input folder. Http status: ${status}`);
-    }
 
     const outputFile = await this.fileRepository.save(data, `zip`);
 

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-output-folder.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-output-folder.piece-exporter.ts
@@ -60,6 +60,8 @@ export class ScenarioOutputFolderPieceExporter implements ExportPieceProcessor {
             'x-api-key': AppConfig.get<string>('auth.xApiKey.secret'),
           },
           responseType: 'stream',
+          validateStatus: (status) =>
+            status === HttpStatus.OK || status === HttpStatus.NOT_FOUND,
         },
       )
       .toPromise();
@@ -69,10 +71,6 @@ export class ScenarioOutputFolderPieceExporter implements ExportPieceProcessor {
         ...input,
         uris: [],
       };
-    }
-
-    if (status !== HttpStatus.OK) {
-      throw new Error(`Error obtaining output folder. Http status: ${status}`);
     }
 
     const outputFile = await this.fileRepository.save(data, `zip`);


### PR DESCRIPTION
This PR fixes a bug of scenario output folder piece exporter. Although obtaining a `404` status code when requesting output folder to `api` was an expected case, the piece exporter was throwing an error. By default, `axios` throws an error if the response status code is not in the range [200, 300). 