### PR TITLE
Fix-BLM-Image-Generation-prepares-image-for-publishedProjects

### DIFF
--- a/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
@@ -24,4 +24,8 @@ export class PublishProjectDto {
   @IsOptional()
   @ApiPropertyOptional()
   company?: Company;
+
+  @IsOptional()
+  @ApiPropertyOptional()
+  scenarioId?: string;
 }

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -59,9 +59,12 @@ export class PublishedProjectService {
       return left(alreadyPublished);
     }
 
+    // @debt scenarioId will be used in the png_map_data generation.
+    const { scenarioId, ...projectWithoutScenario } = projectToPublish;
+
     await this.crudService.create({
       id,
-      ...projectToPublish,
+      ...projectWithoutScenario,
     });
     return right(true);
   }

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/blm-final-results.repository.ts
@@ -49,7 +49,7 @@ export class BlmFinalResultsRepository {
     await this.entityManager.transaction(async (txManager) => {
       const query = `
         update blm_final_results
-        set protected_pu_ids NULL
+        set protected_pu_ids = NULL
         where blm_final_results.scenario_id = $1 and blm_final_results.blm_value = $2`;
       await txManager.query(query, [scenarioId, blmValue]);
 


### PR DESCRIPTION
-Fix blm image query for setting `protected_pu_ids` to NULL that prevented the blm image generation from working.
-Set up scenarioId in DTO for publishedProjects so the image generation process can be based on it.