### PR TITLE
fix: added export failed api event reason

### DIFF
--- a/api/apps/api/src/modules/clone/export/application/finalize-archive.handler.ts
+++ b/api/apps/api/src/modules/clone/export/application/finalize-archive.handler.ts
@@ -51,7 +51,7 @@ export class FinalizeArchiveHandler
   ): Promise<void> {
     this.logger.error(error);
 
-    await this.commandBus.execute(new MarkExportAsFailed(exportId));
+    await this.commandBus.execute(new MarkExportAsFailed(exportId, error));
   }
 
   private async generateManifestAndSignatureFiles(
@@ -121,7 +121,7 @@ export class FinalizeArchiveHandler
     if (!exportInstance) {
       this.logErrorAndMarkExportAsFailed(
         exportId,
-        `${FinalizeArchiveHandler.name} could not find export ${exportId.value} to complete archive.`,
+        `${FinalizeArchiveHandler.name} could not find export ${exportId} to complete archive.`,
       );
       return;
     }
@@ -160,7 +160,7 @@ export class FinalizeArchiveHandler
     if (isLeft(archiveResult)) {
       this.logErrorAndMarkExportAsFailed(
         exportId,
-        `${FinalizeArchiveHandler.name} could not create archive for ${exportId.value}.`,
+        `${FinalizeArchiveHandler.name} could not create archive for ${exportId}.`,
       );
       return;
     }
@@ -174,7 +174,7 @@ export class FinalizeArchiveHandler
     if (isLeft(result)) {
       this.logErrorAndMarkExportAsFailed(
         exportId,
-        `${FinalizeArchiveHandler.name} tried to complete Export with archive but pieces were not ready.`,
+        `${FinalizeArchiveHandler.name} tried to complete export with id ${exportId} but pieces were not ready.`,
       );
       return;
     }

--- a/api/apps/api/src/modules/clone/export/domain/export/export.id.ts
+++ b/api/apps/api/src/modules/clone/export/domain/export/export.id.ts
@@ -7,4 +7,8 @@ export class ExportId {
   static create(): ExportId {
     return new ExportId(v4());
   }
+
+  toString(): string {
+    return this.value;
+  }
 }

--- a/api/apps/api/src/modules/clone/infra/export/export-piece-failed.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/export/export-piece-failed.saga.ts
@@ -14,7 +14,10 @@ export class ExportPieceFailedSaga {
       ofType(ExportPieceFailed),
       mergeMap((event) =>
         of(
-          new MarkExportAsFailed(event.exportId),
+          new MarkExportAsFailed(
+            event.exportId,
+            `Piece with id ${event.componentId} failed`,
+          ),
           new CancelExportPendingJobs(event.exportId),
         ),
       ),

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.command.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.command.ts
@@ -2,7 +2,10 @@ import { ExportId } from '@marxan-api/modules/clone';
 import { Command } from '@nestjs-architects/typed-cqrs';
 
 export class MarkExportAsFailed extends Command<void> {
-  constructor(public readonly exportId: ExportId) {
+  constructor(
+    public readonly exportId: ExportId,
+    public readonly reason?: string,
+  ) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/export/mark-export-as-failed.handler.ts
@@ -26,7 +26,7 @@ export class MarkExportAsFailedHandler
     this.logger.setContext(MarkExportAsFailedHandler.name);
   }
 
-  async execute({ exportId }: MarkExportAsFailed): Promise<void> {
+  async execute({ exportId, reason }: MarkExportAsFailed): Promise<void> {
     const exportInstance = await this.exportRepository.find(exportId);
 
     if (!exportInstance) {
@@ -45,6 +45,7 @@ export class MarkExportAsFailedHandler
         exportId: exportId.value,
         resourceId: resourceId.value,
         resourceKind,
+        reason,
       },
     });
 
@@ -58,6 +59,7 @@ export class MarkExportAsFailedHandler
         data: {
           resourceId: importResourceId,
           resourceKind,
+          reason: 'Export failed' + reason ? ` - ${reason}` : '',
         },
       });
     }

--- a/api/libs/cloning/src/domain/component.id.ts
+++ b/api/libs/cloning/src/domain/component.id.ts
@@ -11,4 +11,8 @@ export class ComponentId {
   equals(other: ComponentId): boolean {
     return this.value === other.value;
   }
+
+  toString(): string {
+    return this.value;
+  }
 }


### PR DESCRIPTION
This PR adds `reason` property to export failed api events

### Feature relevant tickets

[Download project doesn't seem to work](https://vizzuality.atlassian.net/browse/MARXAN-1583)

When reviewing api events for the project of the issue we found that we were not storing the reason of the export failed api event. All piece exporters succeeded but an export failed api event was being emitted.