### PR TITLE
feat: export marxan execution metadata

### DIFF
--- a/api/apps/api/src/migrations/api/1649665709084-AddClonePieceForMarxanExecutionMetadata.ts
+++ b/api/apps/api/src/migrations/api/1649665709084-AddClonePieceForMarxanExecutionMetadata.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddClonePieceForMarxanExecutionMetadata1649665709084
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE clone_piece_enum RENAME VALUE 'feautures-specification' TO 'features-specification'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE clone_piece_enum ADD VALUE 'marxan-execution-metadata'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "clone_piece_enum_tmp" AS ENUM(
+        'export-config',
+        'project-metadata',
+        'project-custom-protected-areas',
+        'planning-area-gadm',
+        'planning-area-custom',
+        'planning-area-custom-geojson',
+        'planning-units-grid',
+        'planning-units-grid-geojson',
+        'scenario-metadata',
+        'scenario-planning-units-data',
+        'scenario-run-results',
+        'scenario-protected-areas',
+        'project-custom-features',
+        'feautures-specification',
+        'scenario-features-data',
+        'scenario-input-folder',
+        'scenario-output-folder'
+      );
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE export_components
+      ALTER COLUMN piece TYPE clone_piece_enum_tmp;
+    `);
+    await queryRunner.query(`
+      ALTER TABLE import_components
+      ALTER COLUMN piece TYPE clone_piece_enum_tmp;
+    `);
+
+    await queryRunner.query(`
+      DROP TYPE clone_piece_enum;
+    `);
+    await queryRunner.query(`
+      ALTER TYPE clone_piece_enum_tmp RENAME TO clone_piece_enum;
+    `);
+  }
+}

--- a/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.spec.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.spec.ts
@@ -111,6 +111,7 @@ const getFixtures = async () => {
       ClonePiece.ScenarioInputFolder,
       ClonePiece.ScenarioOutputFolder,
       ClonePiece.FeaturesSpecification,
+      ClonePiece.MarxanExecutionMetadata,
     ];
     if (!projectExport) pieces.push(ClonePiece.ExportConfig);
     return pieces;

--- a/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.ts
@@ -72,6 +72,7 @@ export class ExportResourcePiecesAdapter implements ExportResourcePieces {
       ExportComponent.newOne(id, ClonePiece.ScenarioInputFolder),
       ExportComponent.newOne(id, ClonePiece.ScenarioOutputFolder),
       ExportComponent.newOne(id, ClonePiece.FeaturesSpecification),
+      ExportComponent.newOne(id, ClonePiece.MarxanExecutionMetadata),
     ];
 
     if (kind === ResourceKind.Scenario) {

--- a/api/apps/api/src/modules/clone/import/adapters/import-resource-pieces.adapter.ts
+++ b/api/apps/api/src/modules/clone/import/adapters/import-resource-pieces.adapter.ts
@@ -1,6 +1,5 @@
 import {
   ArchiveLocation,
-  ClonePiece,
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';

--- a/api/apps/geoprocessing/src/export/pieces-exporters/marxan-execution-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/marxan-execution-metadata.piece-exporter.ts
@@ -1,0 +1,132 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
+import { ComponentLocation } from '@marxan/cloning/domain';
+import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
+import {
+  FolderZipType,
+  getMarxanExecutionMetadataFolderRelativePath,
+  MarxanExecutionMetadataContent,
+} from '@marxan/cloning/infrastructure/clone-piece-data/marxan-execution-metadata';
+import { FileRepository } from '@marxan/files-repository';
+import { MarxanExecutionMetadataGeoEntity } from '@marxan/marxan-output';
+import { isDefined } from '@marxan/utils';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/Either';
+import { Readable } from 'stream';
+import { EntityManager } from 'typeorm';
+import {
+  ExportPieceProcessor,
+  PieceExportProvider,
+} from '../pieces/export-piece-processor';
+
+type FolderZipData = {
+  id: string;
+  type: FolderZipType;
+  buffer: Buffer;
+};
+
+@Injectable()
+@PieceExportProvider()
+export class MarxanExecutionMetadataPieceExporter
+  implements ExportPieceProcessor {
+  constructor(
+    private readonly fileRepository: FileRepository,
+    @InjectEntityManager(geoprocessingConnections.default)
+    private readonly entityManager: EntityManager,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(MarxanExecutionMetadataPieceExporter.name);
+  }
+
+  isSupported(piece: ClonePiece): boolean {
+    return piece === ClonePiece.MarxanExecutionMetadata;
+  }
+
+  private async saveZipFile(
+    file: Buffer,
+    executionId: string,
+    type: FolderZipType,
+  ): Promise<string> {
+    const locationOrError = await this.fileRepository.save(Readable.from(file));
+    if (isLeft(locationOrError)) {
+      const errorMessage = `${MarxanExecutionMetadataPieceExporter.name} - couldn't save ${type} folder file for execution with id ${executionId} - ${locationOrError.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return locationOrError.right;
+  }
+
+  async run(input: ExportJobInput): Promise<ExportJobOutput> {
+    const marxanExecutionMetadataWithBuffers = await this.entityManager
+      .getRepository(MarxanExecutionMetadataGeoEntity)
+      .find({ where: { scenarioId: input.resourceId } });
+
+    const fileContent: MarxanExecutionMetadataContent = {
+      marxanExecutionMetadata: marxanExecutionMetadataWithBuffers.map(
+        (metadata) => ({
+          id: metadata.id,
+          failed: metadata.failed,
+          stdError: metadata.stdError,
+          stdOutput: metadata.stdOutput,
+          includesOutputFolder: isDefined(metadata.outputZip),
+        }),
+      ),
+    };
+    const foldersZipsData: FolderZipData[] = marxanExecutionMetadataWithBuffers.flatMap(
+      ({ id, inputZip, outputZip }) => {
+        const files: FolderZipData[] = [
+          { id, buffer: inputZip, type: 'input' },
+        ];
+        if (outputZip) files.push({ id, buffer: outputZip, type: 'output' });
+
+        return files;
+      },
+    );
+
+    const jsonFile = await this.fileRepository.save(
+      Readable.from(JSON.stringify(fileContent)),
+      `json`,
+    );
+
+    if (isLeft(jsonFile)) {
+      const errorMessage = `${MarxanExecutionMetadataPieceExporter.name} - couldn't save file - ${jsonFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const [jsonFileLocation] = ClonePieceUrisResolver.resolveFor(
+      ClonePiece.MarxanExecutionMetadata,
+      jsonFile.right,
+      {
+        kind: input.resourceKind,
+        scenarioId: input.resourceId,
+      },
+    );
+    const jsonFileRelativePath = jsonFileLocation.relativePath;
+
+    const foldersZipsRelativePathPrefix = jsonFileRelativePath.substring(
+      0,
+      jsonFileRelativePath.lastIndexOf('/') + 1,
+    );
+
+    const folderZipsLocations = await Promise.all(
+      foldersZipsData.map(async ({ buffer, id, type }) => {
+        const location = await this.saveZipFile(buffer, id, type);
+        const relativePath = getMarxanExecutionMetadataFolderRelativePath(
+          id,
+          foldersZipsRelativePathPrefix,
+          type,
+        );
+
+        return new ComponentLocation(location, relativePath);
+      }),
+    );
+
+    return {
+      ...input,
+      uris: [jsonFileLocation, ...folderZipsLocations],
+    };
+  }
+}

--- a/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
@@ -1,11 +1,15 @@
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ScenarioFeaturesData } from '@marxan/features';
 import { FileRepositoryModule } from '@marxan/files-repository';
-import { OutputScenariosFeaturesDataGeoEntity } from '@marxan/marxan-output';
+import {
+  MarxanExecutionMetadataGeoEntity,
+  OutputScenariosFeaturesDataGeoEntity,
+} from '@marxan/marxan-output';
 import { HttpModule, Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ExportConfigProjectPieceExporter } from './export-config.project-piece-exporter';
 import { ExportConfigScenarioPieceExporter } from './export-config.scenario-piece-exporter';
+import { MarxanExecutionMetadataPieceExporter } from './marxan-execution-metadata.piece-exporter';
 import { PlanningAreaCustomGeojsonPieceExporter } from './planning-area-custom-geojson.piece-exporter';
 import { PlanningAreaCustomPieceExporter } from './planning-area-custom.piece-exporter';
 import { PlanningAreaGadmPieceExporter } from './planning-area-gadm.piece-exporter';
@@ -15,8 +19,8 @@ import { ProjectCustomFeaturesPieceExporter } from './project-custom-features.pi
 import { ProjectCustomProtectedAreasPieceExporter } from './project-custom-protected-areas.piece-exporter';
 import { ProjectMetadataPieceExporter } from './project-metadata.piece-exporter';
 import { ScenarioFeaturesDataPieceExporter } from './scenario-features-data.piece-exporter';
-import { ScenarioInputFolderPieceExporter } from './scenario-input-folder.piece-exporter';
 import { ScenarioFeaturesSpecificationPieceExporter } from './scenario-features-specification.piece-exporter';
+import { ScenarioInputFolderPieceExporter } from './scenario-input-folder.piece-exporter';
 import { ScenarioMetadataPieceExporter } from './scenario-metadata.piece-exporter';
 import { ScenarioOutputFolderPieceExporter } from './scenario-output-folder.piece-exporter';
 import { ScenarioPlanningUnitsDataPieceExporter } from './scenario-planning-units-data.piece-exporter';
@@ -28,7 +32,11 @@ import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-ex
     FileRepositoryModule,
     TypeOrmModule.forFeature([], geoprocessingConnections.apiDB),
     TypeOrmModule.forFeature(
-      [ScenarioFeaturesData, OutputScenariosFeaturesDataGeoEntity],
+      [
+        ScenarioFeaturesData,
+        OutputScenariosFeaturesDataGeoEntity,
+        MarxanExecutionMetadataGeoEntity,
+      ],
       geoprocessingConnections.default,
     ),
     HttpModule,
@@ -52,6 +60,7 @@ import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-ex
     ScenarioInputFolderPieceExporter,
     ScenarioOutputFolderPieceExporter,
     ScenarioFeaturesSpecificationPieceExporter,
+    MarxanExecutionMetadataPieceExporter,
     Logger,
   ],
 })

--- a/api/apps/geoprocessing/test/integration/clonning/fixtures.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/fixtures.ts
@@ -8,6 +8,7 @@ import { ScenarioFeaturesData } from '@marxan/features';
 import { FileRepository } from '@marxan/files-repository';
 import { GeoFeatureGeometry, GeometrySource } from '@marxan/geofeatures';
 import {
+  MarxanExecutionMetadataGeoEntity,
   OutputScenariosFeaturesDataGeoEntity,
   OutputScenariosPuDataGeoEntity,
 } from '@marxan/marxan-output';
@@ -163,6 +164,32 @@ export async function GivenScenarioExists(
       ...scenarioData,
     })
     .execute();
+}
+
+export function GivenMarxanExecutionMetadata(
+  em: EntityManager,
+  scenarioId: string,
+  amountOfRuns: number,
+) {
+  return em.getRepository(MarxanExecutionMetadataGeoEntity).save(
+    Array(amountOfRuns)
+      .fill('')
+      .map(() => ({
+        scenarioId,
+        stdOutput: 'success',
+        inputZip: Buffer.from('input zip file'),
+        outputZip: Buffer.from('output zip file'),
+      })),
+  );
+}
+
+export function DeleteMarxanExecutionMetadata(
+  em: EntityManager,
+  scenarioId: string,
+) {
+  return em
+    .getRepository(MarxanExecutionMetadataGeoEntity)
+    .delete({ scenarioId });
 }
 
 export async function DeleteProjectAndOrganization(

--- a/api/apps/geoprocessing/test/integration/clonning/marxan-execution-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/marxan-execution-metadata.piece-exporter.e2e-spec.ts
@@ -1,0 +1,142 @@
+import { MarxanExecutionMetadataPieceExporter } from '@marxan-geoprocessing/export/pieces-exporters/marxan-execution-metadata.piece-exporter';
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ExportJobInput } from '@marxan/cloning';
+import { ResourceKind } from '@marxan/cloning/domain';
+import { MarxanExecutionMetadataContent } from '@marxan/cloning/infrastructure/clone-piece-data/marxan-execution-metadata';
+import { FileRepository, FileRepositoryModule } from '@marxan/files-repository';
+import { MarxanExecutionMetadataGeoEntity } from '@marxan/marxan-output';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getEntityManagerToken, TypeOrmModule } from '@nestjs/typeorm';
+import { isLeft, Right } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+import { EntityManager } from 'typeorm';
+import { v4 } from 'uuid';
+import {
+  DeleteMarxanExecutionMetadata,
+  GivenMarxanExecutionMetadata,
+  readSavedFile,
+} from './fixtures';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+describe(MarxanExecutionMetadataPieceExporter, () => {
+  beforeEach(async () => {
+    fixtures = await getFixtures();
+  }, 10_000);
+
+  afterEach(async () => {
+    await fixtures?.cleanUp();
+  });
+
+  it('should save empty marxan execution metadata file', async () => {
+    const input = fixtures.GivenAMarxanExecutionMetadataExportJob();
+    await fixtures.GivenNoMarxanExecutionMetadata();
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenAnEmptyMarxanExecutionMetadataFileIsSaved();
+  });
+
+  it('should save succesfully marxan execution metadata', async () => {
+    const input = fixtures.GivenAMarxanExecutionMetadataExportJob();
+    await fixtures.GivenMarxanExecutionMetadata();
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenAMarxanExecutionMetadataFileIsSaved();
+  });
+});
+
+const getFixtures = async () => {
+  const sandbox = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.apiDB,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.default,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forFeature([MarxanExecutionMetadataGeoEntity]),
+      FileRepositoryModule,
+    ],
+    providers: [
+      MarxanExecutionMetadataPieceExporter,
+      { provide: Logger, useValue: { error: () => {}, setContext: () => {} } },
+    ],
+  }).compile();
+
+  await sandbox.init();
+  const projectId = v4();
+  const scenarioId = v4();
+
+  const sut = sandbox.get(MarxanExecutionMetadataPieceExporter);
+  const geoEntityManager: EntityManager = sandbox.get(
+    getEntityManagerToken(geoprocessingConnections.default),
+  );
+  const fileRepository = sandbox.get(FileRepository);
+  const amountOfMarxanRuns = 3;
+
+  return {
+    cleanUp: async () => {
+      return DeleteMarxanExecutionMetadata(geoEntityManager, scenarioId);
+    },
+    GivenNoMarxanExecutionMetadata: async (): Promise<void> => {},
+    GivenAMarxanExecutionMetadataExportJob: (): ExportJobInput => {
+      return {
+        allPieces: [
+          { resourceId: projectId, piece: ClonePiece.ProjectMetadata },
+          {
+            resourceId: scenarioId,
+            piece: ClonePiece.MarxanExecutionMetadata,
+          },
+        ],
+        componentId: v4(),
+        exportId: v4(),
+        piece: ClonePiece.MarxanExecutionMetadata,
+        resourceId: scenarioId,
+        resourceKind: ResourceKind.Project,
+      };
+    },
+    GivenMarxanExecutionMetadata: () =>
+      GivenMarxanExecutionMetadata(
+        geoEntityManager,
+        scenarioId,
+        amountOfMarxanRuns,
+      ),
+    WhenPieceExporterIsInvoked: (input: ExportJobInput) => {
+      return {
+        ThenAnEmptyMarxanExecutionMetadataFileIsSaved: async () => {
+          const result = await sut.run(input);
+          const file = await fileRepository.get(result.uris[0].uri);
+          expect((file as Right<Readable>).right).toBeDefined();
+          if (isLeft(file)) throw new Error();
+          const savedStream = file.right;
+          const content = await readSavedFile(savedStream);
+          const emptyFile: MarxanExecutionMetadataContent = {
+            marxanExecutionMetadata: [],
+          };
+          expect(content).toEqual(emptyFile);
+        },
+        ThenAMarxanExecutionMetadataFileIsSaved: async () => {
+          const result = await sut.run(input);
+          const file = await fileRepository.get(result.uris[0].uri);
+          expect((file as Right<Readable>).right).toBeDefined();
+          if (isLeft(file)) throw new Error();
+          const savedStream = file.right;
+          const content = await readSavedFile<MarxanExecutionMetadataContent>(
+            savedStream,
+          );
+          expect(content.marxanExecutionMetadata).toHaveLength(
+            amountOfMarxanRuns,
+          );
+
+          expect(result.uris).toHaveLength(1 + amountOfMarxanRuns * 2);
+        },
+      };
+    },
+  };
+};

--- a/api/libs/cloning/src/domain/clone-piece.ts
+++ b/api/libs/cloning/src/domain/clone-piece.ts
@@ -11,7 +11,8 @@ export enum ClonePiece {
   ScenarioRunResults = 'scenario-run-results',
   ScenarioProtectedAreas = 'scenario-protected-areas',
   ScenarioFeaturesData = 'scenario-features-data',
-  FeaturesSpecification = 'feautures-specification',
+  FeaturesSpecification = 'features-specification',
+  MarxanExecutionMetadata = 'marxan-execution-metadata',
   // marxan-data pieces
   PlanningAreaCustomGeojson = 'planning-area-custom-geojson',
   PlanningUnitsGridGeojson = 'planning-units-grid-geojson',

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/marxan-execution-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/marxan-execution-metadata.ts
@@ -1,0 +1,23 @@
+export type FolderZipType = 'input' | 'output';
+
+export const marxanExecutionMetadataRelativePath = `marxan-execution-metadata.json`;
+export const marxanExecutionMetadataFoldersRelativePath = `marxan-execution-metadata`;
+
+export const getMarxanExecutionMetadataFolderRelativePath = (
+  executionId: string,
+  pathPrefix: string,
+  type: FolderZipType,
+) =>
+  `${pathPrefix}/${marxanExecutionMetadataFoldersRelativePath}/${executionId}/${type}.zip`;
+
+export type MarxanExecutionMetadataElement = {
+  id: string;
+  stdOutput?: string | null;
+  stdError?: string | null;
+  failed?: boolean;
+  includesOutputFolder: boolean;
+};
+
+export type MarxanExecutionMetadataContent = {
+  marxanExecutionMetadata: MarxanExecutionMetadataElement[];
+};


### PR DESCRIPTION
This PR adds `ClonePiece.MarxanExecutionMetadata` piece exporter

### Feature relevant tickets

[export piece (scenario): marxan execution metadata](https://vizzuality.atlassian.net/browse/MARXAN-1449)