### PR TITLE
Project-metadata-publicMetadata-isAdminEndpoints

### DIFF
--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -98,6 +98,8 @@ export class ProjectsCrudService extends AppBaseService<
         'bbox',
         'customProtectedAreas',
         'isPublic',
+        'publicMetadata',
+        'metadata',
       ],
       keyForAttribute: 'camelCase',
       scenarios: {

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -45,7 +45,7 @@ export class PublishedProjectCrudService extends AppBaseService<
 
   async extendFindAllQuery(
     query: SelectQueryBuilder<PublishedProject>,
-    fetchSpecification: FetchSpecification,
+    fetchSpecification?: FetchSpecification,
     info?: ProjectsRequest,
   ): Promise<SelectQueryBuilder<PublishedProject>> {
     const userId = info?.authenticatedUser?.id;

--- a/api/apps/api/src/modules/users/users.service.ts
+++ b/api/apps/api/src/modules/users/users.service.ts
@@ -6,7 +6,7 @@ import {
   NotImplementedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ILike, Repository } from 'typeorm';
+import { ILike, Repository, SelectQueryBuilder } from 'typeorm';
 import { User, userResource } from './user.api.entity';
 
 import { omit } from 'lodash';
@@ -26,6 +26,7 @@ import { v4 } from 'uuid';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { PlatformAdminEntity } from './platform-admin/admin.api.entity';
 import { Either, left, right } from 'fp-ts/lib/Either';
+import { FetchSpecification } from 'nestjs-base-service';
 
 export const forbiddenError = Symbol(`unauthorized access`);
 export const badRequestError = Symbol(`operation not allowed`);
@@ -243,6 +244,7 @@ export class UsersService extends AppBaseService<
 
   async extendFindAllResults(
     entitiesAndCount: [User[], number],
+    _fetchSpecification?: FetchSpecification,
   ): Promise<[User[], number]> {
     const extendedEntities: Promise<User>[] = entitiesAndCount[0].map(
       (entity) => this.extendGetByIdResult(entity),

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -129,6 +129,8 @@ export const getFixtures = async () => {
             planningUnitGridShape: expect.any(String),
             planningAreaId: 'NAM',
             planningAreaName: 'Namibia',
+            metadata: null,
+            publicMetadata: null,
           },
           id: publicProjectId,
           type: 'projects',

--- a/api/apps/geoprocessing/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/geoprocessing/src/modules/scenarios/scenarios.service.ts
@@ -196,7 +196,7 @@ export class ScenariosService {
 
     const query = `with data as (select unnest(protected_pu_ids) as pu_ids 
     from blm_final_results bfr where blm_value = $1) 
-    select ST_AsMVT(tile.*, 'layer0', {extent}, 'mvt_geom') as mvt 
+    select ST_AsMVT(tile.*, 'layer0', ${extent}, 'mvt_geom') as mvt 
     from (select pu_ids, ST_AsMVTGeom(ST_Transform(${geometry}, 3857),
     ST_TileEnvelope(${z}, ${x}, ${y}), ${extent}, ${buffer}, true) AS mvt_geom from scenarios_pu_data spd 
     inner join projects_pu pp on pp.id = spd.project_pu_id


### PR DESCRIPTION
-Adds query search for users endpoint, also adds isAdmin check to prevent users from being seen by regular users.
-Adds metadata and publicMetadata to project JSONAPI serializer.
-Fix tiles DB request failing because missing escaped param.