### PR TITLE
remove allowedHeaders whitelisting [MARXAN-1406]

### DIFF
--- a/api/apps/api/src/bootstrap-app.ts
+++ b/api/apps/api/src/bootstrap-app.ts
@@ -54,7 +54,6 @@ export async function bootstrapSetUp() {
   }
 
   app.enableCors({
-    allowedHeaders: 'Content-Type,Authorization,Content-Disposition',
     exposedHeaders: 'Authorization',
     origin: CorsUtils.originHandler,
     credentials: true,

--- a/webshot/src/utils/passthrough-console.utils.ts
+++ b/webshot/src/utils/passthrough-console.utils.ts
@@ -1,6 +1,7 @@
-import * as puppeteer from "puppeteer";
+import * as puppeteer from 'puppeteer';
+import { inspect } from 'util';
 
-export const passthroughConsole = (msg: puppeteer.ConsoleMessage) => {
+export const passthroughConsole = async (msg: puppeteer.ConsoleMessage) => {
   for (let i = 0; i < msg.args().length; ++i)
-    console.debug(`${i}: ${msg.args()[i]}`);
+    console.debug(inspect(msg.args()[i]?._remoteObject, undefined, 5));
 };


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1406

The whitelisting of specific headers was an historical artifact inherited from earlier NestJS setups, but in practice, I don't think we need to be so picky with request headers as long as we whitelist origins correctly, as we seem to be doing.

Somehow, the previous setup was working correctly for the frontend app, except when this is puppeteered via the webshot service.
