### PR TITLE
feat: return user id on get latest export endpoint

### DIFF
--- a/api/apps/api/src/modules/projects/dto/export.project.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/export.project.dto.ts
@@ -17,8 +17,22 @@ export class RequestProjectExportBodyDto {
 
 export class RequestProjectExportResponseDto {
   @ApiProperty({
-    description: 'ID of the project',
+    description: 'ID of the export',
     example: '6fbec34e-04a7-4131-be14-c245f2435a6c',
   })
   id!: string;
+}
+
+export class GetLatestExportResponseDto {
+  @ApiProperty({
+    description: 'ID of the export',
+    example: '6fbec34e-04a7-4131-be14-c245f2435a6c',
+  })
+  exportId!: string;
+
+  @ApiProperty({
+    description: 'ID of the user who launched the export',
+    example: '6fbec34e-04a7-4131-be14-c245f2435a6c',
+  })
+  userId!: string;
 }

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -99,6 +99,7 @@ import { locationNotFound } from '@marxan-api/modules/clone/export/application/g
 import {
   RequestProjectExportResponseDto,
   RequestProjectExportBodyDto,
+  GetLatestExportResponseDto,
 } from './dto/export.project.dto';
 import { ScenarioLockResultPlural } from '@marxan-api/modules/access-control/scenarios-acl/locks/dto/scenario.lock.dto';
 import { RequestProjectImportResponseDto } from './dto/import.project.response.dto';
@@ -684,19 +685,19 @@ export class ProjectsController {
     name: 'projectId',
     description: 'ID of the Project',
   })
-  @ApiOkResponse({ type: RequestProjectExportResponseDto })
+  @ApiOkResponse({ type: GetLatestExportResponseDto })
   @Get(`:projectId/export`)
   async getLatestExportId(
     @Param('projectId') projectId: string,
     @Req() req: RequestWithAuthenticatedUser,
-  ) {
-    const exportIdOrError = await this.projectsService.getLatestExportForProject(
+  ): Promise<GetLatestExportResponseDto> {
+    const resultOrError = await this.projectsService.getLatestExportForProject(
       projectId,
       req.user.id,
     );
 
-    if (isLeft(exportIdOrError)) {
-      switch (exportIdOrError.left) {
+    if (isLeft(resultOrError)) {
+      switch (resultOrError.left) {
         case exportNotFound:
           throw new NotFoundException(
             `Export for project with id ${projectId} not found`,
@@ -707,7 +708,7 @@ export class ProjectsController {
           throw new InternalServerErrorException();
       }
     }
-    return { id: exportIdOrError.right };
+    return resultOrError.right;
   }
 
   @ImplementsAcl()

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -35,6 +35,11 @@ import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block
 import { ProjectCheckerModule } from '@marxan-api/modules/projects/project-checker/project-checker.module';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
 import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
+import { ExportEntity } from '../clone/export/adapters/entities/exports.api.entity';
+import { ExportComponentEntity } from '../clone/export/adapters/entities/export-components.api.entity';
+import { ExportComponentLocationEntity } from '../clone/export/adapters/entities/export-component-locations.api.entity';
+import { ExportRepository } from '../clone/export/application/export-repository.port';
+import { TypeormExportRepository } from '../clone/export/adapters/typeorm-export.repository';
 
 @Module({
   imports: [
@@ -50,6 +55,9 @@ import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
       ProjectJobStatus,
       PublishedProject,
       UsersProjectsApiEntity,
+      ExportEntity,
+      ExportComponentEntity,
+      ExportComponentLocationEntity,
     ]),
     TypeOrmModule.forFeature(
       [ProtectedArea],
@@ -75,6 +83,10 @@ import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
     JobStatusSerializer,
     GetProjectHandler,
     ProxyService,
+    {
+      provide: ExportRepository,
+      useClass: TypeormExportRepository,
+    },
   ],
   controllers: [
     ProjectsListingController,

--- a/api/apps/api/test/project/get-latest-export.e2e-spec.ts
+++ b/api/apps/api/test/project/get-latest-export.e2e-spec.ts
@@ -227,7 +227,8 @@ export const getFixtures = async () => {
     },
     ThenLatestExportIdIsObtained: (response: request.Response) => {
       expect(response.status).toBe(200);
-      expect(response.body.id).toEqual(exportId.value);
+      expect(response.body.exportId).toEqual(exportId.value);
+      expect(response.body.userId).toBeDefined();
     },
     ThenForbiddenIsReturned: (response: request.Response) => {
       expect(response.status).toBe(403);


### PR DESCRIPTION
This PR adds the id of the user who launched the export to the response of get latest export endpoint

### Feature relevant tickets

[return userId on API endpoint GET /api/v1/projects/{projectId}/export](https://vizzuality.atlassian.net/browse/MARXAN-1476)