### PR TITLE
update regexp match to ignore azure zone URL hostname part

### DIFF
--- a/.github/workflows/deploy-to-kubernetes.yml
+++ b/.github/workflows/deploy-to-kubernetes.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           mkdir ~/.kube
           az aks get-credentials --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name ${{ secrets.AZURE_AKS_CLUSTER_NAME }}
-          sed -i 's/marxan.privatelink.westeurope.azmk8s.io:443/marxan.privatelink.westeurope.azmk8s.io:4433/g' ~/.kube/config
+          sed -i 's/\(marxan.privatelink.[[:alnum:]]+?.azmk8s.io\):443/\1:4433/g' ~/.kube/config
 
       - name: Creating SSH tunnel
         run: |


### PR DESCRIPTION
This change should allow the configured `sed` regexp replacement to work irrespective of the Azure zone the AKS API is in.

Assuming that the part of hostname for zones is always going to be alphanumeric. Maybe "anything but a `.`" maybe more resilient? I think alphanumeric should be good enough for the time being, without being overly permissive.