### PR TITLE
BLM-image-url-errors-add-project-metadata

### DIFF
--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -60,15 +60,6 @@ export class MarxanSandboxBlmRunnerService
     const { blmValues, scenarioId } = input;
     const calibrationId = v4();
 
-    const projectId = await this.apiEntityManager
-      .createQueryBuilder()
-      .select(['project_id'])
-      .from('scenarios', 's')
-      .where('id = :scenarioId', { scenarioId })
-      .getRawOne();
-
-    const webshotUrl = AppConfig.get('webshot.url') as string;
-
     this.eventBus.publish(new BlmCalibrationStarted(scenarioId, calibrationId));
 
     const inputFilesHandler = await this.moduleRef.create(BlmInputFiles);
@@ -76,6 +67,17 @@ export class MarxanSandboxBlmRunnerService
       inputFilesHandler,
       this.finalResultsRepository,
     ]);
+
+    const result = await this.apiEntityManager
+      .createQueryBuilder()
+      .select(['project_id'])
+      .from('scenarios', 's')
+      .where('id = :scenarioId', { scenarioId })
+      .getRawOne();
+
+    const projectId = result.project_id;
+
+    const webshotUrl = AppConfig.get('webshot.url') as string;
 
     return new Promise<void>(async (resolve, reject) => {
       try {

--- a/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
@@ -28,7 +28,10 @@ import { GivenScenarioPuData } from '../../steps/given-scenario-pu-data-exists';
 import { delay } from '../../utils';
 import { Test } from '@nestjs/testing';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
-import { GivenScenarioExists } from '../clonning/fixtures';
+import {
+  GivenScenarioExists,
+  DeleteProjectAndOrganization,
+} from '../clonning/fixtures';
 
 let fixtures: PromiseType<ReturnType<typeof getFixtures>>;
 
@@ -179,6 +182,11 @@ const getFixtures = async () => {
   });
   return {
     cleanup: async () => {
+      await DeleteProjectAndOrganization(
+        apiEntityManager,
+        projectId,
+        organizationId,
+      );
       await metadataRepo.delete({
         scenarioId,
       });

--- a/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
@@ -17,7 +17,7 @@ import {
   OutputScenariosFeaturesDataGeoEntity,
   OutputScenariosPuDataGeoEntity,
 } from '@marxan/marxan-output';
-import { getEntityManagerToken, getRepositoryToken } from '@nestjs/typeorm';
+import { getEntityManagerToken, TypeOrmModule } from '@nestjs/typeorm';
 import { readFileSync } from 'fs';
 import { last } from 'lodash';
 import * as nock from 'nock';
@@ -25,7 +25,10 @@ import { EntityManager, In, Repository } from 'typeorm';
 import { PromiseType } from 'utility-types';
 import { v4 } from 'uuid';
 import { GivenScenarioPuData } from '../../steps/given-scenario-pu-data-exists';
-import { bootstrapApplication, delay } from '../../utils';
+import { delay } from '../../utils';
+import { Test } from '@nestjs/testing';
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { GivenScenarioExists } from '../clonning/fixtures';
 
 let fixtures: PromiseType<ReturnType<typeof getFixtures>>;
 
@@ -101,6 +104,7 @@ const NUMBER_OF_RUNS = 100;
 
 const getFixtures = async () => {
   const projectId = v4();
+  const organizationId = v4();
   const scenarioId = v4();
   const featureId = v4();
   const outputsIds: string[] = [];
@@ -108,31 +112,57 @@ const getFixtures = async () => {
 
   nock.disableNetConnect();
 
-  const app = await bootstrapApplication();
+  const app = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.default,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.apiDB,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forFeature([]),
+      TypeOrmModule.forFeature([], geoprocessingConnections.apiDB.name),
+      BlmRunAdapterModule,
+    ],
+  }).compile();
+
+  const apiEntityManager: EntityManager = app.get(
+    getEntityManagerToken(geoprocessingConnections.apiDB),
+  );
+  await GivenScenarioExists(
+    apiEntityManager,
+    scenarioId,
+    projectId,
+    organizationId,
+  );
   const entityManager = app.get<EntityManager>(getEntityManagerToken());
-  const featuresData: Repository<GeoFeatureGeometry> = app.get(
-    getRepositoryToken(GeoFeatureGeometry),
+  const featuresData: Repository<GeoFeatureGeometry> = entityManager.getRepository(
+    GeoFeatureGeometry,
   );
-  const scenarioFeatureRepo: Repository<ScenarioFeaturesData> = app.get(
-    getRepositoryToken(ScenarioFeaturesData),
+  const scenarioFeatureRepo: Repository<ScenarioFeaturesData> = entityManager.getRepository(
+    ScenarioFeaturesData,
   );
-  const planningUnitsGeomRepo: Repository<PlanningUnitsGeom> = app.get(
-    getRepositoryToken(PlanningUnitsGeom),
+  const planningUnitsGeomRepo: Repository<PlanningUnitsGeom> = entityManager.getRepository(
+    PlanningUnitsGeom,
   );
-  const puOutputRepo: Repository<OutputScenariosPuDataGeoEntity> = app.get(
-    getRepositoryToken(OutputScenariosPuDataGeoEntity),
+  const puOutputRepo: Repository<OutputScenariosPuDataGeoEntity> = entityManager.getRepository(
+    OutputScenariosPuDataGeoEntity,
   );
-  const metadataRepo: Repository<MarxanExecutionMetadataGeoEntity> = app.get(
-    getRepositoryToken(MarxanExecutionMetadataGeoEntity),
+  const metadataRepo: Repository<MarxanExecutionMetadataGeoEntity> = entityManager.getRepository(
+    MarxanExecutionMetadataGeoEntity,
   );
-  const featuresOutputRepo: Repository<OutputScenariosFeaturesDataGeoEntity> = app.get(
-    getRepositoryToken(OutputScenariosFeaturesDataGeoEntity),
+  const featuresOutputRepo: Repository<OutputScenariosFeaturesDataGeoEntity> = entityManager.getRepository(
+    OutputScenariosFeaturesDataGeoEntity,
   );
-  const blmFinalResultsRepo: Repository<BlmFinalResultEntity> = app.get(
-    getRepositoryToken(BlmFinalResultEntity),
+  const blmFinalResultsRepo: Repository<BlmFinalResultEntity> = entityManager.getRepository(
+    BlmFinalResultEntity,
   );
-  const blmPartialResultsRepo: Repository<BlmPartialResultEntity> = app.get(
-    getRepositoryToken(BlmPartialResultEntity),
+  const blmPartialResultsRepo: Repository<BlmPartialResultEntity> = entityManager.getRepository(
+    BlmPartialResultEntity,
   );
   // note that SandboxRunner may be both single and blm-calibration one
   const runModuleContext = app.select(BlmRunAdapterModule);


### PR DESCRIPTION
-Changes how projectId is taken for the webshot service.
-Refactors blm-calibration test in geoprocessing due to mocked projectId/scenarioId not existant in API DB.