### PR TITLE
feat: scenario cloning adjustments

### DIFF
--- a/api/apps/api/src/modules/clone/export/application/export-application.module.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-application.module.ts
@@ -8,6 +8,7 @@ import {
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Project } from '../../../projects/project.api.entity';
+import { Scenario } from '../../../scenarios/scenario.api.entity';
 import { AllPiecesReadySaga } from './all-pieces-ready.saga';
 import { CompleteExportPieceHandler } from './complete-export-piece.handler';
 import { ExportProjectHandler } from './export-project.handler';
@@ -22,7 +23,7 @@ export class ExportApplicationModule {
       module: ExportApplicationModule,
       imports: [
         CqrsModule,
-        TypeOrmModule.forFeature([Project]),
+        TypeOrmModule.forFeature([Project, Scenario]),
         ...(adapters ?? []),
       ],
       providers: [


### PR DESCRIPTION
This PR edits how `scenario-metadata` piece is exported/imported. Scenarios being cloned are now created at export scenario command handler level. With these changes, frontend will be able to query the status of the cloning process after receiving the response of clone endpoint

### Feature relevant tickets

[modify scenario metadata piece importer/exporter to take into account cloning processes](https://vizzuality.atlassian.net/browse/MARXAN-1480)