### PR TITLE
fix(front): remove firefox blm input margin [MARXAN-1571]

### DIFF
--- a/app/layout/scenarios/edit/parameters/blm-calibration/component.tsx
+++ b/app/layout/scenarios/edit/parameters/blm-calibration/component.tsx
@@ -138,7 +138,7 @@ export const ScenariosBLMCalibration: React.FC<ScenariosBLMCalibrationProps> = (
                     iconClassName="w-10 h-10 text-primary-500"
                   />
 
-                  <div className="flex justify-between space-x-10">
+                  <div className="grid justify-between w-full grid-cols-2 gap-x-10">
                     <div className="flex items-center flex-grow flex-shrink-0">
                       <Label theme="dark" className="mr-3 text-xs uppercase">From</Label>
                       <div className="flex flex-col items-end flex-grow">


### PR DESCRIPTION
## Remove firefox blm input margin

### Overview

We still have the input arrows that are seen in Firefox but I have decided to leave them that way so as not to influence the rest of the project or insert css classes

### Feature relevant tickets

[MARXAN-1571](https://vizzuality.atlassian.net/browse/MARXAN-1571)
