### PR TITLE
MARXAN1498-public-project-patch-endpoint

### DIFF
--- a/api/apps/api/src/modules/published-project/controllers/publish-project.controller.ts
+++ b/api/apps/api/src/modules/published-project/controllers/publish-project.controller.ts
@@ -55,7 +55,7 @@ import {
   ProcessFetchSpecification,
 } from 'nestjs-base-service';
 import { PublishedProjectSerializer } from '../published-project.serializer';
-import { CreatePublishProjectDto } from '../dto/publish-project.dto';
+import { PublishProjectDto } from '../dto/publish-project.dto';
 import { RequestPublishedProjectCloneResponseDto } from '@marxan-api/modules/projects/dto/export.project.dto';
 import { ProjectsService } from '@marxan-api/modules/projects/projects.service';
 import { ExportId } from '@marxan-api/modules/clone';
@@ -82,7 +82,7 @@ export class PublishProjectController {
   @ApiInternalServerErrorResponse()
   async publish(
     @Param('id') id: string,
-    @Body() dto: CreatePublishProjectDto,
+    @Body() dto: PublishProjectDto,
     @Request() req: RequestWithAuthenticatedUser,
     @AppSessionTokenCookie() appSessionTokenCookie: string,
   ): Promise<void> {
@@ -169,6 +169,26 @@ export class PublishProjectController {
     }
 
     return;
+  }
+
+  @ApiOperation({ description: 'Update public project' })
+  @ApiOkResponse({ type: PublishedProjectResultSingular })
+  @Patch('/published-projects/:id')
+  async update(
+    @Param('id') id: string,
+    @Body() dto: PublishProjectDto,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<PublishedProjectResultSingular> {
+    const result = await this.publishedProjectService.update(
+      id,
+      dto,
+      req.user.id,
+    );
+
+    if (isLeft(result)) {
+      throw new ForbiddenException();
+    }
+    return await this.serializer.serialize(result.right);
   }
 
   @Patch(':id/moderation-status/set')

--- a/api/apps/api/src/modules/published-project/dto/create-published-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/create-published-project.dto.ts
@@ -13,8 +13,7 @@ export interface Company {
   logoDataUrl: string;
 }
 
-export interface CreatePublishedProjectDto {
-  id: string;
+export interface PublishedProjectDto {
   name?: string;
   description?: string;
   location?: string;
@@ -23,4 +22,11 @@ export interface CreatePublishedProjectDto {
   company?: Company;
   pngData?: string;
   exportId?: string;
+}
+
+export interface CreatePublishedProjectDto extends PublishedProjectDto {
+  id: string;
+}
+export interface UpdatePublishedProjectDto extends PublishedProjectDto {
+  underModeration?: boolean;
 }

--- a/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/publish-project.dto.ts
@@ -1,7 +1,13 @@
 import { WebshotConfig } from '@marxan/webshot';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsOptional, IsString, IsUUID, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
 import { Company, Creator, Resource } from './create-published-project.dto';
 
 export class PublishProjectDto {
@@ -34,9 +40,7 @@ export class PublishProjectDto {
   @IsOptional()
   @ApiPropertyOptional()
   featuredScenarioId?: string;
-}
 
-export class CreatePublishProjectDto extends PublishProjectDto {
   @ApiProperty()
   @ValidateNested({ each: true })
   @Type(() => WebshotConfig)

--- a/api/apps/api/src/modules/published-project/dto/update-published-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/update-published-project.dto.ts
@@ -1,8 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsOptional } from 'class-validator';
-import { CreatePublishProjectDto } from './publish-project.dto';
+import { PublishProjectDto } from './publish-project.dto';
 
-export class UpdatePublishedProjectDto extends CreatePublishProjectDto {
+export class UpdatePublishedProjectDto extends PublishProjectDto {
   @IsBoolean()
   @IsOptional()
   @ApiPropertyOptional()

--- a/api/apps/api/src/modules/published-project/dto/update-published-project.dto.ts
+++ b/api/apps/api/src/modules/published-project/dto/update-published-project.dto.ts
@@ -1,8 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsOptional } from 'class-validator';
-import { PublishProjectDto } from './publish-project.dto';
+import { CreatePublishProjectDto } from './publish-project.dto';
 
-export class UpdatePublishedProjectDto extends PublishProjectDto {
+export class UpdatePublishedProjectDto extends CreatePublishProjectDto {
   @IsBoolean()
   @IsOptional()
   @ApiPropertyOptional()

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -4,9 +4,11 @@ import {
   JSONAPISerializerConfig,
 } from '@marxan-api/utils/app-base.service';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
-import { UpdatePublishedProjectDto } from '@marxan-api/modules/published-project/dto/update-published-project.dto';
 import { ProjectsRequest } from '@marxan-api/modules/projects/project-requests-info';
-import { CreatePublishedProjectDto } from '@marxan-api/modules/published-project/dto/create-published-project.dto';
+import {
+  CreatePublishedProjectDto,
+  UpdatePublishedProjectDto,
+} from '@marxan-api/modules/published-project/dto/create-published-project.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { AppConfig } from '@marxan-api/utils/config.utils';

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -116,7 +116,7 @@ export class PublishedProjectService {
 
       if (isLeft(result)) {
         console.info(
-          `Scenario snapshot could not be generated for scenario ${featuredScenarioId}`,
+          `Map snapshot could not be generated for scenario ${featuredScenarioId} of project ${id}`,
         );
       }
 
@@ -193,7 +193,7 @@ export class PublishedProjectService {
 
       if (isLeft(result)) {
         console.info(
-          `Scenario snapshot could not be generated for scenario ${featuredScenarioId}`,
+          `Scenario snapshot could not be generated for scenario ${featuredScenarioId} of project ${projectId}`,
         );
       }
 

--- a/api/apps/api/src/utils/webshot.utils.ts
+++ b/api/apps/api/src/utils/webshot.utils.ts
@@ -1,0 +1,33 @@
+import { WebshotConfig, WebshotService } from '@marxan/webshot';
+import { Either, isLeft, left, right } from 'fp-ts/lib/Either';
+import { AppConfig } from './config.utils';
+const webshotUrl = AppConfig.get('webshot.url') as string;
+const imgGenerationError = Symbol(`Image generation has failed.`);
+
+export const getScenarioSnapshot = async (
+  featuredScenarioId: string,
+  projectId: string,
+  webshotService: WebshotService,
+  config: WebshotConfig,
+): Promise<Either<typeof imgGenerationError, string>> => {
+  const pngData = await webshotService.getPublishedProjectsImage(
+    featuredScenarioId,
+    projectId,
+    {
+      ...config,
+      screenshotOptions: {
+        clip: { x: 0, y: 0, width: 500, height: 500 },
+      },
+    },
+    webshotUrl,
+  );
+
+  if (isLeft(pngData)) {
+    console.info(
+      `Map screenshot for public project ${projectId} could not be generated`,
+    );
+    return left(imgGenerationError);
+  }
+
+  return right(pngData.right);
+};

--- a/api/apps/api/src/utils/webshot.utils.ts
+++ b/api/apps/api/src/utils/webshot.utils.ts
@@ -23,9 +23,6 @@ export const getScenarioSnapshot = async (
   );
 
   if (isLeft(pngData)) {
-    console.info(
-      `Map screenshot for public project ${projectId} could not be generated`,
-    );
     return left(imgGenerationError);
   }
 

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -124,6 +124,21 @@ export const getFixtures = async () => {
       expect(response.body.data.length).toEqual(1);
       expect(response.body.data[0].id).toEqual(publicProjectId);
     },
+    ThenPublicProjectIsUpdated: (
+      publicProjectId: string,
+      response: request.Response,
+    ) => {
+      expect(response.status).toEqual(200);
+      expect(response.body.data.id).toEqual(publicProjectId);
+      expect(response.body.data.type).toEqual('published_projects');
+      expect(response.body.data.attributes.name).toEqual('Updated Name');
+      expect(response.body.data.attributes.description).toEqual(
+        'Updated Description',
+      );
+      expect(response.body.data.attributes.location).toEqual(
+        'Updated Location',
+      );
+    },
     ThenPublicProjectWithUnderModerationStatusIsAvailable: (
       publicProjectId: string,
       response: request.Response,
@@ -288,6 +303,24 @@ export const getFixtures = async () => {
           featuredScenarioId: scenarioId,
         })
         .set('Authorization', `Bearer ${randomUserToken}`),
+    WhenUpdatingAPublicProject: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .patch(`/api/v1/projects/published-projects/${projectId}`)
+        .send({
+          name: 'Updated Name',
+          description: 'Updated Description',
+          location: 'Updated Location',
+        })
+        .set('Authorization', `Bearer ${randomUserToken}`),
+    WhenUpdatingAPublicProjectAsNotIncludedUser: async (projectId: string) =>
+      await request(app.getHttpServer())
+        .patch(`/api/v1/projects/published-projects/${projectId}`)
+        .send({
+          name: 'Updated Name',
+          description: 'Updated Description',
+          location: 'Updated Location',
+        })
+        .set('Authorization', `Bearer ${notIncludedUserToken}`),
     WhenUnpublishingAProjectAsProjectOwner: async (projectId: string) =>
       await request(app.getHttpServer())
         .post(`/api/v1/projects/${projectId}/unpublish`)

--- a/api/apps/api/test/project/public-projects.e2e-spec.ts
+++ b/api/apps/api/test/project/public-projects.e2e-spec.ts
@@ -168,6 +168,26 @@ test(`when unpublishing a public project that is under moderation as a platform 
   fixtures.ThenNoProjectIsAvailable(response);
 });
 
+test(`when updating a public project as the project owner`, async () => {
+  const projectId = await fixtures.GivenPrivateProjectWasCreated();
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
+  fixtures.ThenCreatedIsReturned(response);
+  response = await fixtures.WhenUpdatingAPublicProject(projectId);
+  fixtures.ThenPublicProjectIsUpdated(projectId, response);
+});
+
+test(`when updating a public project as not project owner`, async () => {
+  const projectId = await fixtures.GivenPrivateProjectWasCreated();
+  const scenarioId = await fixtures.GivenScenarioWasCreated(projectId);
+  let response = await fixtures.WhenPublishingAProject(projectId, scenarioId);
+  fixtures.ThenCreatedIsReturned(response);
+  response = await fixtures.WhenUpdatingAPublicProjectAsNotIncludedUser(
+    projectId,
+  );
+  fixtures.ThenForbiddenIsReturned(response);
+});
+
 test(`when cloning a project that does not belong to the requesting user, it should import the public project`, async () => {
   const projectId = await fixtures.GivenPublicProjectWasCreated();
   const exportId = await fixtures.GivenProjectHasAnExportPrepared(projectId);


### PR DESCRIPTION
-Adds PATCH endpoint to update public projects.
-Refactors how webshot is called from public projects actions for scenario snapshot generation.
-Adds basic tests for this new endpoint.