### PR TITLE
Ref/project metadata piece importer

### DIFF
--- a/api/apps/api/src/modules/clone/import/application/export-config-reader.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/export-config-reader.spec.ts
@@ -40,7 +40,6 @@ describe('ExportConfigReader', () => {
       scenarios: [],
       version: '1.0.0',
       description: 'description',
-      isCloning: false,
       exportId: v4(),
     };
     const zipFile = await fixtures.GivenArchiveWithInvalidExportConfig(
@@ -65,7 +64,6 @@ describe('ExportConfigReader', () => {
       scenarios: [],
       version: '1.0.0',
       description: 'description',
-      isCloning: false,
       exportId: v4(),
     };
     const zipFile = await fixtures.GivenArchiveWithInvalidExportConfig(
@@ -85,7 +83,6 @@ describe('ExportConfigReader', () => {
       scenarios: [],
       version: '1.0.0',
       description: 'description',
-      isCloning: false,
       exportId: v4(),
     };
     const zipFile = await fixtures.GivenArchiveWithInvalidExportConfig(
@@ -131,7 +128,6 @@ const getFixtures = async () => {
     resourceKind: ResourceKind.Project,
     scenarios: [{ id: v4(), name: 'random scenario' }],
     version: exportVersion,
-    isCloning: false,
   };
 
   const sut = sandbox.get(ExportConfigReader);

--- a/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece.events-handler.spec.ts
@@ -100,7 +100,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     WhenJobFinishes: async (input: ExportJobInput) => {

--- a/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/schedule-piece-export.handler.ts
@@ -71,7 +71,6 @@ export class SchedulePieceExportHandler
       resourceId,
       resourceKind,
       allPieces,
-      isCloning: Boolean(importResourceId),
     });
 
     if (!job) {

--- a/api/apps/api/test/project/clone-project.e2e-spec.ts
+++ b/api/apps/api/test/project/clone-project.e2e-spec.ts
@@ -83,7 +83,6 @@ export const getFixtures = async () => {
         const exportId = exportInstance.id.value;
         if (piece.piece === ClonePiece.ExportConfig) {
           const exportConfigContent: ProjectExportConfigContent = {
-            isCloning: true,
             version: exportVersion,
             name: 'random name',
             description: 'random desc',

--- a/api/apps/api/test/project/import-project.e2e-spec.ts
+++ b/api/apps/api/test/project/import-project.e2e-spec.ts
@@ -119,7 +119,6 @@ export const getFixtures = async () => {
       );
       const projectMetadataContent: ProjectMetadataContent = {
         name: 'test project',
-        projectAlreadyCreated: false,
         description: 'description',
       };
 

--- a/api/apps/api/test/project/import-project.e2e-spec.ts
+++ b/api/apps/api/test/project/import-project.e2e-spec.ts
@@ -98,7 +98,6 @@ export const getFixtures = async () => {
     },
     GivenImportFile: async () => {
       const exportConfigContent: ProjectExportConfigContent = {
-        isCloning: false,
         version: exportVersion,
         name: 'random name',
         description: 'random desc',

--- a/api/apps/api/test/scenarios/clone-scenario.e2e-spec.ts
+++ b/api/apps/api/test/scenarios/clone-scenario.e2e-spec.ts
@@ -127,7 +127,6 @@ export const getFixtures = async () => {
         const exportId = exportInstance.id.value;
         if (piece.piece === ClonePiece.ExportConfig) {
           const exportConfigContent: ScenarioExportConfigContent = {
-            isCloning: true,
             version: exportVersion,
             name: 'random name',
             description: 'random desc',

--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.project-piece-exporter.ts
@@ -85,7 +85,6 @@ export class ExportConfigProjectPieceExporter implements ExportPieceProcessor {
       resourceKind: input.resourceKind,
       resourceId: projectId,
       exportId: input.exportId,
-      isCloning: input.isCloning,
       pieces: {
         project: projectPieces,
         scenarios: scenarioPieces,

--- a/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/export-config.scenario-piece-exporter.ts
@@ -63,7 +63,6 @@ export class ExportConfigScenarioPieceExporter implements ExportPieceProcessor {
       resourceId: scenarioId,
       exportId: input.exportId,
       pieces: input.allPieces.map((elem) => elem.piece),
-      isCloning: true,
     };
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
@@ -103,7 +103,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenAPlanningAreaGadmScenarioExportJob: () => {
@@ -117,7 +116,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Scenario,
-        isCloning: false,
       };
     },
     WhenProjectGadmDataIsMissing: () => {

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
@@ -56,7 +56,6 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
       name: projectData.name,
       description: projectData.description,
       planningUnitGridShape: projectData.planning_unit_grid_shape,
-      projectAlreadyCreated: input.isCloning,
     };
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/export-config.project-piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/export-config.project-piece-exporter.e2e-spec.ts
@@ -114,7 +114,6 @@ const getFixtures = async () => {
         project: [ClonePiece.ProjectMetadata, ClonePiece.ExportConfig],
         scenarios,
       },
-      isCloning: false,
     };
   };
 
@@ -143,7 +142,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ExportConfig,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async (options = defaultFixtureOptions) => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/export-config.scenario-piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/export-config.scenario-piece-exporter.e2e-spec.ts
@@ -84,7 +84,6 @@ const getFixtures = async () => {
     resourceId: scenarioId,
     exportId,
     pieces: [ClonePiece.ScenarioMetadata, ClonePiece.ExportConfig],
-    isCloning: true,
   };
 
   return {
@@ -106,7 +105,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ExportConfig,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Scenario,
-        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/marxan-execution-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/marxan-execution-metadata.piece-exporter.e2e-spec.ts
@@ -102,7 +102,6 @@ const getFixtures = async () => {
         piece: ClonePiece.MarxanExecutionMetadata,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenMarxanExecutionMetadata: () =>

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-area-custom-geojson.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-area-custom-geojson.piece-exporter.e2e-spec.ts
@@ -117,7 +117,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaCustomGeojson,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-area-custom.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-area-custom.piece-exporter.e2e-spec.ts
@@ -113,7 +113,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaCustom,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-area-gadm.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-area-gadm.piece-exporter.e2e-spec.ts
@@ -98,7 +98,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningAreaGAdm,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectWithGadmArea: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-units-grid-geojson.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-units-grid-geojson.piece-exporter.e2e-spec.ts
@@ -108,7 +108,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningUnitsGridGeojson,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-units-grid.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/planning-units-grid.piece-exporter.e2e-spec.ts
@@ -121,7 +121,6 @@ const getFixtures = async () => {
         piece: ClonePiece.PlanningUnitsGrid,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-custom-features.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-custom-features.piece-exporter.e2e-spec.ts
@@ -116,7 +116,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectCustomFeatures,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-custom-protected-areas.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-custom-protected-areas.piece-exporter.e2e-spec.ts
@@ -116,7 +116,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-metadata.piece-exporter.e2e-spec.ts
@@ -95,7 +95,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ProjectMetadata,
         resourceId: projectId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenProjectExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-metadata.piece-exporter.e2e-spec.ts
@@ -75,7 +75,6 @@ const getFixtures = async () => {
   const expectedContent: ProjectMetadataContent = {
     name: `test project - ${projectId}`,
     planningUnitGridShape: PlanningUnitGridShape.Square,
-    projectAlreadyCreated: false,
   };
 
   return {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-data.piece-exporter.e2e-spec.ts
@@ -130,7 +130,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioFeaturesData,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenScenarioExist: () =>

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-specification.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-specification.piece-exporter.e2e-spec.ts
@@ -155,7 +155,6 @@ const getFixtures = async () => {
         piece: ClonePiece.FeaturesSpecification,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-metadata.piece-exporter.e2e-spec.ts
@@ -98,7 +98,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioMetadata,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Scenario,
-        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-planning-units-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-planning-units-data.piece-exporter.e2e-spec.ts
@@ -117,7 +117,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioPlanningUnitsData,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-protected-areas.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-protected-areas.piece-exporter.e2e-spec.ts
@@ -125,7 +125,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioProtectedAreas,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-run-results.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-run-results.piece-exporter.e2e-spec.ts
@@ -137,7 +137,6 @@ const getFixtures = async () => {
         piece: ClonePiece.ScenarioRunResults,
         resourceId: scenarioId,
         resourceKind: ResourceKind.Project,
-        isCloning: false,
       };
     },
     GivenScenarioExist: async () => {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-importers/project-metadata.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-importers/project-metadata.piece-importer.e2e-spec.ts
@@ -65,9 +65,7 @@ describe(ProjectMetadataPieceImporter, () => {
     await fixtures.GivenOrganization();
     await fixtures.GivenUser();
 
-    const archiveLocation = await fixtures.GivenValidProjectMetadataFile({
-      existingProject: false,
-    });
+    const archiveLocation = await fixtures.GivenValidProjectMetadataFile();
     const input = fixtures.GivenJobInput(archiveLocation);
     await fixtures
       .WhenPieceImporterIsInvoked(input)
@@ -78,9 +76,7 @@ describe(ProjectMetadataPieceImporter, () => {
     await fixtures.GivenUser();
     await fixtures.GivenProject();
 
-    const archiveLocation = await fixtures.GivenValidProjectMetadataFile({
-      existingProject: true,
-    });
+    const archiveLocation = await fixtures.GivenValidProjectMetadataFile();
     const input = fixtures.GivenJobInput(archiveLocation);
     await fixtures
       .WhenPieceImporterIsInvoked(input)
@@ -120,7 +116,6 @@ const getFixtures = async () => {
     name: `test project - ${projectId}`,
     description: 'project description',
     planningUnitGridShape: PlanningUnitGridShape.Hexagon,
-    projectAlreadyCreated: false,
   };
 
   return {
@@ -168,11 +163,7 @@ const getFixtures = async () => {
     GivenNoProjectMetadataFileIsAvailable: () => {
       return new ArchiveLocation('not found');
     },
-    GivenValidProjectMetadataFile: async (
-      { existingProject } = { existingProject: false },
-    ) => {
-      validProjectMetadataFileContent.projectAlreadyCreated = existingProject;
-
+    GivenValidProjectMetadataFile: async () => {
       const exportId = v4();
       const relativePath = ClonePieceRelativePathResolver.resolveFor(
         ClonePiece.ProjectMetadata,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/export-config.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/export-config.ts
@@ -36,10 +36,6 @@ class CommonFields {
   @IsString()
   @IsOptional()
   description?: string;
-
-  @IsBoolean()
-  @IsOptional()
-  isCloning!: boolean;
 }
 
 class ScenarioMetadata {

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
@@ -4,7 +4,6 @@ export type ProjectMetadataContent = {
   name: string;
   description?: string;
   planningUnitGridShape?: PlanningUnitGridShape;
-  projectAlreadyCreated: boolean;
 };
 
 export const projectMetadataRelativePath = 'project-metadata.json';

--- a/api/libs/cloning/src/job-input.ts
+++ b/api/libs/cloning/src/job-input.ts
@@ -6,7 +6,6 @@ export interface ExportJobInput {
   readonly resourceId: string;
   readonly resourceKind: ResourceKind;
   readonly piece: ClonePiece;
-  readonly isCloning: boolean;
   readonly allPieces: { piece: ClonePiece; resourceId: string }[];
 }
 


### PR DESCRIPTION
This PR refactors how project metadata piece importer decides wether to create a new project or update an existing one. It also simplifies export piece job input and project metadata content types