### PR TITLE
Fix/clone missing data

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-metadata.piece-exporter.ts
@@ -45,9 +45,10 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
       name: string;
       description: string;
       planning_unit_grid_shape: PlanningUnitGridShape;
+      metadata: Record<string, unknown> | null;
     }[] = await this.entityManager
       .createQueryBuilder()
-      .select(['name', 'description', 'planning_unit_grid_shape'])
+      .select(['name', 'description', 'planning_unit_grid_shape', 'metadata'])
       .from('projects', 'p')
       .where('id = :projectId', { projectId })
       .execute();
@@ -78,6 +79,7 @@ export class ProjectMetadataPieceExporter implements ExportPieceProcessor {
       description: projectData.description,
       planningUnitGridShape: projectData.planning_unit_grid_shape,
       blmRange,
+      metadata: projectData.metadata ?? undefined,
     };
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-metadata.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-metadata.piece-exporter.ts
@@ -20,6 +20,9 @@ type SelectScenarioResult = {
   blm?: number;
   number_of_runs?: number;
   metadata?: ScenarioMetadataContent['metadata'];
+  ran_at_least_once: boolean;
+  status: ScenarioMetadataContent['status'] | null;
+  type: string;
 };
 
 type SelectScenarioBlmResult = {
@@ -51,7 +54,16 @@ export class ScenarioMetadataPieceExporter implements ExportPieceProcessor {
       SelectScenarioResult,
     ] = await this.entityManager
       .createQueryBuilder()
-      .select('name, description, blm, number_of_runs, metadata')
+      .select([
+        'name',
+        'description',
+        'blm',
+        'number_of_runs',
+        'metadata',
+        'type',
+        'status',
+        'ran_at_least_once',
+      ])
       .from('scenarios', 's')
       .where('s.id = :scenarioId', { scenarioId })
       .execute();
@@ -84,6 +96,9 @@ export class ScenarioMetadataPieceExporter implements ExportPieceProcessor {
       name: scenario.name,
       numberOfRuns: scenario.number_of_runs,
       blmRange,
+      ranAtLeastOnce: scenario.ran_at_least_once,
+      type: scenario.type,
+      status: scenario.status ?? undefined,
     };
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
@@ -43,6 +43,7 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
     projectId: string,
     organizationId: string,
     data: ProjectMetadataContent,
+    ownerId: string,
   ) {
     return em
       .createQueryBuilder()
@@ -54,6 +55,8 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
         description: data.description,
         organization_id: organizationId,
         planning_unit_grid_shape: data.planningUnitGridShape,
+        metadata: data.metadata,
+        created_by: ownerId,
       })
       .execute();
   }
@@ -62,6 +65,7 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
     em: EntityManager,
     projectId: string,
     data: ProjectMetadataContent,
+    ownerId: string,
   ) {
     return em
       .createQueryBuilder()
@@ -69,6 +73,8 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
       .set({
         description: data.description,
         planning_unit_grid_shape: data.planningUnitGridShape,
+        metadata: data.metadata,
+        created_by: ownerId,
       })
       .where('id = :projectId', { projectId })
       .execute();
@@ -123,13 +129,14 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
         projectId,
       );
       if (projectAlreadyCreated) {
-        await this.updateProject(em, projectId, projectMetadata);
+        await this.updateProject(em, projectId, projectMetadata, ownerId);
       } else {
         await this.createProject(
           em,
           projectId,
           organizationId,
           projectMetadata,
+          ownerId,
         );
       }
 

--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
@@ -33,6 +33,7 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
     em: EntityManager,
     scenarioId: string,
     values: ScenarioMetadataContent,
+    ownerId: string,
   ) {
     return em
       .createQueryBuilder()
@@ -43,6 +44,10 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
         blm: values.blm,
         number_of_runs: values.numberOfRuns,
         metadata: values.metadata,
+        ran_at_least_once: values.ranAtLeastOnce,
+        type: values.type,
+        status: values.status,
+        created_by: ownerId,
       })
       .where('id = :scenarioId', { scenarioId })
       .execute();
@@ -53,6 +58,7 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
     scenarioId: string,
     projectId: string,
     values: ScenarioMetadataContent,
+    ownerId: string,
   ) {
     return em
       .createQueryBuilder()
@@ -66,6 +72,10 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
         number_of_runs: values.numberOfRuns,
         metadata: values.metadata,
         project_id: projectId,
+        ran_at_least_once: values.ranAtLeastOnce,
+        type: values.type,
+        status: values.status,
+        created_by: ownerId,
       })
       .execute();
   }
@@ -105,9 +115,15 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
 
     await this.entityManager.transaction(async (em) => {
       if (scenarioCloning) {
-        await this.updateScenario(em, scenarioId, metadata);
+        await this.updateScenario(em, scenarioId, metadata, input.ownerId);
       } else {
-        await this.createScenario(em, scenarioId, projectId, metadata);
+        await this.createScenario(
+          em,
+          scenarioId,
+          projectId,
+          metadata,
+          input.ownerId,
+        );
       }
 
       await em

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-metadata.piece-exporter.e2e-spec.ts
@@ -80,6 +80,8 @@ const getFixtures = async () => {
     getEntityManagerToken(geoprocessingConnections.apiDB),
   );
   const fileRepository = sandbox.get(CloningFilesRepository);
+  const metadata = { foo: 'bar' };
+
   const expectedContent: ProjectMetadataContent = {
     name: `test project - ${projectId}`,
     planningUnitGridShape: PlanningUnitGridShape.Square,
@@ -88,6 +90,7 @@ const getFixtures = async () => {
       range: [0, 100],
       values: [],
     },
+    metadata,
   };
 
   return {
@@ -111,7 +114,9 @@ const getFixtures = async () => {
       };
     },
     GivenProjectExist: async () => {
-      return GivenProjectExists(apiEntityManager, projectId, organizationId);
+      return GivenProjectExists(apiEntityManager, projectId, organizationId, {
+        metadata,
+      });
     },
     GivenProjectBlmRangeExist: async () => {
       return apiEntityManager

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-metadata.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-metadata.piece-exporter.e2e-spec.ts
@@ -91,6 +91,8 @@ const getFixtures = async () => {
       range: [0, 100],
       values: [],
     },
+    ranAtLeastOnce: false,
+    type: 'marxan',
   };
 
   return {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-importers/project-metadata.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-importers/project-metadata.piece-importer.e2e-spec.ts
@@ -33,6 +33,8 @@ interface ProjectSelectResult {
   name: string;
   description: string;
   planning_unit_grid_shape: PlanningUnitGridShape;
+  metadata: Record<string, unknown> | null;
+  created_by: string;
 }
 
 let fixtures: FixtureType<typeof getFixtures>;
@@ -116,6 +118,8 @@ const getFixtures = async () => {
   const projectName = `test project - ${projectId}`;
   const copyProjectName = projectName + ' - copy';
 
+  const expectedMetadata = { foo: 'bar' };
+
   const validProjectMetadataFileContent: ProjectMetadataContent = {
     name: projectName,
     description: 'project description',
@@ -125,6 +129,7 @@ const getFixtures = async () => {
       range: [0, 100],
       values: [],
     },
+    metadata: expectedMetadata,
   };
 
   return {
@@ -218,6 +223,8 @@ const getFixtures = async () => {
           expect(project.planning_unit_grid_shape).toEqual(
             validProjectMetadataFileContent.planningUnitGridShape,
           );
+          expect(project.metadata).toMatchObject(expectedMetadata);
+          expect(project.created_by).toEqual(userId);
 
           const [blmRange]: [
             BlmRange,

--- a/api/apps/geoprocessing/test/integration/cloning/piece-importers/scenario-metadata.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-importers/scenario-metadata.piece-importer.e2e-spec.ts
@@ -31,6 +31,9 @@ interface ScenarioSelectResult {
   description: string;
   number_of_runs: number;
   blm: number;
+  ran_at_least_once: boolean;
+  type: string;
+  created_by: string;
 }
 
 let fixtures: FixtureType<typeof getFixtures>;
@@ -131,6 +134,8 @@ const getFixtures = async () => {
       range: [0, 100],
       values: [],
     },
+    ranAtLeastOnce: true,
+    type: 'marxan',
   };
 
   return {
@@ -234,6 +239,11 @@ const getFixtures = async () => {
           expect(scenario.number_of_runs).toEqual(
             validScenarioMetadataFileContent.numberOfRuns,
           );
+          expect(scenario.ran_at_least_once).toEqual(
+            validScenarioMetadataFileContent.ranAtLeastOnce,
+          );
+          expect(scenario.type).toEqual(validScenarioMetadataFileContent.type);
+          expect(scenario.created_by).toEqual(userId);
 
           const [blmRange]: [
             BlmRange,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-metadata.ts
@@ -11,6 +11,7 @@ export type ProjectMetadataContent = {
   description?: string;
   planningUnitGridShape?: PlanningUnitGridShape;
   blmRange: BlmRange;
+  metadata?: Record<string, unknown>;
 };
 
 export const projectMetadataRelativePath = 'project-metadata.json';

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-metadata.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-metadata.ts
@@ -1,5 +1,6 @@
 import { ScenarioMetadata } from '@marxan/scenario-metadata';
 import { BlmRange } from './project-metadata';
+import { ProjectCustomFeature } from './project-custom-features';
 
 export type ScenarioMetadataContent = {
   name: string;
@@ -8,6 +9,9 @@ export type ScenarioMetadataContent = {
   blm?: number;
   metadata?: ScenarioMetadata;
   blmRange: BlmRange;
+  status?: ProjectCustomFeature['creation_status'];
+  ranAtLeastOnce: boolean;
+  type: string;
 };
 
 export const scenarioMetadataRelativePath = `scenario-metadata.json`;


### PR DESCRIPTION
This PR adds missing scenario and project data to cloning process:

- `created_by` columns of `(apidb)projects` and `(apidb)scenarios` tables
- `metadata` column of `(apidb)projects` table
- `status`, `type` and `ran_at_least_once` columns of `(apidb)scenarios` table