### PR TITLE
fix: project shell visibility

### DIFF
--- a/api/apps/api/src/modules/access-control/role.api.entity.ts
+++ b/api/apps/api/src/modules/access-control/role.api.entity.ts
@@ -20,6 +20,6 @@ export enum Roles {
 @Entity('roles')
 export class Role {
   @PrimaryColumn({ type: 'varchar', enum: Roles })
-  @IsEnum(Object.values(Roles))
+  @IsEnum(Roles)
   name!: Roles;
 }

--- a/api/apps/api/src/modules/clone/export/application/export-application.module.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-application.module.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersProjectsApiEntity } from '../../../access-control/projects-acl/entity/users-projects.api.entity';
 import { Project } from '../../../projects/project.api.entity';
 import { Scenario } from '../../../scenarios/scenario.api.entity';
 import { AllPiecesReadySaga } from './all-pieces-ready.saga';
@@ -23,7 +24,7 @@ export class ExportApplicationModule {
       module: ExportApplicationModule,
       imports: [
         CqrsModule,
-        TypeOrmModule.forFeature([Project, Scenario]),
+        TypeOrmModule.forFeature([Project, Scenario, UsersProjectsApiEntity]),
         ...(adapters ?? []),
       ],
       providers: [

--- a/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-project.handler.spec.ts
@@ -11,6 +11,7 @@ import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { v4 } from 'uuid';
+import { UsersProjectsApiEntity } from '../../../access-control/projects-acl/entity/users-projects.api.entity';
 import { Project } from '../../../projects/project.api.entity';
 import { MemoryExportRepo } from '../adapters/memory-export.repository';
 import {
@@ -63,6 +64,10 @@ const getFixtures = async () => {
       {
         provide: getRepositoryToken(Project),
         useClass: FakeProjectRepoProvider,
+      },
+      {
+        provide: getRepositoryToken(UsersProjectsApiEntity),
+        useClass: FakeUserProjectsRepoProvider,
       },
       ExportProjectHandler,
     ],
@@ -162,5 +167,10 @@ class FakeProjectRepoProvider {
     return { organizationId: v4() };
   }
 
+  save() {}
+}
+
+@Injectable()
+class FakeUserProjectsRepoProvider {
   save() {}
 }

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-metadata.piece-importer.ts
@@ -38,14 +38,14 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
     return id;
   }
 
-  private createProject(
+  private async createProject(
     em: EntityManager,
     projectId: string,
     organizationId: string,
     data: ProjectMetadataContent,
     ownerId: string,
   ) {
-    return em
+    await em
       .createQueryBuilder()
       .insert()
       .into(`projects`)
@@ -57,6 +57,24 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
         planning_unit_grid_shape: data.planningUnitGridShape,
         metadata: data.metadata,
         created_by: ownerId,
+      })
+      .execute();
+
+    await em
+      .createQueryBuilder()
+      .insert()
+      .into(`users_projects`)
+      .values({
+        user_id: ownerId,
+        project_id: projectId,
+        // It would be great to use ProjectRoles enum instead of having
+        // the role hardcoded. The thing is that Geoprocessing code shouldn't depend
+        // directly on elements of Api code, so there were two options:
+        // - Move ProjectRoles enum to libs package
+        // - Harcode the rol
+        // We took the second approach because we are only referencing values from that enum
+        // here
+        role_id: 'project_owner',
       })
       .execute();
   }
@@ -145,24 +163,6 @@ export class ProjectMetadataPieceImporter implements ImportPieceProcessor {
         .insert()
         .into('project_blms')
         .values({ id: projectId, ...projectMetadata.blmRange })
-        .execute();
-
-      await em
-        .createQueryBuilder()
-        .insert()
-        .into(`users_projects`)
-        .values({
-          user_id: ownerId,
-          project_id: projectId,
-          // It would be great to use ProjectRoles enum instead of having
-          // the role hardcoded. The thing is that Geoprocessing code shouldn't depend
-          // directly on elements of Api code, so there were two options:
-          // - Move ProjectRoles enum to libs package
-          // - Harcode the rol
-          // We took the second approach because we are only referencing values from that enum
-          // here
-          role_id: 'project_owner',
-        })
         .execute();
     });
 


### PR DESCRIPTION
This PR adds logic for giving the user `project_owner` role immediately after a project shell is created when cloning is scheduled

### Feature relevant tickets

[project shell not being returned in the list of projects after starting a cloning process](https://vizzuality.atlassian.net/browse/MARXAN-1528)