### PR TITLE
MARXAN-1274-publicMap-screenshot

### DIFF
--- a/api/apps/api/src/migrations/api/1650619314086-AddLocationPngDataPublicProject.ts
+++ b/api/apps/api/src/migrations/api/1650619314086-AddLocationPngDataPublicProject.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddLocationsPngDataPublicProject1650619314086
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE published_projects
+        ADD COLUMN location varchar,
+        ADD COLUMN png_data text;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE published_projects
+            DROP COLUMN location,
+            DROP COLUMN png_data;
+    `);
+  }
+}

--- a/api/apps/api/src/modules/published-project/dto/create-published-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/create-published-project.dto.ts
@@ -17,7 +17,9 @@ export interface CreatePublishedProjectDto {
   id: string;
   name?: string;
   description?: string;
+  location?: string;
   creators?: Creator[];
   resources?: Resource[];
   company?: Company;
+  pngData?: string;
 }

--- a/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
@@ -1,5 +1,7 @@
+import { WebshotConfig } from '@marxan/webshot';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Company, Creator, Resource } from './create-published-project.dto';
 
 export class PublishProjectDto {
@@ -12,6 +14,10 @@ export class PublishProjectDto {
   @IsOptional()
   @ApiPropertyOptional()
   description?: string;
+
+  @IsOptional()
+  @ApiPropertyOptional()
+  location?: string;
 
   @IsOptional()
   @ApiPropertyOptional()
@@ -28,4 +34,9 @@ export class PublishProjectDto {
   @IsOptional()
   @ApiPropertyOptional()
   scenarioId?: string;
+
+  @ApiProperty()
+  @ValidateNested({ each: true })
+  @Type(() => WebshotConfig)
+  config?: WebshotConfig;
 }

--- a/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
@@ -33,7 +33,7 @@ export class PublishProjectDto {
 
   @IsOptional()
   @ApiPropertyOptional()
-  scenarioId?: string;
+  featuredScenarioId?: string;
 
   @ApiProperty()
   @ValidateNested({ each: true })

--- a/api/apps/api/src/modules/published-project/entities/published-project.api.entity.ts
+++ b/api/apps/api/src/modules/published-project/entities/published-project.api.entity.ts
@@ -5,7 +5,6 @@ import {
   Creator,
   Resource,
 } from '../dto/create-published-project.dto';
-import { string } from 'fp-ts';
 
 @Entity('published_projects')
 export class PublishedProject {

--- a/api/apps/api/src/modules/published-project/entities/published-project.api.entity.ts
+++ b/api/apps/api/src/modules/published-project/entities/published-project.api.entity.ts
@@ -5,6 +5,7 @@ import {
   Creator,
   Resource,
 } from '../dto/create-published-project.dto';
+import { string } from 'fp-ts';
 
 @Entity('published_projects')
 export class PublishedProject {
@@ -17,6 +18,9 @@ export class PublishedProject {
   @Column('character varying')
   description?: string;
 
+  @Column('character varying')
+  location?: string;
+
   @Column('boolean', { name: 'under_moderation', default: false })
   underModeration?: boolean;
 
@@ -28,6 +32,9 @@ export class PublishedProject {
 
   @Column('jsonb')
   creators?: Creator[];
+
+  @Column('character varying', { name: 'png_data' })
+  pngData?: string;
 
   @OneToOne(() => Project)
   @JoinColumn({ name: 'id' })

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -41,11 +41,13 @@ export class PublishedProjectCrudService extends AppBaseService<
       attributes: [
         'name',
         'description',
+        'location',
         'creators',
         'company',
         'resources',
         'underModeration',
         'originalProject',
+        'pngData',
       ],
       keyForAttribute: 'camelCase',
       originalProject: {

--- a/api/apps/api/src/modules/published-project/published-project.module.ts
+++ b/api/apps/api/src/modules/published-project/published-project.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { PublishedProjectService } from './published-project.service';
 import { ProjectsModule } from '@marxan-api/modules/projects/projects.module';
 import { PublishedProjectCrudService } from '@marxan-api/modules/published-project/published-project-crud.service';
@@ -9,6 +9,7 @@ import { PublishProjectController } from '@marxan-api/modules/published-project/
 import { PublishedProjectSerializer } from '@marxan-api/modules/published-project/published-project.serializer';
 import { AccessControlModule } from '@marxan-api/modules/access-control';
 import { UsersModule } from '@marxan-api/modules/users/users.module';
+import { WebshotModule } from '@marxan/webshot';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UsersModule } from '@marxan-api/modules/users/users.module';
     ProjectsModule,
     TypeOrmModule.forFeature([PublishedProject]),
     UsersModule,
+    forwardRef(() => WebshotModule),
   ],
   controllers: [PublishProjectController, PublishedProjectReadController],
   providers: [

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -13,7 +13,7 @@ import { PublishProjectDto } from './dto/publish-project.dto';
 import { WebshotService } from '@marxan/webshot';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { assertDefined } from '@marxan/utils';
-import { isLeft, isRight } from 'fp-ts/lib/These';
+import { isLeft, isRight } from 'fp-ts/lib/Either';
 
 export const notFound = Symbol(`project not found`);
 export const accessDenied = Symbol(`not allowed`);
@@ -72,11 +72,17 @@ export class PublishedProjectService {
 
     const webshotUrl = AppConfig.get('webshot.url') as string;
 
-    const { scenarioId, config, ...projectWithoutScenario } = projectToPublish;
-    assertDefined(scenarioId);
+    const {
+      featuredScenarioId,
+      config,
+      ...projectWithoutScenario
+    } = projectToPublish;
+
+    assertDefined(featuredScenarioId);
     assertDefined(config);
+
     const pngData = await this.webshotService.getPublishedProjectsImage(
-      scenarioId,
+      featuredScenarioId,
       id,
       {
         ...config,

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -64,6 +64,12 @@ export class PublishedProjectService {
       return left(alreadyPublished);
     }
 
+    // @debt If we end up moving the scenario map thumbnail generation
+    // to the end of the Marxan run process, this part here regarding
+    // the webshot should be removed and/or adapted to it. It looks
+    // like it does not belong here at all anyways, but right now there
+    // is not a better place to deal with this.
+
     const webshotUrl = AppConfig.get('webshot.url') as string;
 
     const { scenarioId, config, ...projectWithoutScenario } = projectToPublish;
@@ -87,13 +93,12 @@ export class PublishedProjectService {
       );
     }
 
-    if (isRight(pngData)) {
-      await this.crudService.create({
-        id,
-        ...projectWithoutScenario,
-        pngData: pngData.right,
-      });
-    }
+    await this.crudService.create({
+      id,
+      ...projectWithoutScenario,
+      pngData: isRight(pngData) ? pngData.right : '',
+    });
+
     return right(true);
   }
 

--- a/api/apps/api/test/fixtures/test-data.sql
+++ b/api/apps/api/test/fixtures/test-data.sql
@@ -41,15 +41,6 @@ VALUES
 ('Example scenario 1 Project 2 Org 2', (select id from projects where name = 'Example Project 2 Org 2'), 'marxan', 30, 100, 1, (SELECT id FROM users WHERE email = 'aa@example.com') ),
 ('Example scenario 2 Project 2 Org 2', (select id from projects where name = 'Example Project 2 Org 2'), 'marxan', 50, 100, 1, (SELECT id FROM users WHERE email = 'aa@example.com') );
 
-INSERT INTO users_scenarios
-(user_id, scenario_id, role_id)
-VALUES
-((SELECT id FROM users WHERE lower(email) = 'aa@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 1 Project 2 Org 2'), 'scenario_owner'),
-((SELECT id FROM users WHERE lower(email) = 'bb@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 1 Project 2 Org 2'), 'scenario_contributor'),
-((SELECT id FROM users WHERE lower(email) = 'cc@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 1 Project 2 Org 2'), 'scenario_viewer'),
-((SELECT id FROM users WHERE lower(email) = 'aa@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 2 Project 2 Org 2'), 'scenario_owner'),
-((SELECT id FROM users WHERE lower(email) = 'bb@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 2 Project 2 Org 2'), 'scenario_contributor'),
-((SELECT id FROM users WHERE lower(email) = 'cc@example.com'), (SELECT id FROM scenarios WHERE name = 'Example scenario 2 Project 2 Org 2'), 'scenario_viewer');
 
 INSERT INTO platform_admins
 (user_id)

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -285,7 +285,7 @@ export const getFixtures = async () => {
           creators: [{ displayName: 'fake name', avatarDataUrl: blmImageMock }],
           resources: [{ title: 'fake url', url: 'http://www.example.com' }],
           config: { baseUrl: 'example/png', cookie: 'randomCookie' },
-          scenarioId,
+          featuredScenarioId: scenarioId,
         })
         .set('Authorization', `Bearer ${randomUserToken}`),
     WhenUnpublishingAProjectAsProjectOwner: async (projectId: string) =>

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -225,6 +225,7 @@ export const getFixtures = async () => {
             ],
             resources: [{ title: expect.any(String), url: expect.any(String) }],
             location: expect.any(String),
+            pngData: expect.any(String),
           },
           id: publicProjectId,
           type: 'published_projects',
@@ -242,6 +243,7 @@ export const getFixtures = async () => {
             name: expect.any(String),
             underModeration: true,
             description: expect.any(String),
+            location: expect.any(String),
             company: {
               name: expect.any(String),
               logoDataUrl: expect.any(String),
@@ -253,6 +255,7 @@ export const getFixtures = async () => {
               },
             ],
             resources: [{ title: expect.any(String), url: expect.any(String) }],
+            pngData: expect.any(String),
           },
           id: publicProjectId,
           type: 'published_projects',

--- a/api/apps/api/test/project/public-projects.e2e-spec.ts
+++ b/api/apps/api/test/project/public-projects.e2e-spec.ts
@@ -25,7 +25,8 @@ test(`getting public projects`, async () => {
 
 test(`publishing a project`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenGettingPublicProjects();
   fixtures.ThenPublicProjectIsAvailable(projectId, response);
@@ -33,7 +34,8 @@ test(`publishing a project`, async () => {
 
 test(`when placing a public project under moderation as a platform admin`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
     projectId,
@@ -61,7 +63,8 @@ test(`when placing a public project under moderation as a platform admin`, async
 
 test(`when clearing under moderation status from a public project as a platform admin`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
     projectId,
@@ -82,7 +85,8 @@ test(`when clearing under moderation status from a public project as a platform 
 
 test(`when placing a public project under moderation as not a platform admin`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenPlacingAPublicProjectUnderModerationNotAsAdmin(
     projectId,
@@ -96,7 +100,8 @@ test(`when placing a public project under moderation as not a platform admin`, a
 
 test(`when clearing under moderation status from a public project not as platform admin`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
     projectId,
@@ -119,7 +124,8 @@ test(`when clearing under moderation status from a public project not as platfor
 
 test(`when unpublishing a public project as a project owner`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
 
   response = await fixtures.WhenUnpublishingAProjectAsProjectOwner(projectId);
@@ -130,7 +136,8 @@ test(`when unpublishing a public project as a project owner`, async () => {
 
 test(`when unpublishing a public project that is under moderation as a project owner`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
     projectId,
@@ -145,7 +152,8 @@ test(`when unpublishing a public project that is under moderation as a project o
 
 test(`when unpublishing a public project that is under moderation as a platform admin`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  let response = await fixtures.WhenPublishingAProject(projectId);
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
   fixtures.ThenCreatedIsReturned(response);
   response = await fixtures.WhenPlacingAPublicProjectUnderModerationAsAdmin(
     projectId,

--- a/api/libs/webshot/src/webshot.service.ts
+++ b/api/libs/webshot/src/webshot.service.ts
@@ -77,7 +77,7 @@ export class WebshotService {
     try {
       const pngBuffer = await this.httpService
         .post(
-          `${webshotUrl}/projects/${projectId}/scenarios/${scenarioId}/published-project/frequency`,
+          `${webshotUrl}/projects/${projectId}/scenarios/${scenarioId}/published-projects/frequency`,
           config,
           { responseType: 'arraybuffer' },
         )

--- a/api/libs/webshot/src/webshot.service.ts
+++ b/api/libs/webshot/src/webshot.service.ts
@@ -67,4 +67,31 @@ export class WebshotService {
       return left(unknownPngWebshotError);
     }
   }
+
+  async getPublishedProjectsImage(
+    scenarioId: string,
+    projectId: string,
+    config: WebshotPngConfig,
+    webshotUrl: string,
+  ): Promise<Either<typeof unknownPngWebshotError, string>> {
+    try {
+      const pngBuffer = await this.httpService
+        .post(
+          `${webshotUrl}/projects/${projectId}/scenarios/${scenarioId}/published-project/frequency`,
+          config,
+          { responseType: 'arraybuffer' },
+        )
+        .toPromise()
+        .then((response) => response.data)
+        .catch((error) => {
+          throw new Error(error);
+        });
+
+      const pngBase64String = Buffer.from(pngBuffer).toString('base64');
+
+      return right(pngBase64String);
+    } catch (error) {
+      return left(unknownPngWebshotError);
+    }
+  }
 }

--- a/webshot/src/domain/published-project-maps/published-projects-maps.ts
+++ b/webshot/src/domain/published-project-maps/published-projects-maps.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from "express";
+import puppeteer, { ScreenshotOptions } from "puppeteer";
+import { passthroughConsole } from "../../utils/passthrough-console.utils";
+import { waitForReportReady } from "../../utils/wait-function";
+
+const appRouteTemplate =
+  "/reports/:projectId/:scenarioId/frequency";
+
+export const generatePngImageFromPublishedProjectData = async (
+  req: Request,
+  res: Response
+) => {
+  const {
+    body: { baseUrl, cookie, screenshotOptions },
+  }: {
+    body: {
+      baseUrl: string;
+      cookie: string;
+      screenshotOptions: ScreenshotOptions;
+    };
+  } = req;
+
+  const {
+    params: { projectId, scenarioId },
+  } = req;
+
+  if (!(projectId || scenarioId )) {
+    res.status(400).json({
+      error: `Invalid request: projectId (${projectId}) or scenarioId (${scenarioId}) were not provided.`,
+    });
+    return;
+  }
+
+  if (!baseUrl) {
+    res.status(400).json({ error: "No baseUrl was provided." });
+    return;
+  }
+
+  try {
+    new URL(baseUrl);
+  } catch (error) {
+    res
+      .status(400)
+      .json({ error: `The provided baseUrl (${baseUrl} is not a valid URL.` });
+    return;
+  }
+
+  const pageUrl = `${baseUrl}${appRouteTemplate
+    .replace(":projectId", projectId)
+    .replace(":scenarioId", scenarioId)}`;
+
+  const browser = await puppeteer.launch({
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      '--disable-web-security',
+      "--disable-features=IsolateOrigins",
+      "--disable-site-isolation-trials",
+    ],
+  });
+  const page = await browser.newPage();
+  // Pass through browser console to our own service's console
+  page.on("console", passthroughConsole);
+
+  /**
+   * The webshot service authenticates to the upstream frontend instance by
+   * passing through the cookie that it receives from the API. In practice, all
+   * that is needed is the `__Secure-next-auth.session-token` cookie (or
+   * `next-auth.session-token` in development environments where the frontend
+   * may not be running behind an HTTPS reverse proxy).
+   *
+   * @todo remove Bypass-Tunnel-Reminder once done with all development and
+   * checks via LocalTunnel; the following line will do instead.
+   *
+   * if (cookie) await page.setExtraHTTPHeaders({ cookie });
+   */
+  if (cookie) {
+    await page.setExtraHTTPHeaders({
+      cookie,
+      "Bypass-Tunnel-Reminder": "true",
+    });
+  } else {
+    await page.setExtraHTTPHeaders({ "Bypass-Tunnel-Reminder": "true" });
+  }
+
+  console.info(`Rendering ${pageUrl} as PNG`);
+  await page.goto(pageUrl);
+  await page.waitForFunction(waitForReportReady, { timeout: 30e3 });
+
+  const pageAsPng = await Promise.race([
+    page.screenshot({ ...screenshotOptions }),
+    new Promise((resolve, reject) => setTimeout(reject, 30e3)),
+  ]);
+  await page.close();
+  await browser.close();
+
+  res.type("image/png");
+  res.end(pageAsPng);
+};

--- a/webshot/src/main.ts
+++ b/webshot/src/main.ts
@@ -10,6 +10,7 @@ import config from "config";
 import helmet from "helmet";
 import { generateSummaryReportForScenario } from "./domain/solutions-report/solutions-report";
 import { generatePngImageFromBlmData } from "./domain/blm-previews/png-image";
+import { generatePngImageFromPublishedProjectData } from "./domain/published-project-maps/published-projects-maps";
 
 const app: Application = express();
 const daemonListenPort = config.get("port");
@@ -37,6 +38,16 @@ app.post(
   "/projects/:projectId/scenarios/:scenarioId/calibration/maps/preview/:blmValue",
   async (req: Request, res: Response, next: NextFunction) => {
     await generatePngImageFromBlmData(req, res).catch((error) => {
+      console.error(error);
+      next(error);
+    });
+  }
+);
+
+app.post(
+  "/projects/:projectId/scenarios/:scenarioId/published-projects/frequency",
+  async (req: Request, res: Response, next: NextFunction) => {
+    await generatePngImageFromPublishedProjectData(req, res).catch((error) => {
       console.error(error);
       next(error);
     });


### PR DESCRIPTION
-Adds screenshot generation to publish action.
-Adds new location field to published project entity.
-Adapts tests to new fields.
-Minor removal of redundant fixture data.