### PR TITLE
fix: output scenarios summaries cloning

### DIFF
--- a/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
@@ -2,6 +2,7 @@ import { GeoCloningFilesRepositoryModule } from '@marxan-geoprocessing/modules/c
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScenariosOutputResultsApiEntity } from '../../../../../libs/marxan-output/src';
 import { MarxanExecutionMetadataPieceImporter } from './marxan-execution-metadata.piece-importer';
 import { PlanningAreaCustomPieceImporter } from './planning-area-custom.piece-importer';
 import { PlanningAreaGadmPieceImporter } from './planning-area-gadm.piece-importer';
@@ -19,7 +20,10 @@ import { ScenarioRunResultsPieceImporter } from './scenario-run-results.piece-im
 @Module({
   imports: [
     GeoCloningFilesRepositoryModule,
-    TypeOrmModule.forFeature([], geoprocessingConnections.apiDB),
+    TypeOrmModule.forFeature(
+      [ScenariosOutputResultsApiEntity],
+      geoprocessingConnections.apiDB,
+    ),
   ],
   providers: [
     ProjectMetadataPieceImporter,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-run-results.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-run-results.ts
@@ -12,7 +12,24 @@ export type MarxanRunResultsContent = {
   puid: number;
 };
 
+export type OutputScenarioSummary = {
+  runId?: number;
+  scoreValue?: number;
+  costValue?: number;
+  planningUnits?: number;
+  connectivity?: number;
+  connectivityTotal?: number;
+  mpm?: number;
+  penaltyValue?: number;
+  shortfall?: number;
+  missingValues?: number;
+  metadata?: Record<string, unknown>;
+  best?: boolean;
+  distinctFive?: boolean;
+};
+
 export type ScenarioRunResultsContent = {
   blmResults: BlmResultsContent[];
   marxanRunResults: MarxanRunResultsContent[];
+  outputSummaries: OutputScenarioSummary[];
 };


### PR DESCRIPTION
This PR adds `output_scenarios_summaries` data to cloning process

### Feature relevant tickets

[BE - export/import/clone solutions data missing](https://vizzuality.atlassian.net/browse/MARXAN-1535)