### PR TITLE
feat: endpoint for retrieving latest exports of a project

### DIFF
--- a/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
@@ -1,3 +1,4 @@
+import { ResourceKind } from '@marxan/cloning/domain';
 import { Either, right } from 'fp-ts/lib/Either';
 import {
   ExportRepository,
@@ -5,6 +6,13 @@ import {
   Success,
 } from '../application/export-repository.port';
 import { Export, ExportId } from '../domain';
+
+function createdAtPropertySorter(first: Export, second: Export): number {
+  const firstDate = first.toSnapshot().createdAt;
+  const secondDate = second.toSnapshot().createdAt;
+
+  return secondDate.getTime() - firstDate.getTime();
+}
 
 export class MemoryExportRepo implements ExportRepository {
   #memory: Record<string, Export> = {};
@@ -16,6 +24,44 @@ export class MemoryExportRepo implements ExportRepository {
   async save(exportInstance: Export): Promise<Either<SaveError, Success>> {
     this.#memory[exportInstance.id.value] = exportInstance;
     return right(true);
+  }
+
+  async findLatestExportsFor(
+    projectId: string,
+    limit: number = 5,
+    options?: {
+      isStandalone?: boolean;
+      isFinished?: boolean;
+      isLocal?: boolean;
+    },
+  ): Promise<Export[]> {
+    return Object.values(this.#memory)
+      .filter((exportInstance) => {
+        const { resourceId, resourceKind } = exportInstance.toSnapshot();
+        return (
+          projectId === resourceId && resourceKind === ResourceKind.Project
+        );
+      })
+      .filter((exportInstance) => {
+        const { archiveLocation } = exportInstance.toSnapshot();
+        return options?.isFinished === undefined || options.isFinished
+          ? archiveLocation !== undefined
+          : archiveLocation === undefined;
+      })
+      .filter((exportInstance) => {
+        const { importResourceId } = exportInstance.toSnapshot();
+        return options?.isStandalone === undefined || options.isStandalone
+          ? importResourceId === undefined
+          : importResourceId !== undefined;
+      })
+      .filter((exportInstance) => {
+        const { foreignExport } = exportInstance.toSnapshot();
+        return (
+          options?.isLocal === undefined || foreignExport === !options.isLocal
+        );
+      })
+      .sort(createdAtPropertySorter)
+      .slice(0, limit);
   }
 
   transaction<T>(code: (repo: ExportRepository) => Promise<T>): Promise<T> {

--- a/api/apps/api/src/modules/clone/export/application/export-repository.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-repository.port.ts
@@ -11,6 +11,16 @@ export abstract class ExportRepository {
 
   abstract find(exportId: ExportId): Promise<Export | undefined>;
 
+  abstract findLatestExportsFor(
+    projectId: string,
+    limit: number,
+    options?: {
+      isStandalone?: boolean;
+      isFinished?: boolean;
+      isLocal?: boolean;
+    },
+  ): Promise<Export[]>;
+
   abstract transaction<T>(
     code: (repo: ExportRepository) => Promise<T>,
   ): Promise<T>;

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
@@ -192,6 +192,18 @@ class FakeExportRepository implements ExportRepository {
     });
   }
 
+  async findLatestExportsFor(
+    projectId: string,
+    limit: number,
+    options?: {
+      isStandalone?: boolean | undefined;
+      isFinished?: boolean | undefined;
+      isLocal?: boolean | undefined;
+    },
+  ): Promise<Export[]> {
+    return [];
+  }
+
   transaction<T>(code: (repo: ExportRepository) => Promise<T>): Promise<T> {
     throw new Error('Method not implemented.');
   }

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
@@ -207,6 +207,18 @@ class FakeExportRepository implements ExportRepository {
     });
   }
 
+  async findLatestExportsFor(
+    projectId: string,
+    limit: number,
+    options?: {
+      isStandalone?: boolean | undefined;
+      isFinished?: boolean | undefined;
+      isLocal?: boolean | undefined;
+    },
+  ): Promise<Export[]> {
+    return [];
+  }
+
   transaction<T>(code: (repo: ExportRepository) => Promise<T>): Promise<T> {
     throw new Error('Method not implemented.');
   }

--- a/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.command.ts
@@ -5,12 +5,14 @@ import { Either } from 'fp-ts/lib/Either';
 import { ExportId } from '../../export';
 
 export const invalidExportZipFile = Symbol('invalid export zip file');
+export const cloningExportProvided = Symbol('cloning export provided');
 export const errorStoringCloningFile = Symbol('error storing cloning file');
 export const errorSavingExport = Symbol('error saving export');
 
 export type GenerateExportFromZipFileError =
   | typeof unknownError
   | typeof invalidExportZipFile
+  | typeof cloningExportProvided
   | typeof errorStoringCloningFile
   | typeof errorSavingExport;
 

--- a/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.handler.ts
@@ -17,6 +17,7 @@ import { ExportRepository } from '../../export/application/export-repository.por
 import { Export, ExportComponent } from '../../export/domain';
 import { ExportConfigReader } from '../../import/application/export-config-reader';
 import {
+  cloningExportProvided,
   errorSavingExport,
   errorStoringCloningFile,
   GenerateExportFromZipFile,
@@ -170,7 +171,11 @@ export class GenerateExportFromZipFileHandler
 
     const exportId = new ExportId(stringExportId);
     const previousExport = await this.exportRepo.find(exportId);
-    if (previousExport) return right(exportId);
+    if (previousExport) {
+      if (previousExport.importResourceId) return left(cloningExportProvided);
+
+      return right(exportId);
+    }
 
     const urisOrError = await this.storeCloningFiles(
       exportId.value,

--- a/api/apps/api/src/modules/projects/dto/export.project.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/export.project.dto.ts
@@ -35,6 +35,16 @@ export class GetLatestExportResponseDto {
     example: '6fbec34e-04a7-4131-be14-c245f2435a6c',
   })
   userId!: string;
+
+  @ApiProperty({
+    description: 'Export creation timestamp',
+  })
+  createdAt!: Date;
+}
+
+export class GetLatestExportsResponseDto {
+  @ApiProperty({ type: GetLatestExportResponseDto, isArray: true })
+  exports!: GetLatestExportResponseDto[];
 }
 
 export class RequestProjectCloneResponseDto {


### PR DESCRIPTION
This PR adds an endpoint for getting the latest finished, standalone and local exports for a project

### Feature relevant tickets

[Endpoint for retrieving the latest 5 standalone exports for a given project /api/v1/projects/:projectId/latest-exports](https://vizzuality.atlassian.net/browse/MARXAN-1500)