### PR TITLE
feat: project metadata clone piece adjustments

### DIFF
--- a/api/apps/api/src/modules/clone/export/application/export-application.module.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-application.module.ts
@@ -6,6 +6,8 @@ import {
   Scope,
 } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Project } from '../../../projects/project.api.entity';
 import { AllPiecesReadySaga } from './all-pieces-ready.saga';
 import { CompleteExportPieceHandler } from './complete-export-piece.handler';
 import { ExportProjectHandler } from './export-project.handler';
@@ -18,7 +20,11 @@ export class ExportApplicationModule {
   static for(adapters: ModuleMetadata['imports']): DynamicModule {
     return {
       module: ExportApplicationModule,
-      imports: [CqrsModule, ...(adapters ?? [])],
+      imports: [
+        CqrsModule,
+        TypeOrmModule.forFeature([Project]),
+        ...(adapters ?? []),
+      ],
       providers: [
         // internal event flow
         AllPiecesReadySaga,

--- a/api/apps/api/src/modules/clone/export/application/export-project.command.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.command.ts
@@ -13,7 +13,7 @@ export class ExportProject extends Command<ExportProjectCommandResult> {
     public readonly id: ResourceId,
     public readonly scenarioIds: string[],
     public readonly ownerId: UserId,
-    public readonly clonning: boolean,
+    public readonly cloning: boolean,
   ) {
     super();
   }

--- a/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
@@ -9,6 +9,9 @@ import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Injectable } from '@nestjs/common';
 import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { v4 } from 'uuid';
+import { Project } from '../../../projects/project.api.entity';
 import { MemoryExportRepo } from '../adapters/memory-export.repository';
 import {
   ExportComponent,
@@ -56,6 +59,10 @@ const getFixtures = async () => {
       {
         provide: ExportRepository,
         useClass: MemoryExportRepo,
+      },
+      {
+        provide: getRepositoryToken(Project),
+        useClass: FakeProjectRepoProvider,
       },
       ExportProjectHandler,
     ],
@@ -149,4 +156,13 @@ class FakePiecesProvider implements ExportResourcePieces {
   resolveForScenario(id: ResourceId, kind: ResourceKind): ExportComponent[] {
     return [];
   }
+}
+
+@Injectable()
+class FakeProjectRepoProvider {
+  findOneOrFail() {
+    return { organizationId: v4() };
+  }
+
+  save() {}
 }

--- a/api/apps/api/src/modules/clone/export/application/export-project.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.handler.ts
@@ -26,6 +26,18 @@ export class ExportProjectHandler
     private readonly projectRepo: Repository<Project>,
   ) {}
 
+  private async createProjectShell(
+    existingProjectId: string,
+    newProjectId: string,
+  ) {
+    const project = await this.projectRepo.findOneOrFail(existingProjectId);
+    await this.projectRepo.save({
+      id: newProjectId,
+      name: '',
+      organizationId: project.organizationId,
+    });
+  }
+
   async execute({
     id,
     scenarioIds,
@@ -42,12 +54,11 @@ export class ExportProjectHandler
     exportRequest.commit();
 
     if (cloning) {
-      const project = await this.projectRepo.findOneOrFail(id.value);
-      await this.projectRepo.save({
-        id: exportRequest.importResourceId!.value,
-        name: '',
-        organizationId: project.organizationId,
-      });
+      // TODO Mark cloning as submitted
+      await this.createProjectShell(
+        id.value,
+        exportRequest.importResourceId!.value,
+      );
     }
 
     return {

--- a/api/apps/api/src/modules/clone/import/application/export-config-reader.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/export-config-reader.spec.ts
@@ -60,6 +60,7 @@ describe('ExportConfigReader', () => {
       scenarios: [],
       version: '1.0.0',
       description: 'description',
+      isCloning: false,
     };
     const archiveLocation = await fixtures.GivenArchiveWithInvalidExportConfig(
       invalidExportConfig,
@@ -83,6 +84,7 @@ describe('ExportConfigReader', () => {
       scenarios: [],
       version: '1.0.0',
       description: 'description',
+      isCloning: false,
     };
     const archiveLocation = await fixtures.GivenArchiveWithInvalidExportConfig(
       invalidExportConfig,
@@ -101,6 +103,7 @@ describe('ExportConfigReader', () => {
       scenarios: [],
       version: '1.0.0',
       description: 'description',
+      isCloning: false,
     };
     const archiveLocation = await fixtures.GivenArchiveWithInvalidExportConfig(
       invalidExportConfig,
@@ -148,6 +151,7 @@ const getFixtures = async () => {
     resourceKind: ResourceKind.Project,
     scenarios: [{ id: v4(), name: 'random scenario' }],
     version: exportVersion,
+    isCloning: false,
   };
 
   const sut = sandbox.get(ExportConfigReader);

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
@@ -100,6 +100,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     WhenJobFinishes: async (input: ExportJobInput) => {

--- a/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.ts
@@ -41,7 +41,11 @@ export class SchedulePieceExportHandler
       this.eventBus.publish(new ExportPieceFailed(exportId, componentId));
       return;
     }
-    const { resourceKind, exportPieces } = exportInstance.toSnapshot();
+    const {
+      resourceKind,
+      exportPieces,
+      importResourceId,
+    } = exportInstance.toSnapshot();
 
     const component = exportPieces.find(
       (piece) => piece.id === componentId.value,
@@ -67,6 +71,7 @@ export class SchedulePieceExportHandler
       resourceId,
       resourceKind,
       allPieces,
+      isCloning: Boolean(importResourceId),
     });
 
     if (!job) {

--- a/api/apps/geoprocessing/src/export/export-pieces.integration.spec.ts
+++ b/api/apps/geoprocessing/src/export/export-pieces.integration.spec.ts
@@ -27,6 +27,7 @@ test(`exporting supported piece`, async () => {
     resourceId,
     resourceKind: ResourceKind.Project,
     allPieces: [{ resourceId, piece: ClonePiece.ProjectMetadata }],
+    isCloning: false,
   };
   const result = await fixtures.sut.run(input);
   expect(result).toEqual({
@@ -49,6 +50,7 @@ test(`exporting unsupported piece`, async () => {
     resourceId,
     resourceKind: ResourceKind.Scenario,
     allPieces: [{ resourceId, piece: ClonePiece.ProjectMetadata }],
+    isCloning: false,
   };
   expect(async () => await fixtures.sut.run(input)).rejects.toEqual(
     new Error(`some piece is not yet supported.`),

--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
@@ -84,6 +84,7 @@ export class ExportConfigProjectPieceExporter implements ExportPieceProcessor {
       description: project.description,
       resourceKind: input.resourceKind,
       resourceId: projectId,
+      isCloning: input.isCloning,
       pieces: {
         project: projectPieces,
         scenarios: scenarioPieces,

--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
@@ -62,6 +62,7 @@ export class ExportConfigScenarioPieceExporter implements ExportPieceProcessor {
       resourceKind: input.resourceKind,
       resourceId: scenarioId,
       pieces: input.allPieces.map((elem) => elem.piece),
+      isCloning: true,
     };
 
     const outputFile = await this.fileRepository.save(

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
@@ -102,6 +102,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenAPlanningAreaGadmScenarioExportJob: () => {
@@ -115,6 +116,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Scenario,
+        isCloning: false,
       };
     },
     WhenProjectGadmDataIsMissing: () => {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
@@ -56,6 +56,7 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
       name: projectData.name,
       description: projectData.description,
       planningUnitGridShape: projectData.planning_unit_grid_shape,
+      projectAlreadyCreated: input.isCloning,
     };
 
     const outputFile = await this.fileRepository.save(

--- a/api/apps/geoprocessing/test/integration/clonning/export-config.project-piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/export-config.project-piece-exporter.e2e-spec.ts
@@ -109,6 +109,7 @@ const getFixtures = async () => {
         project: [ClonePiece.ProjectMetadata, ClonePiece.ExportConfig],
         scenarios,
       },
+      isCloning: false,
     };
   };
 
@@ -137,6 +138,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ExportConfig,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async (options = defaultFixtureOptions) => {

--- a/api/apps/geoprocessing/test/integration/clonning/export-config.scenario-piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/export-config.scenario-piece-exporter.e2e-spec.ts
@@ -79,6 +79,7 @@ const getFixtures = async () => {
     resourceKind: ResourceKind.Scenario,
     resourceId: scenarioId,
     pieces: [ClonePiece.ScenarioMetadata, ClonePiece.ExportConfig],
+    isCloning: false,
   };
 
   return {
@@ -100,6 +101,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ExportConfig,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Scenario,
+        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/export-config.scenario-piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/export-config.scenario-piece-exporter.e2e-spec.ts
@@ -79,7 +79,7 @@ const getFixtures = async () => {
     resourceKind: ResourceKind.Scenario,
     resourceId: scenarioId,
     pieces: [ClonePiece.ScenarioMetadata, ClonePiece.ExportConfig],
-    isCloning: false,
+    isCloning: true,
   };
 
   return {

--- a/api/apps/geoprocessing/test/integration/clonning/marxan-execution-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/marxan-execution-metadata.piece-exporter.e2e-spec.ts
@@ -99,6 +99,7 @@ const getFixtures = async () => {
         piece: ClonePiece.MarxanExecutionMetadata,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenMarxanExecutionMetadata: () =>

--- a/api/apps/geoprocessing/test/integration/clonning/planning-area-custom-geojson.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-area-custom-geojson.piece-exporter.e2e-spec.ts
@@ -114,6 +114,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaCustomGeojson,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/planning-area-custom.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-area-custom.piece-exporter.e2e-spec.ts
@@ -110,6 +110,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaCustom,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/planning-area-gadm.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-area-gadm.piece-exporter.e2e-spec.ts
@@ -95,6 +95,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectWithGadmArea: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/planning-units-grid-geojson.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-units-grid-geojson.piece-exporter.e2e-spec.ts
@@ -105,6 +105,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningUnitsGridGeojson,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/planning-units-grid.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/planning-units-grid.piece-exporter.e2e-spec.ts
@@ -118,6 +118,7 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningUnitsGrid,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/project-custom-features.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/project-custom-features.piece-exporter.e2e-spec.ts
@@ -113,6 +113,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectCustomFeatures,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/project-custom-protected-areas.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/project-custom-protected-areas.piece-exporter.e2e-spec.ts
@@ -113,6 +113,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/project-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/project-metadata.piece-exporter.e2e-spec.ts
@@ -72,6 +72,7 @@ const getFixtures = async () => {
   const expectedContent: ProjectMetadataContent = {
     name: `test project - ${projectId}`,
     planningUnitGridShape: PlanningUnitGridShape.Square,
+    projectAlreadyCreated: false,
   };
 
   return {
@@ -92,6 +93,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-features-data.piece-exporter.e2e-spec.ts
@@ -127,6 +127,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioFeaturesData,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenScenarioExist: () =>

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-features-specification.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-features-specification.piece-exporter.e2e-spec.ts
@@ -152,6 +152,7 @@ const getFixtures = async () => {
         piece: ClonePiece.FeaturesSpecification,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-metadata.piece-exporter.e2e-spec.ts
@@ -95,6 +95,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioMetadata,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Scenario,
+        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-planning-units-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-planning-units-data.piece-exporter.e2e-spec.ts
@@ -114,6 +114,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioPlanningUnitsData,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-protected-areas.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-protected-areas.piece-exporter.e2e-spec.ts
@@ -122,6 +122,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioProtectedAreas,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/clonning/scenario-run-results.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/clonning/scenario-run-results.piece-exporter.e2e-spec.ts
@@ -134,6 +134,7 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioRunResults,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
+        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/export-config.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/export-config.ts
@@ -2,6 +2,7 @@ import { Type } from 'class-transformer';
 import {
   Equals,
   IsArray,
+  IsBoolean,
   IsEnum,
   IsOptional,
   IsString,
@@ -32,6 +33,10 @@ class CommonFields {
   @IsString()
   @IsOptional()
   description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isCloning!: boolean;
 }
 
 class ScenarioMetadata {

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
@@ -4,6 +4,7 @@ export type ProjectMetadataContent = {
   name: string;
   description?: string;
   planningUnitGridShape?: PlanningUnitGridShape;
+  projectAlreadyCreated: boolean;
 };
 
 export const projectMetadataRelativePath = 'project-metadata.json';

--- a/api/libs/cloning/src/job-input.ts
+++ b/api/libs/cloning/src/job-input.ts
@@ -1,4 +1,3 @@
-import { string } from 'fp-ts';
 import { ClonePiece, ComponentLocationSnapshot, ResourceKind } from './domain';
 
 export interface ExportJobInput {
@@ -7,6 +6,7 @@ export interface ExportJobInput {
   readonly resourceId: string;
   readonly resourceKind: ResourceKind;
   readonly piece: ClonePiece;
+  readonly isCloning: boolean;
   readonly allPieces: { piece: ClonePiece; resourceId: string }[];
 }
 


### PR DESCRIPTION
This PR edits how `project-metadata` piece is exported/imported. Projects being cloned are now created at export project command handler level. With these changes, frontend will be able to query the status of the cloning process after receiving the response of clone endpoint

### Feature relevant tickets

[modify project metadata piece importer/exporter to take into account cloning processes](https://vizzuality.atlassian.net/browse/MARXAN-1479)