### PR TITLE
Feat/marxan 1469 hash and sign export files

### DIFF
--- a/.github/workflows/api-e2e-tests.yml
+++ b/.github/workflows/api-e2e-tests.yml
@@ -28,6 +28,7 @@ jobs:
       GEO_POSTGRES_DB: marxan-geo-api
       POSTGRES_GEO_SERVICE_PORT: 3533
       REDIS_API_SERVICE_PORT: 3479
+      CLONING_SIGNING_SECRET: ${{ secrets.CLONING_SIGNING_SECRET }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -52,6 +52,10 @@ applications.
   requests from the in-browser frontend app to the API, required except when
   accessing the frontend app on the default URL defined in
   `api/apps/api/config/default.json`, via the `network.cors.origins` config key)
+* `CLONING_SIGNING_SECRET` (base64-encoded string, required): this is a
+  base64-encoded representation of a PEM-format RSA private key; the key must be
+  created without a passphrase, for example via a command such as `openssl
+  genrsa 4096 | base64 -w0`.
 
 ### PostgreSQL service - API database
 

--- a/api/apps/api/config/custom-environment-variables.json
+++ b/api/apps/api/config/custom-environment-variables.json
@@ -58,6 +58,11 @@
       "localPath": "CLONING_FILE_STORAGE_LOCAL_PATH"
     }
   },
+  "cloning": {
+    "manifestFile": {
+      "privateKey": "CLONING_MANIFEST_FILE_PRIVATE_KEY"
+    }
+  },
   "marxan": {
     "inputFiles": {
       "inputDat": {

--- a/api/apps/api/config/custom-environment-variables.json
+++ b/api/apps/api/config/custom-environment-variables.json
@@ -59,9 +59,7 @@
     }
   },
   "cloning": {
-    "manifestFile": {
-      "privateKey": "CLONING_MANIFEST_FILE_PRIVATE_KEY"
-    }
+    "signingSecret": "CLONING_SIGNING_SECRET"
   },
   "marxan": {
     "inputFiles": {

--- a/api/apps/api/src/modules/clone/export/adapters/export-adapters.module.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-adapters.module.ts
@@ -1,15 +1,21 @@
 import { ApiCloningFilesRepositoryModule } from '@marxan-api/modules/cloning-file-repository/api-cloning-file-repository.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AppConfig } from '../../../../utils/config.utils';
 import { Project } from '../../../projects/project.api.entity';
 import { ArchiveCreator } from '../application/archive-creator.port';
 import { ExportRepository } from '../application/export-repository.port';
 import { ExportResourcePieces } from '../application/export-resource-pieces.port';
+import {
+  ManifestFilePrivateKey,
+  ManifestFileService,
+} from '../application/manifest-file-service.port';
 import { ExportComponentLocationEntity } from './entities/export-component-locations.api.entity';
 import { ExportComponentEntity } from './entities/export-components.api.entity';
 import { ExportEntity } from './entities/exports.api.entity';
 import { ExportResourcePiecesAdapter } from './export-resource-pieces.adapter';
 import { NodeArchiveCreator } from './node-archive-creator';
+import { NodeManifestFileService } from './node-manifest-file-service.adapter';
 import { TypeormExportRepository } from './typeorm-export.repository';
 
 @Module({
@@ -24,6 +30,16 @@ import { TypeormExportRepository } from './typeorm-export.repository';
   ],
   providers: [
     {
+      provide: ManifestFilePrivateKey,
+      useFactory: () => {
+        const base64Value = AppConfig.get<string>(
+          'cloning.manifestFile.privateKey',
+        );
+
+        return Buffer.from(base64Value, 'base64').toString();
+      },
+    },
+    {
       provide: ExportRepository,
       useClass: TypeormExportRepository,
     },
@@ -35,7 +51,16 @@ import { TypeormExportRepository } from './typeorm-export.repository';
       provide: ArchiveCreator,
       useClass: NodeArchiveCreator,
     },
+    {
+      provide: ManifestFileService,
+      useClass: NodeManifestFileService,
+    },
   ],
-  exports: [ExportRepository, ExportResourcePieces, ArchiveCreator],
+  exports: [
+    ExportRepository,
+    ExportResourcePieces,
+    ArchiveCreator,
+    ManifestFileService,
+  ],
 })
 export class ExportAdaptersModule {}

--- a/api/apps/api/src/modules/clone/export/adapters/export-adapters.module.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-adapters.module.ts
@@ -7,7 +7,7 @@ import { ArchiveCreator } from '../application/archive-creator.port';
 import { ExportRepository } from '../application/export-repository.port';
 import { ExportResourcePieces } from '../application/export-resource-pieces.port';
 import {
-  ManifestFilePrivateKey,
+  CloningSigningSecret,
   ManifestFileService,
 } from '../application/manifest-file-service.port';
 import { ExportComponentLocationEntity } from './entities/export-component-locations.api.entity';
@@ -30,11 +30,9 @@ import { TypeormExportRepository } from './typeorm-export.repository';
   ],
   providers: [
     {
-      provide: ManifestFilePrivateKey,
+      provide: CloningSigningSecret,
       useFactory: () => {
-        const base64Value = AppConfig.get<string>(
-          'cloning.manifestFile.privateKey',
-        );
+        const base64Value = AppConfig.get<string>('cloning.signingSecret');
 
         return Buffer.from(base64Value, 'base64').toString();
       },

--- a/api/apps/api/src/modules/clone/export/adapters/node-archive-creator.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/node-archive-creator.ts
@@ -12,6 +12,7 @@ import {
   cannotCreateArchive,
   cannotGetFile,
   cannotStoreArchive,
+  FileDestination,
   unknownError,
 } from '../application/archive-creator.port';
 
@@ -25,7 +26,7 @@ export class NodeArchiveCreator extends ArchiveCreator {
 
   async zip(
     exportId: string,
-    files: { uri: string; relativeDestination: string }[],
+    files: FileDestination[],
   ): Promise<Either<ArchiveCreationError, ArchiveLocation>> {
     let archivePersistencePromise: ReturnType<
       CloningFilesRepository['saveZipFile']

--- a/api/apps/api/src/modules/clone/export/adapters/node-manifest-file-service.adapter.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/node-manifest-file-service.adapter.ts
@@ -1,0 +1,143 @@
+import {
+  CloningFilesRepository,
+  GetFileError,
+  SaveFileError,
+} from '@marxan/cloning-files-repository';
+import { ArchiveLocation } from '@marxan/cloning/domain';
+import {
+  manifestFileRelativePath,
+  signatureFileRelativePath,
+} from '@marxan/cloning/infrastructure/clone-piece-data/manifest-file';
+import { readableToBuffer } from '@marxan/utils';
+import { Inject, Injectable } from '@nestjs/common';
+import { spawnSync } from 'child_process';
+import { createSign } from 'crypto';
+import { Either, left, right } from 'fp-ts/lib/Either';
+import { isLeft } from 'fp-ts/lib/These';
+import { Readable } from 'stream';
+import { FileDestination } from '../application/archive-creator.port';
+import {
+  integrityCheckFailed,
+  invalidSignature,
+  manifestFileGenerationError,
+  ManifestFilePrivateKey,
+  ManifestFileService,
+  signatureFileGenerationError,
+} from '../application/manifest-file-service.port';
+import { ExportId } from '../domain';
+
+@Injectable()
+export class NodeManifestFileService implements ManifestFileService {
+  constructor(
+    private readonly fileRepository: CloningFilesRepository,
+    @Inject(ManifestFilePrivateKey)
+    private readonly manifestFilePrivateKey: string,
+  ) {}
+
+  private async getManifestFileReadable(
+    exportFolder: string,
+  ): Promise<Either<typeof manifestFileGenerationError, Buffer>> {
+    const childProcess = spawnSync(
+      `find ${exportFolder} -type f -exec sha256sum {} \\;`,
+      { shell: true },
+    );
+
+    if (childProcess.error) {
+      return left(manifestFileGenerationError);
+    }
+
+    return right(childProcess.stdout);
+  }
+
+  performIntegrityCheck(
+    exportId: ExportId,
+  ): Either<typeof integrityCheckFailed, true> {
+    const exportFolder = this.fileRepository.getFilesFolderFor(exportId.value);
+
+    const childProcess = spawnSync(
+      `sha256sum -c ${exportFolder}/manifest.txt`,
+      { shell: true },
+    );
+
+    const stdout = childProcess.stdout.toString();
+    const stderr = childProcess.stderr.toString();
+    const error = stdout.includes('FAILED') || stderr.length > 0;
+
+    if (error) {
+      return left(integrityCheckFailed);
+    }
+
+    return right(true);
+  }
+
+  verifyManifestFileSignature(
+    archiveLocation: ArchiveLocation,
+  ): Promise<Either<typeof invalidSignature, true>> {
+    throw new Error('Method not implemented.');
+  }
+
+  async generateSignatureFileFor(
+    exportId: ExportId,
+    manifestFileUri: string,
+  ): Promise<
+    Either<
+      typeof signatureFileGenerationError | SaveFileError | GetFileError,
+      FileDestination
+    >
+  > {
+    try {
+      const manifestFile = await this.fileRepository.get(manifestFileUri);
+
+      if (isLeft(manifestFile)) {
+        return manifestFile;
+      }
+
+      const manifestFileBuffer = await readableToBuffer(manifestFile.right);
+
+      const signer = createSign('RSA-SHA256');
+      signer.update(manifestFileBuffer);
+      const result = signer.sign(this.manifestFilePrivateKey, 'hex');
+
+      const signatureFile = await this.fileRepository.saveCloningFile(
+        exportId.value,
+        Readable.from(result),
+        signatureFileRelativePath,
+      );
+
+      if (isLeft(signatureFile)) return signatureFile;
+
+      return right({
+        relativeDestination: signatureFileRelativePath,
+        uri: signatureFile.right,
+      });
+    } catch (err) {
+      return left(signatureFileGenerationError);
+    }
+  }
+
+  async generateManifestFileFor(
+    exportId: ExportId,
+  ): Promise<
+    Either<typeof manifestFileGenerationError | SaveFileError, FileDestination>
+  > {
+    const exportFilesFolder = this.fileRepository.getFilesFolderFor(
+      exportId.value,
+    );
+    const bufferOrError = await this.getManifestFileReadable(exportFilesFolder);
+
+    if (isLeft(bufferOrError)) return bufferOrError;
+
+    const manifestFile = await this.fileRepository.saveCloningFile(
+      exportId.value,
+      Readable.from(bufferOrError.right),
+      manifestFileRelativePath,
+    );
+
+    if (isLeft(manifestFile)) return manifestFile;
+
+    return right({
+      uri: manifestFile.right,
+      relativeDestination: manifestFileRelativePath,
+    });
+  }
+}

--- a/api/apps/api/src/modules/clone/export/adapters/node-manifest-file-service.adapter.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/node-manifest-file-service.adapter.ts
@@ -1,64 +1,31 @@
-import {
-  CloningFilesRepository,
-  GetFileError,
-  SaveFileError,
-} from '@marxan/cloning-files-repository';
-import {
-  manifestFileRelativePath,
-  signatureFileRelativePath,
-} from '@marxan/cloning/infrastructure/clone-piece-data/manifest-file';
-import { readableToBuffer } from '@marxan/utils';
 import { Inject, Injectable } from '@nestjs/common';
 import { spawnSync } from 'child_process';
 import { createSign, createVerify } from 'crypto';
 import { Either, left, right } from 'fp-ts/lib/Either';
-import { isLeft } from 'fp-ts/lib/These';
-import { Readable } from 'stream';
-import { FileDestination } from '../application/archive-creator.port';
 import {
+  CloningSigningSecret,
   integrityCheckFailed,
   invalidSignature,
   manifestFileGenerationError,
-  CloningSigningSecret,
   ManifestFileService,
   signatureFileGenerationError,
 } from '../application/manifest-file-service.port';
-import { ExportId } from '../domain';
 
 @Injectable()
 export class NodeManifestFileService implements ManifestFileService {
   private readonly algorithm = 'RSA-SHA256';
 
   constructor(
-    private readonly fileRepository: CloningFilesRepository,
     @Inject(CloningSigningSecret)
     private readonly cloningSigningSecret: string,
   ) {}
 
-  private async getManifestFileReadable(
-    exportFolder: string,
-  ): Promise<Either<typeof manifestFileGenerationError, Buffer>> {
-    const childProcess = spawnSync(
-      `find ${exportFolder} -type f -exec sha256sum {} \\;`,
-      { shell: true },
-    );
-
-    if (childProcess.error) {
-      return left(manifestFileGenerationError);
-    }
-
-    return right(childProcess.stdout);
-  }
-
   performIntegrityCheck(
-    exportId: ExportId,
+    manifestFilePath: string,
   ): Either<typeof integrityCheckFailed, true> {
-    const exportFolder = this.fileRepository.getFilesFolderFor(exportId.value);
-
-    const childProcess = spawnSync(
-      `sha256sum -c ${exportFolder}/manifest.txt`,
-      { shell: true },
-    );
+    const childProcess = spawnSync(`sha256sum -c ${manifestFilePath}`, {
+      shell: true,
+    });
 
     const stdout = childProcess.stdout.toString();
     const stderr = childProcess.stderr.toString();
@@ -72,92 +39,45 @@ export class NodeManifestFileService implements ManifestFileService {
   }
 
   async verifyManifestFileSignature(
-    manifestFileUri: string,
+    manifestFile: Buffer,
+    signatureFile: Buffer,
   ): Promise<Either<typeof invalidSignature, true>> {
-    const signatureFileUri = manifestFileUri.replace(
-      manifestFileRelativePath,
-      signatureFileRelativePath,
-    );
-
-    const manifestFile = await this.fileRepository.get(manifestFileUri);
-    const signatureFile = await this.fileRepository.get(signatureFileUri);
-    if (isLeft(signatureFile) || isLeft(manifestFile)) {
-      return left(invalidSignature);
-    }
-    const manifestFileBuffer = await readableToBuffer(manifestFile.right);
-    const signatureFileBuffer = await readableToBuffer(signatureFile.right);
-    const uploadedSignature = signatureFileBuffer.toString();
+    const uploadedSignature = signatureFile.toString();
 
     const verifier = createVerify(this.algorithm);
-    verifier.update(manifestFileBuffer);
+    verifier.update(manifestFile);
 
     return verifier.verify(this.cloningSigningSecret, uploadedSignature, 'hex')
       ? right(true)
       : left(invalidSignature);
   }
 
+  async generateManifestFileFor(
+    folderPath: string,
+  ): Promise<Either<typeof manifestFileGenerationError, Buffer>> {
+    const childProcess = spawnSync(
+      `find ${folderPath} -type f -exec sha256sum {} \\;`,
+      { shell: true },
+    );
+
+    if (childProcess.error) {
+      return left(manifestFileGenerationError);
+    }
+
+    return right(childProcess.stdout);
+  }
+
   async generateSignatureFileFor(
-    exportId: ExportId,
-    manifestFileUri: string,
-  ): Promise<
-    Either<
-      typeof signatureFileGenerationError | SaveFileError | GetFileError,
-      FileDestination
-    >
-  > {
+    manifestFile: Buffer,
+  ): Promise<Either<typeof signatureFileGenerationError, Buffer>> {
     try {
-      const manifestFile = await this.fileRepository.get(manifestFileUri);
-
-      if (isLeft(manifestFile)) {
-        return manifestFile;
-      }
-
-      const manifestFileBuffer = await readableToBuffer(manifestFile.right);
-
       const signer = createSign(this.algorithm);
-      signer.update(manifestFileBuffer);
+      signer.update(manifestFile);
       const result = signer.sign(this.cloningSigningSecret, 'hex');
 
-      const signatureFile = await this.fileRepository.saveCloningFile(
-        exportId.value,
-        Readable.from(result),
-        signatureFileRelativePath,
-      );
-
-      if (isLeft(signatureFile)) return signatureFile;
-
-      return right({
-        relativeDestination: signatureFileRelativePath,
-        uri: signatureFile.right,
-      });
+      return right(Buffer.from(result));
     } catch (err) {
       return left(signatureFileGenerationError);
     }
-  }
-
-  async generateManifestFileFor(
-    exportId: ExportId,
-  ): Promise<
-    Either<typeof manifestFileGenerationError | SaveFileError, FileDestination>
-  > {
-    const exportFilesFolder = this.fileRepository.getFilesFolderFor(
-      exportId.value,
-    );
-    const bufferOrError = await this.getManifestFileReadable(exportFilesFolder);
-
-    if (isLeft(bufferOrError)) return bufferOrError;
-
-    const manifestFile = await this.fileRepository.saveCloningFile(
-      exportId.value,
-      Readable.from(bufferOrError.right),
-      manifestFileRelativePath,
-    );
-
-    if (isLeft(manifestFile)) return manifestFile;
-
-    return right({
-      uri: manifestFile.right,
-      relativeDestination: manifestFileRelativePath,
-    });
   }
 }

--- a/api/apps/api/src/modules/clone/export/adapters/node-manifest-file-service.adapter.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/node-manifest-file-service.adapter.ts
@@ -19,7 +19,7 @@ import {
   integrityCheckFailed,
   invalidSignature,
   manifestFileGenerationError,
-  ManifestFilePrivateKey,
+  CloningSigningSecret,
   ManifestFileService,
   signatureFileGenerationError,
 } from '../application/manifest-file-service.port';
@@ -29,8 +29,8 @@ import { ExportId } from '../domain';
 export class NodeManifestFileService implements ManifestFileService {
   constructor(
     private readonly fileRepository: CloningFilesRepository,
-    @Inject(ManifestFilePrivateKey)
-    private readonly manifestFilePrivateKey: string,
+    @Inject(CloningSigningSecret)
+    private readonly cloningSigningSecret: string,
   ) {}
 
   private async getManifestFileReadable(
@@ -84,7 +84,7 @@ export class NodeManifestFileService implements ManifestFileService {
       const signer = createSign('RSA-SHA256');
       signer.update(manifestFileBuffer);
       const recalculatedSignature = signer.sign(
-        this.manifestFilePrivateKey,
+        this.cloningSigningSecret,
         'hex',
       );
 
@@ -128,7 +128,7 @@ export class NodeManifestFileService implements ManifestFileService {
 
       const signer = createSign('RSA-SHA256');
       signer.update(manifestFileBuffer);
-      const result = signer.sign(this.manifestFilePrivateKey, 'hex');
+      const result = signer.sign(this.cloningSigningSecret, 'hex');
 
       const signatureFile = await this.fileRepository.saveCloningFile(
         exportId.value,

--- a/api/apps/api/src/modules/clone/export/application/archive-creator.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/archive-creator.port.ts
@@ -12,12 +12,14 @@ export type ArchiveCreationError =
   | typeof cannotCreateArchive
   | typeof cannotStoreArchive;
 
+export type FileDestination = {
+  uri: string;
+  relativeDestination: string;
+};
+
 export abstract class ArchiveCreator {
   abstract zip(
     exportId: string,
-    files: {
-      uri: string;
-      relativeDestination: string;
-    }[],
+    files: FileDestination[],
   ): Promise<Either<ArchiveCreationError, ArchiveLocation>>;
 }

--- a/api/apps/api/src/modules/clone/export/application/finalize-archive.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/finalize-archive.handler.ts
@@ -1,4 +1,11 @@
-import { manifestFileRelativePath } from '@marxan/cloning/infrastructure/clone-piece-data/manifest-file';
+import {
+  CloningFilesRepository,
+  SaveFileError,
+} from '@marxan/cloning-files-repository';
+import {
+  manifestFileRelativePath,
+  signatureFileRelativePath,
+} from '@marxan/cloning/infrastructure/clone-piece-data/manifest-file';
 import { isDefined } from '@marxan/utils';
 import { Logger } from '@nestjs/common';
 import {
@@ -7,12 +14,22 @@ import {
   EventPublisher,
   IInferredCommandHandler,
 } from '@nestjs/cqrs';
-import { isLeft } from 'fp-ts/Either';
+import { Either, isLeft, right } from 'fp-ts/Either';
+import { Readable } from 'stream';
 import { MarkExportAsFailed } from '../../infra/export/mark-export-as-failed.command';
-import { ArchiveCreator } from './archive-creator.port';
+import { ArchiveCreator, FileDestination } from './archive-creator.port';
 import { ExportRepository } from './export-repository.port';
 import { ExportId, FinalizeArchive } from './finalize-archive.command';
-import { ManifestFileService } from './manifest-file-service.port';
+import {
+  manifestFileGenerationError,
+  ManifestFileService,
+  signatureFileGenerationError,
+} from './manifest-file-service.port';
+
+type ManifestAndSignatureFilesUris = {
+  manifestFileDestination: FileDestination;
+  signatureFileDestination: FileDestination;
+};
 
 @CommandHandler(FinalizeArchive)
 export class FinalizeArchiveHandler
@@ -24,6 +41,7 @@ export class FinalizeArchiveHandler
     private readonly archiveCreator: ArchiveCreator,
     private readonly eventPublisher: EventPublisher,
     private readonly manifestFileService: ManifestFileService,
+    private readonly cloningFilesRepository: CloningFilesRepository,
     private readonly commandBus: CommandBus,
   ) {}
 
@@ -34,6 +52,67 @@ export class FinalizeArchiveHandler
     this.logger.error(error);
 
     await this.commandBus.execute(new MarkExportAsFailed(exportId));
+  }
+
+  private async generateManifestAndSignatureFiles(
+    exportId: string,
+  ): Promise<
+    Either<
+      | typeof manifestFileGenerationError
+      | typeof signatureFileGenerationError
+      | SaveFileError,
+      ManifestAndSignatureFilesUris
+    >
+  > {
+    const exportFolder = this.cloningFilesRepository.getFilesFolderFor(
+      exportId,
+    );
+
+    const manifestFile = await this.manifestFileService.generateManifestFileFor(
+      exportFolder,
+    );
+
+    if (isLeft(manifestFile)) {
+      return manifestFile;
+    }
+
+    const signatureFile = await this.manifestFileService.generateSignatureFileFor(
+      manifestFile.right,
+    );
+
+    if (isLeft(signatureFile)) {
+      return signatureFile;
+    }
+
+    const manifestFileUri = await this.cloningFilesRepository.saveCloningFile(
+      exportId,
+      Readable.from(manifestFile.right),
+      manifestFileRelativePath,
+    );
+
+    const signatureFileUri = await this.cloningFilesRepository.saveCloningFile(
+      exportId,
+      Readable.from(signatureFile.right),
+      signatureFileRelativePath,
+    );
+
+    if (isLeft(manifestFileUri)) {
+      return manifestFileUri;
+    }
+    if (isLeft(signatureFileUri)) {
+      return signatureFileUri;
+    }
+
+    return right({
+      manifestFileDestination: {
+        uri: manifestFileUri.right,
+        relativeDestination: manifestFileRelativePath,
+      },
+      signatureFileDestination: {
+        uri: signatureFileUri.right,
+        relativeDestination: signatureFileRelativePath,
+      },
+    });
   }
 
   async execute({ exportId }: FinalizeArchive): Promise<void> {
@@ -47,30 +126,21 @@ export class FinalizeArchiveHandler
       return;
     }
 
-    const manifestFile = await this.manifestFileService.generateManifestFileFor(
-      exportId,
+    const manifestAndSignatureFilesUris = await this.generateManifestAndSignatureFiles(
+      exportId.value,
     );
 
-    if (isLeft(manifestFile)) {
+    if (isLeft(manifestAndSignatureFilesUris)) {
       this.logErrorAndMarkExportAsFailed(
         exportId,
-        `${FinalizeArchiveHandler.name} could not generate manifest file for export with ID ${exportId.value}`,
+        `${FinalizeArchiveHandler.name} could not generate manifest and/or signature files`,
       );
       return;
     }
-
-    const signatureFile = await this.manifestFileService.generateSignatureFileFor(
-      exportId,
-      manifestFile.right.uri,
-    );
-
-    if (isLeft(signatureFile)) {
-      this.logErrorAndMarkExportAsFailed(
-        exportId,
-        `${FinalizeArchiveHandler.name} could not generate signature file for export with ID ${exportId.value}`,
-      );
-      return;
-    }
+    const {
+      manifestFileDestination,
+      signatureFileDestination,
+    } = manifestAndSignatureFilesUris.right;
 
     const pieces = exportInstance
       .toSnapshot()
@@ -84,7 +154,7 @@ export class FinalizeArchiveHandler
           uri: piece.uri,
           relativeDestination: piece.relativePath,
         }))
-        .concat(manifestFile.right, signatureFile.right),
+        .concat(manifestFileDestination, signatureFileDestination),
     );
 
     if (isLeft(archiveResult)) {

--- a/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
@@ -1,0 +1,42 @@
+import { GetFileError, SaveFileError } from '@marxan/cloning-files-repository';
+import { ArchiveLocation } from '@marxan/cloning/domain';
+import { Either } from 'fp-ts/Either';
+import { ExportId } from '../domain';
+import { FileDestination } from './archive-creator.port';
+
+export const integrityCheckFailed = Symbol('integrity check failed');
+export const invalidSignature = Symbol('invalid signature');
+export const manifestFileGenerationError = Symbol(
+  'manifest file generation error',
+);
+export const signatureFileGenerationError = Symbol(
+  'signature file generation error',
+);
+
+export const ManifestFilePrivateKey = Symbol('manifest file private key');
+
+export abstract class ManifestFileService {
+  abstract performIntegrityCheck(
+    exportId: ExportId,
+  ): Either<typeof integrityCheckFailed, true>;
+
+  abstract verifyManifestFileSignature(
+    archiveLocation: ArchiveLocation,
+  ): Promise<Either<typeof invalidSignature, true>>;
+
+  abstract generateManifestFileFor(
+    exportId: ExportId,
+  ): Promise<
+    Either<typeof manifestFileGenerationError | SaveFileError, FileDestination>
+  >;
+
+  abstract generateSignatureFileFor(
+    exportId: ExportId,
+    manifestFileUri: string,
+  ): Promise<
+    Either<
+      typeof signatureFileGenerationError | SaveFileError | GetFileError,
+      FileDestination
+    >
+  >;
+}

--- a/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
@@ -21,7 +21,7 @@ export abstract class ManifestFileService {
   ): Either<typeof integrityCheckFailed, true>;
 
   abstract verifyManifestFileSignature(
-    archiveLocation: ArchiveLocation,
+    manifestFileUri: string,
   ): Promise<Either<typeof invalidSignature, true>>;
 
   abstract generateManifestFileFor(

--- a/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
@@ -1,7 +1,4 @@
-import { GetFileError, SaveFileError } from '@marxan/cloning-files-repository';
 import { Either } from 'fp-ts/Either';
-import { ExportId } from '../domain';
-import { FileDestination } from './archive-creator.port';
 
 export const integrityCheckFailed = Symbol('integrity check failed');
 export const invalidSignature = Symbol('invalid signature');
@@ -16,26 +13,19 @@ export const CloningSigningSecret = Symbol('cloning signing secret');
 
 export abstract class ManifestFileService {
   abstract performIntegrityCheck(
-    exportId: ExportId,
+    manifestFilePath: string,
   ): Either<typeof integrityCheckFailed, true>;
 
   abstract verifyManifestFileSignature(
-    manifestFileUri: string,
+    manifestFile: Buffer,
+    signatureFile: Buffer,
   ): Promise<Either<typeof invalidSignature, true>>;
 
   abstract generateManifestFileFor(
-    exportId: ExportId,
-  ): Promise<
-    Either<typeof manifestFileGenerationError | SaveFileError, FileDestination>
-  >;
+    folderPath: string,
+  ): Promise<Either<typeof manifestFileGenerationError, Buffer>>;
 
   abstract generateSignatureFileFor(
-    exportId: ExportId,
-    manifestFileUri: string,
-  ): Promise<
-    Either<
-      typeof signatureFileGenerationError | SaveFileError | GetFileError,
-      FileDestination
-    >
-  >;
+    manifestFile: Buffer,
+  ): Promise<Either<typeof signatureFileGenerationError, Buffer>>;
 }

--- a/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/manifest-file-service.port.ts
@@ -1,5 +1,4 @@
 import { GetFileError, SaveFileError } from '@marxan/cloning-files-repository';
-import { ArchiveLocation } from '@marxan/cloning/domain';
 import { Either } from 'fp-ts/Either';
 import { ExportId } from '../domain';
 import { FileDestination } from './archive-creator.port';
@@ -13,7 +12,7 @@ export const signatureFileGenerationError = Symbol(
   'signature file generation error',
 );
 
-export const ManifestFilePrivateKey = Symbol('manifest file private key');
+export const CloningSigningSecret = Symbol('cloning signing secret');
 
 export abstract class ManifestFileService {
   abstract performIntegrityCheck(

--- a/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.command.ts
@@ -3,7 +3,10 @@ import { UserId } from '@marxan/domain-ids';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { Either } from 'fp-ts/lib/Either';
 import { ExportId } from '../../export';
-import { integrityCheckFailed } from '../../export/application/manifest-file-service.port';
+import {
+  integrityCheckFailed,
+  invalidSignature,
+} from '../../export/application/manifest-file-service.port';
 
 export const invalidExportZipFile = Symbol('invalid export zip file');
 export const cloningExportProvided = Symbol('cloning export provided');
@@ -16,7 +19,8 @@ export type GenerateExportFromZipFileError =
   | typeof cloningExportProvided
   | typeof errorStoringCloningFile
   | typeof errorSavingExport
-  | typeof integrityCheckFailed;
+  | typeof integrityCheckFailed
+  | typeof invalidSignature;
 
 export class GenerateExportFromZipFile extends Command<
   Either<GenerateExportFromZipFileError, ExportId>

--- a/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.command.ts
@@ -3,6 +3,7 @@ import { UserId } from '@marxan/domain-ids';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { Either } from 'fp-ts/lib/Either';
 import { ExportId } from '../../export';
+import { integrityCheckFailed } from '../../export/application/manifest-file-service.port';
 
 export const invalidExportZipFile = Symbol('invalid export zip file');
 export const cloningExportProvided = Symbol('cloning export provided');
@@ -14,7 +15,8 @@ export type GenerateExportFromZipFileError =
   | typeof invalidExportZipFile
   | typeof cloningExportProvided
   | typeof errorStoringCloningFile
-  | typeof errorSavingExport;
+  | typeof errorSavingExport
+  | typeof integrityCheckFailed;
 
 export class GenerateExportFromZipFile extends Command<
   Either<GenerateExportFromZipFileError, ExportId>

--- a/api/apps/api/src/modules/clone/infra/import/import-piece.events-handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/import-piece.events-handler.ts
@@ -10,7 +10,6 @@ import { ImportJobInput, ImportJobOutput } from '@marxan/cloning';
 import { ComponentId, ResourceKind } from '@marxan/cloning/domain';
 import { Inject, Injectable } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
-import { ApiEventsService } from '../../../api-events';
 import { CompleteImportPiece } from '../../import/application/complete-import-piece.command';
 import { ImportId } from '../../import/domain';
 import { importPieceEventsFactoryToken } from './import-queue.provider';

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -112,7 +112,10 @@ import {
   invalidExportZipFile,
 } from '../clone/infra/import/generate-export-from-zip-file.command';
 import { exportNotFound } from '../clone/import/application/import-project.command';
-import { integrityCheckFailed } from '../clone/export/application/manifest-file-service.port';
+import {
+  integrityCheckFailed,
+  invalidSignature,
+} from '../clone/export/application/manifest-file-service.port';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -832,6 +835,7 @@ export class ProjectsController {
       switch (idsOrError.left) {
         case forbiddenError:
           throw new ForbiddenException();
+        case invalidSignature:
         case integrityCheckFailed:
         case cloningExportProvided:
         case invalidExportZipFile:

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -54,7 +54,6 @@ import {
 import { GeoFeatureResult } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
 import { ApiConsumesShapefile } from '../../decorators/shapefile.decorator';
 import {
-  exportNotFound,
   notAllowed,
   projectNotFound,
   ProjectsService,
@@ -112,6 +111,7 @@ import {
   cloningExportProvided,
   invalidExportZipFile,
 } from '../clone/infra/import/generate-export-from-zip-file.command';
+import { exportNotFound } from '../clone/import/application/import-project.command';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -112,6 +112,7 @@ import {
   invalidExportZipFile,
 } from '../clone/infra/import/generate-export-from-zip-file.command';
 import { exportNotFound } from '../clone/import/application/import-project.command';
+import { integrityCheckFailed } from '../clone/export/application/manifest-file-service.port';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -831,6 +832,7 @@ export class ProjectsController {
       switch (idsOrError.left) {
         case forbiddenError:
           throw new ForbiddenException();
+        case integrityCheckFailed:
         case cloningExportProvided:
         case invalidExportZipFile:
           throw new BadRequestException('Invalid export zip file');

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -54,6 +54,7 @@ import {
   GenerateExportFromZipFileError,
 } from '../clone/infra/import/generate-export-from-zip-file.command';
 import {
+  exportNotFound,
   ImportProject,
   ImportProjectCommandResult,
   ImportProjectError,
@@ -71,7 +72,6 @@ export const projectIsMissingInfoForRegularPus = Symbol(
 );
 export const notAllowed = Symbol(`not allowed to that action`);
 export const notFound = Symbol(`project not found`);
-export const exportNotFound = Symbol(`project export not found`);
 
 // Check where to centralize this symbols
 export const exportResourceKindIsNotProject = Symbol(
@@ -395,7 +395,17 @@ export class ProjectsService {
   async clone(
     exportId: ExportId,
     userId: UserId,
-  ): Promise<Either<any, ImportProjectCommandResult>> {
+  ): Promise<
+    Either<
+      | typeof exportNotFound
+      | typeof exportResourceKindIsNotProject
+      | typeof exportIsNotStandalone
+      | typeof projectNotFoundForExport
+      | typeof projectIsNotPublished
+      | ImportProjectError,
+      ImportProjectCommandResult
+    >
+  > {
     const exportInstance = await this.exportRepository.find(exportId);
     if (!exportInstance) return left(exportNotFound);
     if (!exportInstance.isForProject())

--- a/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/planning-area-gadm.piece-exporter.spec.ts
@@ -197,4 +197,8 @@ class FakeFileRepository implements CloningFilesRepository {
   deleteExportFolder(exportId: string): Promise<void> {
     throw new Error('Method not implemented.');
   }
+
+  getFilesFolderFor(exportId: string): string {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/api/libs/cloning-files-repository/src/cloning-files.repository.ts
+++ b/api/libs/cloning-files-repository/src/cloning-files.repository.ts
@@ -35,4 +35,6 @@ export abstract class CloningFilesRepository {
   ): Promise<Either<SaveFileError, string>>;
 
   abstract deleteExportFolder(exportId: string): Promise<void>;
+
+  abstract getFilesFolderFor(exportId: string): string;
 }

--- a/api/libs/cloning-files-repository/src/local-cloning-files.repository.ts
+++ b/api/libs/cloning-files-repository/src/local-cloning-files.repository.ts
@@ -61,11 +61,19 @@ export class LocalCloningFilesStorage implements CloningFilesRepository {
     });
   }
 
+  private getStorageRootPath(exportId: string): string {
+    return `${this.storagePath}/${exportId}`;
+  }
+
+  getFilesFolderFor(exportId: string): string {
+    return `${this.getStorageRootPath(exportId)}/files`;
+  }
+
   saveZipFile(
     exportId: string,
     stream: Readable,
   ): Promise<Either<SaveFileError, string>> {
-    const path = `${this.storagePath}/${exportId}/export.zip`;
+    const path = `${this.getStorageRootPath(exportId)}/export.zip`;
 
     this.ensureFolderExists(path);
 
@@ -77,7 +85,7 @@ export class LocalCloningFilesStorage implements CloningFilesRepository {
     stream: Readable,
     relativePath: string,
   ): Promise<Either<SaveFileError, string>> {
-    const path = `${this.storagePath}/${exportId}/files/${relativePath}`;
+    const path = `${this.getFilesFolderFor(exportId)}/${relativePath}`;
 
     this.ensureFolderExists(path);
 
@@ -85,7 +93,7 @@ export class LocalCloningFilesStorage implements CloningFilesRepository {
   }
 
   async deleteExportFolder(exportId: string): Promise<void> {
-    const path = `${this.storagePath}/${exportId}`;
+    const path = this.getStorageRootPath(exportId);
 
     rmSync(path, { recursive: true, force: true });
   }

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/manifest-file.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/manifest-file.ts
@@ -1,0 +1,2 @@
+export const manifestFileRelativePath = 'manifest.txt';
+export const signatureFileRelativePath = 'signature';

--- a/docker-compose-test-e2e.ci.yml
+++ b/docker-compose-test-e2e.ci.yml
@@ -20,6 +20,7 @@ services:
       - POSTGRES_GEO_SERVICE_PORT
       - REDIS_API_SERVICE_PORT
       - API_AUTH_X_API_KEY
+      - CLONING_SIGNING_SECRET
 
   geoprocessing:
     environment:

--- a/env.default
+++ b/env.default
@@ -13,6 +13,9 @@ API_POSTGRES_USER=marxan-api
 API_POSTGRES_PASSWORD=marxan-api
 API_POSTGRES_DB=marxan-api
 POSTGRES_API_SERVICE_PORT=3432
+# CLONING_SIGNING_SECRET *must* be set for the api to work. A suitable private
+# key may be generated via `openssl genrsa 4096 | base64 -w0`
+CLONING_SIGNING_SECRET=
 APP_SERVICE_PORT=3000
 NETWORK_CORS_ORIGINS=http://localhost:3000
 GEOPROCESSING_SERVICE_PORT=3040

--- a/infrastructure/kubernetes/.terraform.lock.hcl
+++ b/infrastructure/kubernetes/.terraform.lock.hcl
@@ -95,22 +95,22 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.1.2"
+  version     = "3.1.3"
   constraints = "~> 3.1.0"
   hashes = [
-    "h1:5A5VsY5wNmOZlupUcLnIoziMPn8htSZBXbP3lI7lBEM=",
-    "zh:0daceba867b330d3f8e2c5dc895c4291845a78f31955ce1b91ab2c4d1cd1c10b",
-    "zh:104050099efd30a630741f788f9576b19998e7a09347decbec3da0b21d64ba2d",
-    "zh:173f4ef3fdf0c7e2564a3db0fac560e9f5afdf6afd0b75d6646af6576b122b16",
-    "zh:41d50f975e535f968b3f37170fb07937c15b76d85ba947d0ce5e5ff9530eda65",
-    "zh:51a5038867e5e60757ed7f513dd6a973068241190d158a81d1b69296efb9cb8d",
-    "zh:6432a568e97a5a36cc8aebca5a7e9c879a55d3bc71d0da1ab849ad905f41c0be",
-    "zh:6bac6501394b87138a5e17c9f3a41e46ff7833ad0ba2a96197bb7787e95b641c",
-    "zh:6c0a7f5faacda644b022e7718e53f5868187435be6d000786d1ca05aa6683a25",
-    "zh:74c89de3fa6ef3027efe08f8473c2baeb41b4c6cee250ba7aeb5b64e8c79800d",
+    "h1:nLWniS8xhb32qRQy+n4bDPjQ7YWZPVMR3v1vSrx7QyY=",
+    "zh:26e07aa32e403303fc212a4367b4d67188ac965c37a9812e07acee1470687a73",
+    "zh:27386f48e9c9d849fbb5a8828d461fde35e71f6b6c9fc235bc4ae8403eb9c92d",
+    "zh:5f4edda4c94240297bbd9b83618fd362348cadf6bf24ea65ea0e1844d7ccedc0",
+    "zh:646313a907126cd5e69f6a9fafe816e9154fccdc04541e06fed02bb3a8fa2d2e",
+    "zh:7349692932a5d462f8dee1500ab60401594dddb94e9aa6bf6c4c0bd53e91bbb8",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b29eabbf0a5298f0e95a1df214c7cfe06ea9bcf362c63b3ad2f72d85da7d4685",
-    "zh:e891458c7a61e5b964e09616f1a4f87d0471feae1ec04cc51776e7dec1a3abce",
+    "zh:9034daba8d9b32b35930d168f363af04cecb153d5849a7e4a5966c97c5dc956e",
+    "zh:bb81dfca59ef5f949ef39f19ea4f4de25479907abc28cdaa36d12ecd7c0a9699",
+    "zh:bcf7806b99b4c248439ae02c8e21f77aff9fadbc019ce619b929eef09d1221bb",
+    "zh:d708e14d169e61f326535dd08eecd3811cd4942555a6f8efabc37dbff9c6fc61",
+    "zh:dc294e19a46e1cefb9e557a7b789c8dd8f319beca99b8c265181bc633dc434cc",
+    "zh:f9d758ee53c55dc016dd736427b6b0c3c8eb4d0dbbc785b6a3579b0ffedd9e42",
   ]
 }
 
@@ -128,5 +128,24 @@ provider "registry.terraform.io/hashicorp/template" {
     "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
     "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
     "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.3.0"
+  hashes = [
+    "h1:xx/b39Q9FVZSlDc97rlDmQ9dNaaxFFyVzP9kV+47z28=",
+    "zh:16140e8cc880f95b642b6bf6564f4e98760e9991864aacc8e21273423571e561",
+    "zh:16338b8457759c97fdd73153965d6063b037f2954fd512e569fcdc42b7fef743",
+    "zh:348bd44b7cd0c6d663bba36cecb474c17635a8f22b02187d034b8e57a8729c5a",
+    "zh:3832ac73c2335c0fac26138bacbd18160efaa3f06c562869acc129e814e27f86",
+    "zh:756d1e60690d0164eee9c93b498b4c8beabbfc1d8b7346cb6d2fa719055089d6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:93b911bcddba8dadc5339edb004c8019c230ea67477c73c4f741c236dd9511b1",
+    "zh:c0c4e5742e8ac004c507540423db52af3f44b8ec04443aa8e14669340819344f",
+    "zh:c78296a1dff8ccd5d50203aac353422fc18d425072ba947c88cf5b46de7d32d2",
+    "zh:d7143f444e0f7e6cd67fcaf080398b4f1487cf05de3e0e79af6c14e22812e38b",
+    "zh:e600ac76b118816ad72132eee4c22ab5fc044f67c3babc54537e1fc1ad53d295",
+    "zh:fca07af5f591e12d2dc178a550da69a4847bdb34f8180a5b8e04fde6b528cf99",
   ]
 }

--- a/infrastructure/kubernetes/modules/api/main.tf
+++ b/infrastructure/kubernetes/modules/api/main.tf
@@ -263,7 +263,7 @@ resource "kubernetes_deployment" "api_deployment" {
           }
 
           env {
-            name  = "api_POSTGRES_LOGGING"
+            name  = "API_POSTGRES_LOGGING"
             value = var.api_postgres_logging
           }
 

--- a/infrastructure/kubernetes/modules/api/main.tf
+++ b/infrastructure/kubernetes/modules/api/main.tf
@@ -178,6 +178,16 @@ resource "kubernetes_deployment" "api_deployment" {
           }
 
           env {
+            name = "CLONING_SIGNING_SECRET"
+            value_from {
+              secret_key_ref {
+                name = "api"
+                key  = "CLONING_SIGNING_SECRET"
+              }
+            }
+          }
+
+          env {
             name = "SPARKPOST_APIKEY"
             value_from {
               secret_key_ref {


### PR DESCRIPTION
This PR adds logic for verifying and integrity checking import files signature and manifest files

### Feature relevant tickets

- [check signed hash of zip file contents users try to import](https://vizzuality.atlassian.net/browse/MARXAN-1470)
- [hash and sign exported data in downloadable zip artifacts](https://vizzuality.atlassian.net/browse/MARXAN-1469)
- [configure signing secret for integrity checks of exported data (via env var+config)](https://vizzuality.atlassian.net/browse/MARXAN-1467)