### PR TITLE
Feat/marxan 1557 mark legacy project import piece as failed handler

### DIFF
--- a/api/apps/api/src/modules/legacy-project-import/application/legacy-project-import.application.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/legacy-project-import.application.module.ts
@@ -15,6 +15,9 @@ import { LegacyProjectImportComponentEntity } from '../infra/entities/legacy-pro
 import { LegacyProjectImportFileEntity } from '../infra/entities/legacy-project-import-file.api.entity';
 import { LegacyProjectImportEntity } from '../infra/entities/legacy-project-import.api.entity';
 import { LegacyProjectImportTypeormRepository } from '../infra/legacy-project-import-typeorm.repository';
+import { MarkLegacyProjectImportAsFailedHandler } from './mark-legacy-project-import-as-failed.handler';
+import { MarkLegacyProjectImportPieceAsFailedHandler } from './mark-legacy-project-import-piece-as-failed.handler';
+import { StartLegacyProjectImportHandler } from './start-legacy-project-import.handler';
 
 @Module({
   imports: [
@@ -47,6 +50,9 @@ import { LegacyProjectImportTypeormRepository } from '../infra/legacy-project-im
         return path.endsWith('/') ? path.substring(0, path.length - 1) : path;
       },
     },
+    MarkLegacyProjectImportAsFailedHandler,
+    MarkLegacyProjectImportPieceAsFailedHandler,
+    StartLegacyProjectImportHandler,
   ],
 })
 export class LegacyProjectImportApplicationModule {}

--- a/api/apps/api/src/modules/legacy-project-import/application/legacy-project-import.application.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/legacy-project-import.application.module.ts
@@ -2,14 +2,15 @@ import { Organization } from '@marxan-api/modules/organizations/organization.api
 import { Project } from '@marxan-api/modules/projects/project.api.entity';
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import {
+  LegacyProjectImportFilesLocalRepository,
   LegacyProjectImportFilesRepository,
   LegacyProjectImportStoragePath,
-  LegacyProjectImportFilesLocalRepository,
 } from '@marxan/legacy-project-import';
-import { Module } from '@nestjs/common';
+import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppConfig } from '../../../utils/config.utils';
+import { ApiEventsModule } from '../../api-events';
 import { LegacyProjectImportRepository } from '../domain/legacy-project-import/legacy-project-import.repository';
 import { LegacyProjectImportComponentEntity } from '../infra/entities/legacy-project-import-component.api.entity';
 import { LegacyProjectImportFileEntity } from '../infra/entities/legacy-project-import-file.api.entity';
@@ -21,6 +22,7 @@ import { StartLegacyProjectImportHandler } from './start-legacy-project-import.h
 
 @Module({
   imports: [
+    ApiEventsModule,
     CqrsModule,
     TypeOrmModule.forFeature([
       LegacyProjectImportEntity,
@@ -53,6 +55,7 @@ import { StartLegacyProjectImportHandler } from './start-legacy-project-import.h
     MarkLegacyProjectImportAsFailedHandler,
     MarkLegacyProjectImportPieceAsFailedHandler,
     StartLegacyProjectImportHandler,
+    { provide: Logger, useClass: Logger, scope: Scope.TRANSIENT },
   ],
 })
 export class LegacyProjectImportApplicationModule {}

--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-failed.command.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-failed.command.ts
@@ -1,0 +1,11 @@
+import { ResourceId } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
+
+export class MarkLegacyProjectImportAsFailed extends Command<void> {
+  constructor(
+    public readonly projectId: ResourceId,
+    public readonly reason: string,
+  ) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-failed.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-failed.handler.ts
@@ -1,0 +1,72 @@
+import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Logger, NotFoundException } from '@nestjs/common';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { isLeft } from 'fp-ts/lib/Either';
+import { ApiEventByTopicAndKind } from '../../api-events/api-event.topic+kind.api.entity';
+import { LegacyProjectImportRepository } from '../domain/legacy-project-import/legacy-project-import.repository';
+import { MarkLegacyProjectImportAsFailed } from './mark-legacy-project-import-as-failed.command';
+
+@CommandHandler(MarkLegacyProjectImportAsFailed)
+export class MarkLegacyProjectImportAsFailedHandler
+  implements IInferredCommandHandler<MarkLegacyProjectImportAsFailed> {
+  constructor(
+    private readonly apiEvents: ApiEventsService,
+    private readonly legacyProjectImportRepository: LegacyProjectImportRepository,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(MarkLegacyProjectImportAsFailedHandler.name);
+  }
+
+  async findPreviousEvent(
+    kind: API_EVENT_KINDS,
+    topic: string,
+  ): Promise<ApiEventByTopicAndKind | undefined> {
+    try {
+      const previousEvent = await this.apiEvents.getLatestEventForTopic({
+        kind,
+        topic,
+      });
+
+      return previousEvent;
+    } catch (err) {
+      if (err instanceof NotFoundException) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  async execute({
+    projectId,
+    reason,
+  }: MarkLegacyProjectImportAsFailed): Promise<void> {
+    const legacyProjectImport = await this.legacyProjectImportRepository.find(
+      projectId,
+    );
+
+    if (isLeft(legacyProjectImport)) {
+      this.logger.error(
+        `Legacy project import for project with ID ${projectId.value} not found. Legacy project import cannot be marked as failed`,
+      );
+      return;
+    }
+    const { ownerId, scenarioId } = legacyProjectImport.right.toSnapshot();
+    const kind = API_EVENT_KINDS.project__legacy__import__failed__v1__alpha;
+    const topic = projectId.value;
+
+    const previousEvent = await this.findPreviousEvent(kind, topic);
+    if (previousEvent) return;
+
+    await this.apiEvents.createIfNotExists({
+      kind,
+      topic,
+      data: {
+        projectId: topic,
+        scenarioId,
+        ownerId,
+        reason,
+      },
+    });
+  }
+}

--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.handler.ts
@@ -1,0 +1,101 @@
+import { Logger } from '@nestjs/common';
+import {
+  CommandBus,
+  CommandHandler,
+  EventPublisher,
+  IInferredCommandHandler,
+} from '@nestjs/cqrs';
+import { ResourceId } from '@marxan/cloning/domain';
+import { LegacyProjectImportRepository } from '../domain/legacy-project-import/legacy-project-import.repository';
+import { MarkLegacyProjectImportPieceAsFailed } from './mark-legacy-project-import-piece-as-failed.command';
+import { MarkLegacyProjectImportAsFailed } from './mark-legacy-project-import-as-failed.command';
+import {
+  LegacyProjectImport,
+  legacyProjectImportComponentAlreadyFailed,
+  legacyProjectImportComponentNotFound,
+} from '../domain/legacy-project-import/legacy-project-import';
+import { isLeft } from 'fp-ts/lib/Either';
+
+@CommandHandler(MarkLegacyProjectImportPieceAsFailed)
+export class MarkLegacyProjectImportPieceAsFailedHandler
+  implements IInferredCommandHandler<MarkLegacyProjectImportPieceAsFailed> {
+  constructor(
+    private readonly legacyProjectImportRepository: LegacyProjectImportRepository,
+    private readonly commandBus: CommandBus,
+    private readonly eventPublisher: EventPublisher,
+    private readonly logger: Logger,
+  ) {}
+
+  private async markLegacyProjectImportAsFailed(
+    projectId: ResourceId,
+    reason: string,
+  ): Promise<void> {
+    this.logger.error(reason);
+    await this.commandBus.execute(
+      new MarkLegacyProjectImportAsFailed(projectId, reason),
+    );
+  }
+
+  async execute({
+    errors,
+    legacyProjectImportComponentId,
+    projectId,
+    warnings,
+  }: MarkLegacyProjectImportPieceAsFailed): Promise<void> {
+    const result = await this.legacyProjectImportRepository.transaction(
+      async (repo) => {
+        const legacyProjectImport = await repo.find(projectId);
+
+        if (isLeft(legacyProjectImport)) {
+          await this.markLegacyProjectImportAsFailed(
+            projectId,
+            `Could not find legacy project import with project ID ${projectId.value} to mark piece ${legacyProjectImportComponentId.value} as failed`,
+          );
+          return;
+        }
+
+        const aggregate = this.eventPublisher.mergeObjectContext(
+          legacyProjectImport.right,
+        );
+
+        const result = aggregate.markPieceAsFailed(
+          legacyProjectImportComponentId,
+          errors,
+          warnings,
+        );
+
+        if (isLeft(result)) {
+          switch (result.left) {
+            case legacyProjectImportComponentNotFound:
+              await this.markLegacyProjectImportAsFailed(
+                projectId,
+                `Could not find piece with ID: ${legacyProjectImportComponentId.value} of legacy project import with project ID: ${projectId.value}`,
+              );
+              return;
+            case legacyProjectImportComponentAlreadyFailed:
+              this.logger.warn(
+                `Component with id ${legacyProjectImportComponentId.value} was already marked as failed`,
+              );
+              return;
+          }
+        }
+
+        const saveResult = await repo.save(aggregate);
+
+        if (isLeft(saveResult)) {
+          await this.markLegacyProjectImportAsFailed(
+            projectId,
+            `Could not save legacy project import with project ID: ${projectId.value}`,
+          );
+          return;
+        }
+
+        return aggregate;
+      },
+    );
+
+    if (result instanceof LegacyProjectImport) {
+      result.commit();
+    }
+  }
+}

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
@@ -183,13 +183,15 @@ export class LegacyProjectImport extends AggregateRoot {
 
   markPieceAsFailed(
     pieceId: LegacyProjectImportComponentId,
+    errors: string[] = [],
+    warnings: string[] = [],
   ): Either<MarkLegacyProjectImportPieceAsFailedErrors, true> {
     const piece = this.pieces.find((pc) => pc.id.value === pieceId.value);
     if (!piece) return left(legacyProjectImportComponentNotFound);
     if (piece.hasFailed())
       return left(legacyProjectImportComponentAlreadyFailed);
 
-    piece.markAsFailed();
+    piece.markAsFailed(errors, warnings);
 
     const hasThisBatchFinished = this.hasBatchFinished(piece.order);
     const hasThisBatchFailed = this.hasBatchFailed(piece.order);
@@ -203,6 +205,7 @@ export class LegacyProjectImport extends AggregateRoot {
 
   completePiece(
     pieceId: LegacyProjectImportComponentId,
+    warnings?: string[],
   ): Either<
     CompleteLegacyProjectImportPieceErrors,
     CompleteLegacyProjectImportPieceSuccess
@@ -216,7 +219,7 @@ export class LegacyProjectImport extends AggregateRoot {
 
     this.apply(new LegacyProjectImportPieceImported(this.id, pieceId));
 
-    pieceToComplete.complete();
+    pieceToComplete.complete(warnings);
 
     const isThisTheLastBatch = this.isLastBatch(pieceToComplete.order);
     const hasThisBatchFinished = this.hasBatchFinished(pieceToComplete.order);


### PR DESCRIPTION
This PR adds `MarkLegacyProjectImportPieceAsFailedHandler`

### Feature relevant tickets

[Implement command handler for marking a legacy project import piece as failed](https://vizzuality.atlassian.net/browse/MARXAN-1557)