### PR TITLE
Public-Projects-ExportId-Switch

### DIFF
--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -53,6 +53,7 @@ export class PublishedProjectCrudService extends AppBaseService<
         'underModeration',
         'originalProject',
         'pngData',
+        'exportId',
       ],
       keyForAttribute: 'camelCase',
       originalProject: {

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -87,7 +87,7 @@ export class PublishedProjectCrudService extends AppBaseService<
     if (exportIdString) {
       const exportId = new ExportId(exportIdString);
       const finalExport = await this.exportRepo.find(exportId);
-      if (!finalExport) {
+      if (!finalExport?.hasFinished()) {
         delete entity.exportId;
       }
     }

--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -16,7 +16,6 @@ import { publishedProjectResource } from '@marxan-api/modules/published-project/
 import { FetchSpecification } from 'nestjs-base-service';
 import { UsersService } from '../users/users.service';
 import { ExportId } from '../clone';
-import { assertDefined } from '@marxan/utils';
 import { ExportRepository } from '../clone/export/application/export-repository.port';
 
 @Injectable()
@@ -82,14 +81,14 @@ export class PublishedProjectCrudService extends AppBaseService<
     _fetchSpecification?: FetchSpecification,
     _info?: ProjectsRequest,
   ): Promise<PublishedProject> {
-    const exportIdString = entity.exportId;
-    assertDefined(exportIdString);
-    const exportId = new ExportId(exportIdString);
+    const exportIdString = entity?.exportId;
 
-    const finalExport = await this.exportRepo.find(exportId);
-
-    if (!finalExport) {
-      delete entity.exportId;
+    if (exportIdString) {
+      const exportId = new ExportId(exportIdString);
+      const finalExport = await this.exportRepo.find(exportId);
+      if (!finalExport) {
+        delete entity.exportId;
+      }
     }
 
     return entity;

--- a/api/apps/api/src/modules/published-project/published-project.module.ts
+++ b/api/apps/api/src/modules/published-project/published-project.module.ts
@@ -12,6 +12,8 @@ import { UsersModule } from '@marxan-api/modules/users/users.module';
 import { WebshotModule } from '@marxan/webshot';
 import { ScenariosModule } from '../scenarios/scenarios.module';
 import { Scenario } from '../scenarios/scenario.api.entity';
+import { ExportRepository } from '../clone/export/application/export-repository.port';
+import { TypeormExportRepository } from '../clone/export/adapters/typeorm-export.repository';
 
 @Module({
   imports: [
@@ -27,6 +29,10 @@ import { Scenario } from '../scenarios/scenario.api.entity';
     PublishedProjectService,
     PublishedProjectCrudService,
     PublishedProjectSerializer,
+    {
+      provide: ExportRepository,
+      useClass: TypeormExportRepository,
+    },
   ],
 })
 export class PublishedProjectModule {}

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -259,12 +259,13 @@ export class PublishedProjectService {
       return left(notFound);
     }
 
-    assertDefined(result?.exportId);
-    const exportId: ExportId = new ExportId(result.exportId);
+    if (result.exportId) {
+      const exportId: ExportId = new ExportId(result.exportId);
 
-    const exportResult = await this.exportRepo.find(exportId);
-    if (!exportResult) {
-      delete result.exportId;
+      const exportResult = await this.exportRepo.find(exportId);
+      if (!exportResult) {
+        delete result.exportId;
+      }
     }
 
     const isUnderModeration = result.underModeration === true;

--- a/api/apps/api/src/modules/published-project/published-project.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project.service.ts
@@ -263,7 +263,7 @@ export class PublishedProjectService {
       const exportId: ExportId = new ExportId(result.exportId);
 
       const exportResult = await this.exportRepo.find(exportId);
-      if (!exportResult) {
+      if (!exportResult?.hasFinished()) {
         delete result.exportId;
       }
     }

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -25,7 +25,6 @@ import { bootstrapApplication } from '../utils/api-application';
 import { EventBusTestUtils } from '../utils/event-bus.test.utils';
 import { ScenariosTestUtils } from '../utils/scenarios.test.utils';
 import { ScenarioType } from '@marxan-api/modules/scenarios/scenario.api.entity';
-import { async } from 'rxjs';
 
 export const getFixtures = async () => {
   const app = await bootstrapApplication([CqrsModule], [EventBusTestUtils]);
@@ -219,6 +218,7 @@ export const getFixtures = async () => {
             creators: null,
             location: null,
             pngData: null,
+            exportId: null,
           },
           id: publicProjectId,
           type: 'published_projects',


### PR DESCRIPTION
-Add conditions on findAll/findOne methods in public projects to avoid showing exportId when it is not ready.
-Add specific test to check that exportId is shown if export is finished.