### PR TITLE
Feat/marxan 1560 legacy project import batch failed saga

### DIFF
--- a/api/apps/api/src/modules/legacy-project-import/infra/failed-legacy-project-import-db-cleanup-queue.provider.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/failed-legacy-project-import-db-cleanup-queue.provider.ts
@@ -1,0 +1,30 @@
+import { QueueBuilder } from '@marxan-api/modules/queue';
+import {
+  FailedLegacyProjectImportDbCleanupJobInput,
+  FailedLegacyProjectImportDbCleanupJobOutput,
+  failedLegacyProjectImportDbCleanupQueueName,
+} from '@marxan/legacy-project-import';
+import { FactoryProvider } from '@nestjs/common';
+import { Queue } from 'bullmq';
+
+export const failedLegacyProjectImportDbCleanupQueueToken = Symbol(
+  'failed legacy project import db cleanup queue token',
+);
+
+export const failedLegacyProjectImportDbCleanupQueueProvider: FactoryProvider<
+  Queue<
+    FailedLegacyProjectImportDbCleanupJobInput,
+    FailedLegacyProjectImportDbCleanupJobOutput
+  >
+> = {
+  provide: failedLegacyProjectImportDbCleanupQueueToken,
+  useFactory: (
+    queueBuilder: QueueBuilder<
+      FailedLegacyProjectImportDbCleanupJobInput,
+      FailedLegacyProjectImportDbCleanupJobOutput
+    >,
+  ) => {
+    return queueBuilder.buildQueue(failedLegacyProjectImportDbCleanupQueueName);
+  },
+  inject: [QueueBuilder],
+};

--- a/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import-batch-failed.saga.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import-batch-failed.saga.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable, of } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import { MarkLegacyProjectImportAsFailed } from '../application/mark-legacy-project-import-as-failed.command';
+import { LegacyProjectImportBatchFailed } from '../domain/events/legacy-project-import-batch-failed.event';
+import { ScheduleDbCleanupForFailedLegacyProjectImport } from './schedule-db-cleanup-for-failed-legacy-project-import.command';
+
+@Injectable()
+export class LegacyProjectImportBatchFailedSaga {
+  @Saga()
+  saga = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(LegacyProjectImportBatchFailed),
+      mergeMap((event) =>
+        of(
+          new MarkLegacyProjectImportAsFailed(
+            event.projectId,
+            `${event.batchNumber} batch contains failed pieces`,
+          ),
+          new ScheduleDbCleanupForFailedLegacyProjectImport(event.projectId),
+        ),
+      ),
+    );
+}

--- a/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
@@ -2,10 +2,11 @@ import { ApiEventsModule } from '@marxan-api/modules/api-events';
 import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
+import { LegacyProjectImportBatchFailedSaga } from './legacy-project-import-batch-failed.saga';
 import {
-  importLegacyProjectPieceQueueProvider,
-  importLegacyProjectPiecenQueueEventsProvider,
   importLegacyProjectPieceEventsFactoryProvider,
+  importLegacyProjectPiecenQueueEventsProvider,
+  importLegacyProjectPieceQueueProvider,
 } from './legacy-project-import-queue.provider';
 
 @Module({
@@ -14,6 +15,7 @@ import {
     importLegacyProjectPieceQueueProvider,
     importLegacyProjectPiecenQueueEventsProvider,
     importLegacyProjectPieceEventsFactoryProvider,
+    LegacyProjectImportBatchFailedSaga,
     {
       provide: Logger,
       useClass: Logger,

--- a/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
@@ -2,12 +2,14 @@ import { ApiEventsModule } from '@marxan-api/modules/api-events';
 import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
+import { failedLegacyProjectImportDbCleanupQueueProvider } from './failed-legacy-project-import-db-cleanup-queue.provider';
 import { LegacyProjectImportBatchFailedSaga } from './legacy-project-import-batch-failed.saga';
 import {
   importLegacyProjectPieceEventsFactoryProvider,
   importLegacyProjectPiecenQueueEventsProvider,
   importLegacyProjectPieceQueueProvider,
 } from './legacy-project-import-queue.provider';
+import { ScheduleDbCleanupForFailedLegacyProjectImportHandler } from './schedule-db-cleanup-for-failed-legacy-project-import.handler';
 
 @Module({
   imports: [ApiEventsModule, QueueApiEventsModule, CqrsModule],
@@ -15,7 +17,9 @@ import {
     importLegacyProjectPieceQueueProvider,
     importLegacyProjectPiecenQueueEventsProvider,
     importLegacyProjectPieceEventsFactoryProvider,
+    failedLegacyProjectImportDbCleanupQueueProvider,
     LegacyProjectImportBatchFailedSaga,
+    ScheduleDbCleanupForFailedLegacyProjectImportHandler,
     {
       provide: Logger,
       useClass: Logger,

--- a/api/apps/api/src/modules/legacy-project-import/infra/schedule-db-cleanup-for-failed-legacy-project-import.command.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/schedule-db-cleanup-for-failed-legacy-project-import.command.ts
@@ -1,0 +1,8 @@
+import { ResourceId } from '@marxan/cloning/domain';
+import { Command } from '@nestjs-architects/typed-cqrs';
+
+export class ScheduleDbCleanupForFailedLegacyProjectImport extends Command<void> {
+  constructor(public readonly projectId: ResourceId) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/legacy-project-import/infra/schedule-db-cleanup-for-failed-legacy-project-import.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/schedule-db-cleanup-for-failed-legacy-project-import.handler.ts
@@ -1,0 +1,39 @@
+import { FailedLegacyProjectImportDbCleanupJobInput } from '@marxan/legacy-project-import';
+import { Inject, Logger } from '@nestjs/common';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { Queue } from 'bullmq';
+import { failedLegacyProjectImportDbCleanupQueueToken } from './failed-legacy-project-import-db-cleanup-queue.provider';
+import { ScheduleDbCleanupForFailedLegacyProjectImport } from './schedule-db-cleanup-for-failed-legacy-project-import.command';
+
+@CommandHandler(ScheduleDbCleanupForFailedLegacyProjectImport)
+export class ScheduleDbCleanupForFailedLegacyProjectImportHandler
+  implements
+    IInferredCommandHandler<ScheduleDbCleanupForFailedLegacyProjectImport> {
+  constructor(
+    @Inject(failedLegacyProjectImportDbCleanupQueueToken)
+    private readonly queue: Queue<FailedLegacyProjectImportDbCleanupJobInput>,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(
+      ScheduleDbCleanupForFailedLegacyProjectImportHandler.name,
+    );
+  }
+
+  async execute({
+    projectId,
+  }: ScheduleDbCleanupForFailedLegacyProjectImport): Promise<void> {
+    const job = await this.queue.add(
+      `failed-legacy-project-import-db-cleanup`,
+      {
+        projectId: projectId.value,
+      },
+    );
+
+    if (!job) {
+      this.logger.error(
+        `failed-legacy-project-import-db-cleanup job couldn't be added to queue`,
+      );
+      return;
+    }
+  }
+}

--- a/api/libs/legacy-project-import/src/failed-legacy-project-import-db-cleanup-queue-name.ts
+++ b/api/libs/legacy-project-import/src/failed-legacy-project-import-db-cleanup-queue-name.ts
@@ -1,0 +1,2 @@
+export const failedLegacyProjectImportDbCleanupQueueName =
+  'failed-legacy-project-import-db-cleanup';

--- a/api/libs/legacy-project-import/src/index.ts
+++ b/api/libs/legacy-project-import/src/index.ts
@@ -1,6 +1,13 @@
 export * from './domain';
 export * from './infra';
-export { LegacyProjectImportJobInput } from './job-input';
-export { LegacyProjectImportJobOutput } from './job-output';
+export {
+  LegacyProjectImportJobInput,
+  FailedLegacyProjectImportDbCleanupJobInput,
+} from './job-input';
+export {
+  LegacyProjectImportJobOutput,
+  FailedLegacyProjectImportDbCleanupJobOutput,
+} from './job-output';
 export { LegacyProjectImportPieceProcessor } from './legacy-project-import-piece-processor.port';
 export { legacyProjectImportQueueName } from './legacy-project-import-queue-name';
+export { failedLegacyProjectImportDbCleanupQueueName } from './failed-legacy-project-import-db-cleanup-queue-name';

--- a/api/libs/legacy-project-import/src/job-input.ts
+++ b/api/libs/legacy-project-import/src/job-input.ts
@@ -9,3 +9,7 @@ export interface LegacyProjectImportJobInput {
   readonly scenarioId: string;
   readonly piece: LegacyProjectImportPiece;
 }
+
+export interface FailedLegacyProjectImportDbCleanupJobInput {
+  readonly projectId: string;
+}

--- a/api/libs/legacy-project-import/src/job-output.ts
+++ b/api/libs/legacy-project-import/src/job-output.ts
@@ -10,3 +10,7 @@ export interface LegacyProjectImportJobOutput {
   readonly piece: LegacyProjectImportPiece;
   readonly warnings?: string[];
 }
+
+export interface FailedLegacyProjectImportDbCleanupJobOutput {
+  readonly projectId: string;
+}


### PR DESCRIPTION
This PR adds `LegacyProjectImportBatchFailedSaga`, it is in charge of sending a `MarkLegacyProjectImportAsFailed` command and scheduling a db cleanup

### Feature relevant tickets

[Implement LegacyProjectImportBatchFailed saga](https://vizzuality.atlassian.net/browse/MARXAN-1560)