### PR TITLE
feat: import marxan execution metadata

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/marxan-execution-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/marxan-execution-metadata.piece-exporter.ts
@@ -3,7 +3,7 @@ import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
 import { ComponentLocation } from '@marxan/cloning/domain';
 import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
 import {
-  FolderZipType,
+  MarxanExecutionMetadataFolderType,
   getMarxanExecutionMetadataFolderRelativePath,
   MarxanExecutionMetadataContent,
 } from '@marxan/cloning/infrastructure/clone-piece-data/marxan-execution-metadata';
@@ -22,7 +22,7 @@ import {
 
 type FolderZipData = {
   id: string;
-  type: FolderZipType;
+  type: MarxanExecutionMetadataFolderType;
   buffer: Buffer;
 };
 
@@ -46,7 +46,7 @@ export class MarxanExecutionMetadataPieceExporter
   private async saveZipFile(
     file: Buffer,
     executionId: string,
-    type: FolderZipType,
+    type: MarxanExecutionMetadataFolderType,
   ): Promise<string> {
     const locationOrError = await this.fileRepository.save(Readable.from(file));
     if (isLeft(locationOrError)) {
@@ -104,20 +104,14 @@ export class MarxanExecutionMetadataPieceExporter
         scenarioId: input.resourceId,
       },
     );
-    const jsonFileRelativePath = jsonFileLocation.relativePath;
-
-    const foldersZipsRelativePathPrefix = jsonFileRelativePath.substring(
-      0,
-      jsonFileRelativePath.lastIndexOf('/') + 1,
-    );
 
     const folderZipsLocations = await Promise.all(
       foldersZipsData.map(async ({ buffer, id, type }) => {
         const location = await this.saveZipFile(buffer, id, type);
         const relativePath = getMarxanExecutionMetadataFolderRelativePath(
           id,
-          foldersZipsRelativePathPrefix,
           type,
+          jsonFileLocation.relativePath,
         );
 
         return new ComponentLocation(location, relativePath);

--- a/api/apps/geoprocessing/src/import/pieces-importers/marxan-execution-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/marxan-execution-metadata.piece-importer.ts
@@ -1,0 +1,178 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
+import {
+  MarxanExecutionMetadataFolderType,
+  getMarxanExecutionMetadataFolderRelativePath,
+  MarxanExecutionMetadataContent,
+  MarxanExecutionMetadataElement,
+} from '@marxan/cloning/infrastructure/clone-piece-data/marxan-execution-metadata';
+import { FileRepository } from '@marxan/files-repository';
+import { MarxanExecutionMetadataGeoEntity } from '@marxan/marxan-output';
+import { extractFile, extractFiles } from '@marxan/utils';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+import { EntityManager } from 'typeorm/entity-manager/EntityManager';
+import {
+  ImportPieceProcessor,
+  PieceImportProvider,
+} from '../pieces/import-piece-processor';
+
+type FolderData = {
+  id: string;
+  relativePath: string;
+  type: MarxanExecutionMetadataFolderType;
+};
+
+type MetadataFolderBuffers = Record<string, Buffer>;
+
+@Injectable()
+@PieceImportProvider()
+export class MarxanExecutionMetadataPieceImporter
+  implements ImportPieceProcessor {
+  constructor(
+    private readonly fileRepository: FileRepository,
+    @InjectEntityManager(geoprocessingConnections.default)
+    private readonly entityManager: EntityManager,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(MarxanExecutionMetadataPieceImporter.name);
+  }
+
+  isSupported(piece: ClonePiece): boolean {
+    return piece === ClonePiece.MarxanExecutionMetadata;
+  }
+
+  private async getExportFileFromFileRepo(uri: string): Promise<Readable> {
+    const readableOrError = await this.fileRepository.get(uri);
+    if (isLeft(readableOrError)) {
+      const errorMessage = `Export file is not available at ${uri}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return readableOrError.right;
+  }
+
+  private async getMetadataFolders(
+    exportFileUri: string,
+    marxanExecutionMetadata: MarxanExecutionMetadataElement[],
+    foldersZipsRelativePathPrefix: string,
+  ): Promise<MetadataFolderBuffers> {
+    const metadataFoldersBuffers: MetadataFolderBuffers = {};
+    const foldersData = marxanExecutionMetadata.flatMap((metadata) => {
+      const relativePaths: FolderData[] = [
+        {
+          id: metadata.id,
+          type: 'input',
+          relativePath: getMarxanExecutionMetadataFolderRelativePath(
+            metadata.id,
+            'input',
+            foldersZipsRelativePathPrefix,
+          ),
+        },
+      ];
+
+      if (metadata.includesOutputFolder)
+        relativePaths.push({
+          id: metadata.id,
+          type: 'output',
+          relativePath: getMarxanExecutionMetadataFolderRelativePath(
+            metadata.id,
+            'output',
+            foldersZipsRelativePathPrefix,
+          ),
+        });
+
+      return relativePaths;
+    });
+
+    const exportFile = await this.getExportFileFromFileRepo(exportFileUri);
+
+    const buffersOrErrors = await extractFiles(
+      exportFile,
+      foldersData.map((data) => data.relativePath),
+    );
+
+    if (isLeft(buffersOrErrors)) {
+      const errorMessage = `Error extracting input and output folders of marxan execution metadata`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    foldersData.forEach((data) => {
+      const buffer = buffersOrErrors.right[data.relativePath];
+
+      if (!buffer) {
+        const errorMessage = `Error extracting ${data.type} folder of execution metadata with id ${data.id}`;
+        this.logger.error(errorMessage);
+        throw new Error(errorMessage);
+      }
+
+      metadataFoldersBuffers[`${data.id}-${data.type}`] = buffer;
+    });
+
+    return metadataFoldersBuffers;
+  }
+
+  async run(input: ImportJobInput): Promise<ImportJobOutput> {
+    const { uris, projectId, pieceResourceId: scenarioId } = input;
+
+    const marxanExecutionMetadataRepo = this.entityManager.getRepository(
+      MarxanExecutionMetadataGeoEntity,
+    );
+
+    if (uris.length !== 1) {
+      const errorMessage = `uris array has an unexpected amount of elements: ${uris.length}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    const [marxanExecutionMetadataLocation] = uris;
+
+    const exportFile = await this.getExportFileFromFileRepo(
+      marxanExecutionMetadataLocation.uri,
+    );
+
+    const marxanExecutionMetadataOrError = await extractFile(
+      exportFile,
+      marxanExecutionMetadataLocation.relativePath,
+    );
+    if (isLeft(marxanExecutionMetadataOrError)) {
+      const errorMessage = `Marxan execution metadata file extraction failed: ${marxanExecutionMetadataLocation.relativePath}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const {
+      marxanExecutionMetadata,
+    }: MarxanExecutionMetadataContent = JSON.parse(
+      marxanExecutionMetadataOrError.right,
+    );
+
+    const buffers = await this.getMetadataFolders(
+      marxanExecutionMetadataLocation.uri,
+      marxanExecutionMetadata,
+      marxanExecutionMetadataLocation.relativePath,
+    );
+
+    await marxanExecutionMetadataRepo.save(
+      marxanExecutionMetadata.map((metadata) => ({
+        scenarioId,
+        stdOutput: metadata.stdOutput,
+        stdError: metadata.stdError,
+        inputZip: buffers[`${metadata.id}-input`],
+        outputZip: buffers[`${metadata.id}-output`],
+        failed: metadata.failed,
+      })),
+    );
+
+    return {
+      importId: input.importId,
+      componentId: input.componentId,
+      pieceResourceId: scenarioId,
+      projectId,
+      piece: input.piece,
+    };
+  }
+}

--- a/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
@@ -2,6 +2,7 @@ import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { FileRepositoryModule } from '@marxan/files-repository';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { MarxanExecutionMetadataPieceImporter } from './marxan-execution-metadata.piece-importer';
 import { PlanningAreaCustomPieceImporter } from './planning-area-custom.piece-importer';
 import { PlanningAreaGadmPieceImporter } from './planning-area-gadm.piece-importer';
 import { PlanningUnitsGridPieceImporter } from './planning-units-grid.piece-importer';
@@ -33,6 +34,7 @@ import { ScenarioRunResultsPieceImporter } from './scenario-run-results.piece-im
     ScenarioRunResultsPieceImporter,
     ScenarioFeaturesDataPieceImporter,
     ScenarioFeaturesSpecificationPieceImporter,
+    MarxanExecutionMetadataPieceImporter,
     { provide: Logger, useClass: Logger, scope: Scope.TRANSIENT },
   ],
 })

--- a/api/apps/geoprocessing/test/integration/clonning/marxan-execution-metadata.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/marxan-execution-metadata.piece-importer.e2e-spec.ts
@@ -1,0 +1,311 @@
+import { MarxanExecutionMetadataPieceImporter } from '@marxan-geoprocessing/import/pieces-importers/marxan-execution-metadata.piece-importer';
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ImportJobInput } from '@marxan/cloning';
+import {
+  ArchiveLocation,
+  ClonePiece,
+  ResourceKind,
+} from '@marxan/cloning/domain';
+import { ClonePieceUrisResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
+import {
+  getMarxanExecutionMetadataFolderRelativePath,
+  MarxanExecutionMetadataContent,
+  MarxanExecutionMetadataFolderType,
+} from '@marxan/cloning/infrastructure/clone-piece-data/marxan-execution-metadata';
+import { FileRepository, FileRepositoryModule } from '@marxan/files-repository';
+import { MarxanExecutionMetadataGeoEntity } from '@marxan/marxan-output';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import * as archiver from 'archiver';
+import { isLeft } from 'fp-ts/lib/Either';
+import { Repository } from 'typeorm';
+import { v4 } from 'uuid';
+
+type MetadataFolder = {
+  id: string;
+  buffer: Buffer;
+  type: MarxanExecutionMetadataFolderType;
+};
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+describe(MarxanExecutionMetadataPieceImporter, () => {
+  beforeEach(async () => {
+    fixtures = await getFixtures();
+  }, 10_000);
+
+  afterEach(async () => {
+    await fixtures?.cleanUp();
+  });
+
+  it('fails when marxan execution metadata file uri is missing in uris array', async () => {
+    const input = fixtures.GivenJobInputWithoutUris();
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenAnUrisArrayErrorShouldBeThrown();
+  });
+
+  it('fails when the file cannot be retrieved from file repo', async () => {
+    const resourceKind = ResourceKind.Project;
+    const archiveLocation = fixtures.GivenNoMarxanExecutionMetadataFileIsAvailable();
+    const input = fixtures.GivenJobInput(archiveLocation, resourceKind);
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenADataNotAvailableErrorShouldBeThrown();
+  });
+
+  it(`fails if zip file doesn't contain marxan execution metadata folder`, async () => {
+    const resourceKind = ResourceKind.Project;
+    await fixtures.GivenWrongMarxanExecutionMetadata();
+    const archiveLocation = await fixtures.GivenMarxanExecutionMetadataFile(
+      resourceKind,
+    );
+    const input = fixtures.GivenJobInput(archiveLocation, resourceKind);
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenAFolderExtractionErrorShouldBeThrown();
+  });
+
+  it('imports marxan execution metadata in a scenario import', async () => {
+    const resourceKind = ResourceKind.Scenario;
+    await fixtures.GivenMarxanExecutionMetadata();
+    const archiveLocation = await fixtures.GivenMarxanExecutionMetadataFile(
+      resourceKind,
+    );
+    const input = fixtures.GivenJobInput(archiveLocation, resourceKind);
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenMarxanExecutionMetadataShouldBeImported();
+  });
+
+  it('imports marxan execution metadata in a project import', async () => {
+    const resourceKind = ResourceKind.Project;
+    await fixtures.GivenMarxanExecutionMetadata();
+    const archiveLocation = await fixtures.GivenMarxanExecutionMetadataFile(
+      resourceKind,
+    );
+    const input = fixtures.GivenJobInput(archiveLocation, resourceKind);
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenMarxanExecutionMetadataShouldBeImported();
+  });
+});
+
+const getFixtures = async () => {
+  const sandbox = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.default,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forFeature([MarxanExecutionMetadataGeoEntity]),
+      FileRepositoryModule,
+    ],
+    providers: [
+      MarxanExecutionMetadataPieceImporter,
+      { provide: Logger, useValue: { error: () => {}, setContext: () => {} } },
+    ],
+  }).compile();
+
+  await sandbox.init();
+  const scenarioId = v4();
+  const projectId = v4();
+  const oldScenarioId = v4();
+  const userId = v4();
+
+  const sut = sandbox.get(MarxanExecutionMetadataPieceImporter);
+  const fileRepository = sandbox.get(FileRepository);
+  const marxanExecutionMetadataRepo = sandbox.get<
+    Repository<MarxanExecutionMetadataGeoEntity>
+  >(getRepositoryToken(MarxanExecutionMetadataGeoEntity));
+
+  const amountOfMarxanRuns = 5;
+
+  const marxanExecutionMetadataFileContent: MarxanExecutionMetadataContent = {
+    marxanExecutionMetadata: [],
+  };
+  const metadataFolders: MetadataFolder[] = [];
+  const expectedStdOutput = 'Success!';
+  const expectedStdError = 'none';
+  const expectedFailedValue = false;
+  const expectedInputBufferText = 'input';
+  const expectedOutputBufferText = 'output';
+
+  return {
+    cleanUp: async () => {
+      await marxanExecutionMetadataRepo.delete({ scenarioId });
+    },
+    GivenMarxanExecutionMetadata: async () => {
+      const metadataList = Array(amountOfMarxanRuns)
+        .fill('')
+        .map(() => ({
+          id: v4(),
+          includesOutputFolder: true,
+          failed: expectedFailedValue,
+          stdOutput: expectedStdOutput,
+          stdError: expectedStdError,
+        }));
+
+      marxanExecutionMetadataFileContent.marxanExecutionMetadata = metadataList;
+
+      metadataFolders.push(
+        ...metadataList.flatMap(({ id }) => [
+          {
+            id,
+            type: 'input' as MarxanExecutionMetadataFolderType,
+            buffer: Buffer.from(expectedInputBufferText),
+          },
+          {
+            id,
+            type: 'output' as MarxanExecutionMetadataFolderType,
+            buffer: Buffer.from(expectedOutputBufferText),
+          },
+        ]),
+      );
+    },
+    GivenWrongMarxanExecutionMetadata: async () => {
+      const metadataList = Array(amountOfMarxanRuns)
+        .fill('')
+        .map(() => ({
+          id: v4(),
+          includesOutputFolder: true,
+          failed: false,
+          stdOutput: 'Success!!!',
+        }));
+
+      marxanExecutionMetadataFileContent.marxanExecutionMetadata = metadataList;
+
+      metadataFolders.push(
+        ...metadataList.slice(1 - metadataList.length).flatMap(({ id }) => [
+          {
+            id,
+            type: 'input' as MarxanExecutionMetadataFolderType,
+            buffer: Buffer.from('input'),
+          },
+          {
+            id,
+            type: 'output' as MarxanExecutionMetadataFolderType,
+            buffer: Buffer.from('output'),
+          },
+        ]),
+      );
+    },
+    GivenJobInput: (
+      archiveLocation: ArchiveLocation,
+      resourceKind: ResourceKind,
+    ): ImportJobInput => {
+      const [
+        uri,
+      ] = ClonePieceUrisResolver.resolveFor(
+        ClonePiece.MarxanExecutionMetadata,
+        archiveLocation.value,
+        { kind: resourceKind, scenarioId: oldScenarioId },
+      );
+
+      return {
+        componentId: v4(),
+        pieceResourceId: scenarioId,
+        importId: v4(),
+        projectId,
+        piece: ClonePiece.MarxanExecutionMetadata,
+        resourceKind,
+        uris: [uri.toSnapshot()],
+        ownerId: userId,
+      };
+    },
+    GivenJobInputWithoutUris: (): ImportJobInput => {
+      return {
+        componentId: v4(),
+        pieceResourceId: scenarioId,
+        importId: v4(),
+        projectId,
+        piece: ClonePiece.MarxanExecutionMetadata,
+        resourceKind: ResourceKind.Project,
+        uris: [],
+        ownerId: userId,
+      };
+    },
+    GivenNoMarxanExecutionMetadataFileIsAvailable: () => {
+      return new ArchiveLocation('invalid uri');
+    },
+    GivenMarxanExecutionMetadataFile: async (resourceKind: ResourceKind) => {
+      const [
+        { relativePath },
+      ] = ClonePieceUrisResolver.resolveFor(
+        ClonePiece.MarxanExecutionMetadata,
+        'marxan execution metadata file relative path',
+        { kind: resourceKind, scenarioId: oldScenarioId },
+      );
+
+      const archive = archiver(`zip`, {
+        zlib: { level: 9 },
+      });
+      archive.append(JSON.stringify(marxanExecutionMetadataFileContent), {
+        name: relativePath,
+      });
+
+      metadataFolders.forEach(({ buffer, id, type }) => {
+        archive.append(buffer, {
+          name: getMarxanExecutionMetadataFolderRelativePath(
+            id,
+            type,
+            relativePath,
+          ),
+        });
+      });
+
+      const saveFile = fileRepository.save(archive);
+      archive.finalize();
+      const uriOrError = await saveFile;
+
+      if (isLeft(uriOrError)) throw new Error("couldn't save file");
+      return new ArchiveLocation(uriOrError.right);
+    },
+    WhenPieceImporterIsInvoked: (input: ImportJobInput) => {
+      return {
+        ThenAnUrisArrayErrorShouldBeThrown: async () => {
+          await expect(sut.run(input)).rejects.toThrow(/uris/gi);
+        },
+        ThenADataNotAvailableErrorShouldBeThrown: async () => {
+          await expect(sut.run(input)).rejects.toThrow(
+            /Export file is not available at/gi,
+          );
+        },
+        ThenAMissingPlanningUnitsErrorShouldBeThrown: async () => {
+          await expect(sut.run(input)).rejects.toThrow(
+            /missing planning units/gi,
+          );
+        },
+        ThenAFolderExtractionErrorShouldBeThrown: async () => {
+          await expect(sut.run(input)).rejects.toThrow(
+            /error extracting.*folder of execution metadata/gi,
+          );
+        },
+        ThenMarxanExecutionMetadataShouldBeImported: async () => {
+          await sut.run(input);
+
+          const importedData = await marxanExecutionMetadataRepo.find({
+            where: { scenarioId },
+          });
+
+          expect(importedData).toHaveLength(amountOfMarxanRuns);
+
+          const [executionMetadata] = importedData;
+
+          expect(executionMetadata.inputZip.toString()).toEqual(
+            expectedInputBufferText,
+          );
+          expect(executionMetadata.outputZip!.toString()).toEqual(
+            expectedOutputBufferText,
+          );
+          expect(executionMetadata.failed).toEqual(expectedFailedValue);
+          expect(executionMetadata.stdOutput).toEqual(expectedStdOutput);
+          expect(executionMetadata.stdError).toEqual(expectedStdError);
+        },
+      };
+    },
+  };
+};

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/marxan-execution-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/marxan-execution-metadata.ts
@@ -1,14 +1,22 @@
-export type FolderZipType = 'input' | 'output';
+export type MarxanExecutionMetadataFolderType = 'input' | 'output';
 
 export const marxanExecutionMetadataRelativePath = `marxan-execution-metadata.json`;
 export const marxanExecutionMetadataFoldersRelativePath = `marxan-execution-metadata`;
 
+const getFolderRelativePathPrefix = (metadataJsonRelativePath: string) =>
+  metadataJsonRelativePath.substring(
+    0,
+    metadataJsonRelativePath.lastIndexOf('/') + 1,
+  );
+
 export const getMarxanExecutionMetadataFolderRelativePath = (
   executionId: string,
-  pathPrefix: string,
-  type: FolderZipType,
+  type: MarxanExecutionMetadataFolderType,
+  metadataJsonRelativePath: string,
 ) =>
-  `${pathPrefix}/${marxanExecutionMetadataFoldersRelativePath}/${executionId}/${type}.zip`;
+  `${getFolderRelativePathPrefix(
+    metadataJsonRelativePath,
+  )}${marxanExecutionMetadataFoldersRelativePath}/${executionId}/${type}.zip`;
 
 export type MarxanExecutionMetadataElement = {
   id: string;

--- a/api/libs/utils/src/index.ts
+++ b/api/libs/utils/src/index.ts
@@ -1,6 +1,11 @@
 export { isDefined } from './is-defined';
 export { assertDefined } from './assert-defined';
-export { extractFile, extractFileFailed } from './zip-file-extractor';
+export {
+  extractFile,
+  extractFiles,
+  fileNotFound,
+  extractFileFailed,
+} from './zip-file-extractor';
 export { FieldsOf } from './fields-of.type';
 export * from './geo';
 export { TimeUserEntityMetadata } from './time-user-entity-metadata';


### PR DESCRIPTION
This PR adds `ClonePiece.MarxanExecutionMetadata` piece importer

### Feature relevant tickets

[import piece (scenario): marxan execution metadata](https://vizzuality.atlassian.net/browse/MARXAN-1475)