### PR TITLE
MARXAN-1274-published-Project-image-webshot-cookie

### DIFF
--- a/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
@@ -34,9 +34,11 @@ export class PublishProjectDto {
   @IsOptional()
   @ApiPropertyOptional()
   featuredScenarioId?: string;
+}
 
+export class CreatePublishProjectDto extends PublishProjectDto {
   @ApiProperty()
   @ValidateNested({ each: true })
   @Type(() => WebshotConfig)
-  config?: WebshotConfig;
+  config!: WebshotConfig;
 }

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -9,7 +9,7 @@ import { ProjectsRequest } from '@marxan-api/modules/projects/project-requests-i
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
 import { ProjectAccessControl } from '@marxan-api/modules/access-control';
 import { UsersService } from '@marxan-api/modules/users/users.service';
-import { PublishProjectDto } from './dto/publish-project.dto';
+import { CreatePublishProjectDto } from './dto/publish-project.dto';
 import { WebshotService } from '@marxan/webshot';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { assertDefined } from '@marxan/utils';
@@ -45,7 +45,7 @@ export class PublishedProjectService {
   async publish(
     id: string,
     requestingUserId: string,
-    projectToPublish: PublishProjectDto,
+    projectToPublish: CreatePublishProjectDto,
   ): Promise<Either<errors | typeof alreadyPublished, true>> {
     const project = await this.projectRepository.findOne(id);
 


### PR DESCRIPTION
-Adds missing cookie for the webshot service to access the tile map.
-Refactors how DTO are set for published project creation / update.