### PR TITLE
fix(front): BLM chart improvements [MARXAN-1392]

### DIFF
--- a/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
+++ b/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
@@ -65,6 +65,9 @@ export const BlmChart: React.FC<BlmChartProps> = ({
   onChange,
 }: BlmChartProps) => {
   const containerRef: React.MutableRefObject<HTMLDivElement> = useRef(null);
+  const blmCostValues = useMemo(() => {
+    return data?.map((v) => v.cost);
+  }, [data]);
 
   const [{ width, height }, setDimensions] = useState({ width: 0, height: 0 });
 
@@ -145,7 +148,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 className="text-xs text-white fill-current"
               >
-                Less
+                {Math.min(...blmCostValues)}
               </text>
             </g>
             <g transform={`translate(${(xScale(xDomain[0]) + xScale(xDomain[1])) / 2} ${yScale(yDomain[0]) + X_AXIS_HEIGHT})`}>
@@ -165,18 +168,11 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 textAnchor="end"
               >
-                More
+                {Math.max(...blmCostValues)}
               </text>
             </g>
           </g>
           {/* Area */}
-          <defs>
-            <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="35%" stopColor="#FFFFFF4D" />
-              <stop offset="55%" stopColor="#FFFFFF33" />
-              <stop offset="100%" stopColor="transparent" />
-            </linearGradient>
-          </defs>
           <path
             d={areaGenerator(data)}
             fill="url(#gradient)"
@@ -197,8 +193,8 @@ export const BlmChart: React.FC<BlmChartProps> = ({
               >
                 <Tooltip
                   content={(
-                    <div className="flex flex-col bg-white p-2 rounded-md">
-                      <div className="flex justify-between text-xs space-x-2">
+                    <div className="flex flex-col p-2 bg-white rounded-md">
+                      <div className="flex justify-between space-x-2 text-xs">
                         <div>
                           <span className="text-gray-600">Boundary Length:</span>
                         </div>
@@ -206,7 +202,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                           {`${blmFormat(boundaryLength)}`}
                         </div>
                       </div>
-                      <div className="flex justify-between text-xs space-x-2">
+                      <div className="flex justify-between space-x-2 text-xs">
                         <div>
                           <span className="text-gray-600">Cost:</span>
                         </div>
@@ -214,7 +210,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                           {`${blmFormat(cost)}`}
                         </div>
                       </div>
-                      <div className="flex justify-between text-xs space-x-2">
+                      <div className="flex justify-between space-x-2 text-xs">
                         <div>
                           <span className="text-gray-600">BLM:</span>
                         </div>

--- a/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
+++ b/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
@@ -4,7 +4,7 @@ import React, {
 
 import classnames from 'classnames';
 import {
-  scaleLinear, line, area,
+  scaleLinear, line, area, format,
 } from 'd3';
 import { blmFormat } from 'utils/units';
 
@@ -69,6 +69,9 @@ export const BlmChart: React.FC<BlmChartProps> = ({
   const costValues = useMemo(() => {
     return data?.map((v) => v.cost);
   }, [data]);
+
+  const maxCostValue = format('.3~s')(Math.ceil(Math.max(...costValues) / 1000) * 1000);
+  const minCostValue = format('.3~s')(Math.floor(Math.min(...costValues) / 1000) * 1000);
 
   const [{ width, height }, setDimensions] = useState({ width: 0, height: 0 });
 
@@ -149,7 +152,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 className="text-xs text-white fill-current"
               >
-                {Math.floor(Math.min(...costValues) / 1000) * 1000}
+                {minCostValue}
               </text>
             </g>
             <g transform={`translate(${(xScale(xDomain[0]) + xScale(xDomain[1])) / 2} ${yScale(yDomain[0]) + X_AXIS_HEIGHT})`}>
@@ -169,7 +172,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 textAnchor="end"
               >
-                {Math.ceil(Math.max(...costValues) / 1000) * 1000}
+                {maxCostValue}
               </text>
             </g>
           </g>

--- a/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
+++ b/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
@@ -65,7 +65,8 @@ export const BlmChart: React.FC<BlmChartProps> = ({
   onChange,
 }: BlmChartProps) => {
   const containerRef: React.MutableRefObject<HTMLDivElement> = useRef(null);
-  const blmCostValues = useMemo(() => {
+
+  const costValues = useMemo(() => {
     return data?.map((v) => v.cost);
   }, [data]);
 
@@ -148,7 +149,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 className="text-xs text-white fill-current"
               >
-                {Math.floor(Math.min(...blmCostValues) / 1000) * 1000}
+                {Math.floor(Math.min(...costValues) / 1000) * 1000}
               </text>
             </g>
             <g transform={`translate(${(xScale(xDomain[0]) + xScale(xDomain[1])) / 2} ${yScale(yDomain[0]) + X_AXIS_HEIGHT})`}>
@@ -168,7 +169,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 textAnchor="end"
               >
-                {Math.ceil(Math.max(...blmCostValues) / 1000) * 1000}
+                {Math.ceil(Math.max(...costValues) / 1000) * 1000}
               </text>
             </g>
           </g>

--- a/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
+++ b/app/layout/scenarios/edit/parameters/blm-calibration/chart/component.tsx
@@ -148,7 +148,7 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 className="text-xs text-white fill-current"
               >
-                {Math.min(...blmCostValues)}
+                {Math.floor(Math.min(...blmCostValues) / 1000) * 1000}
               </text>
             </g>
             <g transform={`translate(${(xScale(xDomain[0]) + xScale(xDomain[1])) / 2} ${yScale(yDomain[0]) + X_AXIS_HEIGHT})`}>
@@ -168,11 +168,18 @@ export const BlmChart: React.FC<BlmChartProps> = ({
                 y="0"
                 textAnchor="end"
               >
-                {Math.max(...blmCostValues)}
+                {Math.ceil(Math.max(...blmCostValues) / 1000) * 1000}
               </text>
             </g>
           </g>
           {/* Area */}
+          <defs>
+            <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="35%" stopColor="#FFFFFF4D" />
+              <stop offset="55%" stopColor="#FFFFFF33" />
+              <stop offset="100%" stopColor="transparent" />
+            </linearGradient>
+          </defs>
           <path
             d={areaGenerator(data)}
             fill="url(#gradient)"

--- a/app/layout/scenarios/edit/parameters/blm-calibration/results/component.tsx
+++ b/app/layout/scenarios/edit/parameters/blm-calibration/results/component.tsx
@@ -150,7 +150,7 @@ export const ScenariosBlmResults: React.FC<ScenariosBlmResultsProps> = ({
                       >
                         {(fprops) => (
                           <Field className="w-44" id="blmCalibration" {...fprops}>
-                            <Label id="blmCalibration" theme="dark" className="text-xs uppercase flex items-center space-x-2">
+                            <Label id="blmCalibration" theme="dark" className="flex items-center space-x-2 text-xs uppercase">
                               <span>BLM:</span>
 
                               <InfoButton
@@ -218,7 +218,7 @@ export const ScenariosBlmResults: React.FC<ScenariosBlmResultsProps> = ({
                     </div>
                   </div>
 
-                  <div className="grid gap-5 grid-cols-3 mt-10">
+                  <div className="grid grid-cols-3 gap-5 mt-10">
                     {calibrationResultsData.map((result) => {
                       const selected = result.blmValue === values.blmCalibration;
 
@@ -236,12 +236,9 @@ export const ScenariosBlmResults: React.FC<ScenariosBlmResultsProps> = ({
                   </div>
 
                   <div>
-                    <div className="flex flex-col mt-8 space-y-2">
-                      <h3 className="text-sm font-bold text-white">Boundary Length</h3>
-                      <p className="text-xs text-white">
-                        More
-                      </p>
-                    </div>
+
+                    <h3 className="mt-10 mb-4 text-sm font-bold text-white">Boundary Length</h3>
+
                     <div className="w-full h-32">
                       <BlmChart
                         data={calibrationResultsData.sort((a, b) => a.cost - b.cost)}
@@ -255,7 +252,7 @@ export const ScenariosBlmResults: React.FC<ScenariosBlmResultsProps> = ({
 
                   <Loading
                     visible={submitting}
-                    className="absolute z-10 top-0 left-0 flex items-center justify-center w-full h-full text-white bg-gray-700 bg-opacity-90"
+                    className="absolute top-0 left-0 z-10 flex items-center justify-center w-full h-full text-white bg-gray-700 bg-opacity-90"
                     iconClassName="w-10 h-10"
                   />
                 </form>


### PR DESCRIPTION
## BLM chart improvements

### Overview
- [x] Add min and max cost values to X axis BLM chart 
- [ ] There is only space to "more" value on yAxis boundaryLength Value and it seems a little bit confused so i decided not to included.
- [ ] Also, removed gradient seems not to be a good idea as it keeps the chart empty with no reference lines.

### Feature relevant tickets

[MARXAN-1392](https://vizzuality.atlassian.net/browse/MARXAN-1392)

---
