### PR TITLE
feat: set proper errors when a job fails

### DIFF
--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.command.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.command.ts
@@ -7,7 +7,6 @@ export class MarkLegacyProjectImportPieceAsFailed extends Command<void> {
     public readonly projectId: ResourceId,
     public readonly legacyProjectImportComponentId: LegacyProjectImportComponentId,
     public readonly errors: string[] = [],
-    public readonly warnings: string[] = [],
   ) {
     super();
   }

--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.handler.ts
@@ -40,7 +40,6 @@ export class MarkLegacyProjectImportPieceAsFailedHandler
     errors,
     legacyProjectImportComponentId,
     projectId,
-    warnings,
   }: MarkLegacyProjectImportPieceAsFailed): Promise<void> {
     const result = await this.legacyProjectImportRepository.transaction(
       async (repo) => {
@@ -61,7 +60,6 @@ export class MarkLegacyProjectImportPieceAsFailedHandler
         const result = aggregate.markPieceAsFailed(
           legacyProjectImportComponentId,
           errors,
-          warnings,
         );
 
         if (isLeft(result)) {

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import-component.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import-component.ts
@@ -1,4 +1,3 @@
-import { ArchiveLocation } from '@marxan/cloning/domain';
 import {
   LegacyProjectImportPiece,
   LegacyProjectImportPieceOrderResolver,
@@ -49,10 +48,9 @@ export class LegacyProjectImportComponent {
     this.warnings.push(...warnings);
   }
 
-  markAsFailed(errors: string[] = [], warnings: string[] = []) {
+  markAsFailed(errors: string[] = []) {
     this.status = this.status.markAsFailed();
     this.errors.push(...errors);
-    this.warnings.push(...warnings);
   }
 
   toSnapshot(): LegacyProjectImportComponentSnapshot {

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
@@ -190,14 +190,13 @@ export class LegacyProjectImport extends AggregateRoot {
   markPieceAsFailed(
     pieceId: LegacyProjectImportComponentId,
     errors: string[] = [],
-    warnings: string[] = [],
   ): Either<MarkLegacyProjectImportPieceAsFailedErrors, true> {
     const piece = this.pieces.find((pc) => pc.id.value === pieceId.value);
     if (!piece) return left(legacyProjectImportComponentNotFound);
     if (piece.hasFailed())
       return left(legacyProjectImportComponentAlreadyFailed);
 
-    piece.markAsFailed(errors, warnings);
+    piece.markAsFailed(errors);
 
     const hasThisBatchFinished = this.hasBatchFinished(piece.order);
     const hasThisBatchFailed = this.hasBatchFailed(piece.order);

--- a/api/apps/api/src/modules/legacy-project-import/infra/import-legacy-project-piece.events-handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/import-legacy-project-piece.events-handler.ts
@@ -99,13 +99,16 @@ export class ImportLegacyProjectPieceEventsHandler
   private async failed(event: EventData<LegacyProjectImportJobInput, unknown>) {
     const { pieceId, projectId } = await event.data;
 
+    const result = await event.result;
+    const errors: string[] = [];
+
+    if (typeof result === 'string') errors.push(result);
+
     await this.commandBus.execute(
       new MarkLegacyProjectImportPieceAsFailed(
         new ResourceId(projectId),
         new LegacyProjectImportComponentId(pieceId),
-        // TODO Obtain actual errors and/or warnings
-        [],
-        [],
+        errors,
       ),
     );
   }

--- a/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
@@ -13,6 +13,7 @@ import {
 import { ScheduleDbCleanupForFailedLegacyProjectImportHandler } from './schedule-db-cleanup-for-failed-legacy-project-import.handler';
 import { LegacyProjectImportRepositoryModule } from './legacy-project-import.repository.module';
 import { ScheduleLegacyProjectImportPieceHandler } from './schedule-legacy-project-import-piece.handler';
+import { ImportLegacyProjectPieceEventsHandler } from './import-legacy-project-piece.events-handler';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ScheduleLegacyProjectImportPieceHandler } from './schedule-legacy-proje
     ScheduleDbCleanupForFailedLegacyProjectImportHandler,
     LegacyProjectImportPieceRequestedSaga,
     ScheduleLegacyProjectImportPieceHandler,
+    ImportLegacyProjectPieceEventsHandler,
     {
       provide: Logger,
       useClass: Logger,

--- a/api/apps/api/src/modules/queue-api-events/adapter.ts
+++ b/api/apps/api/src/modules/queue-api-events/adapter.ts
@@ -50,8 +50,8 @@ export class QueueEventsAdapter<
     queueEvents.on(`completed`, ({ jobId }, eventId) =>
       this.handleFinished(jobId, eventId),
     );
-    queueEvents.on(`failed`, ({ jobId }, eventId) =>
-      this.handleFailed(jobId, eventId),
+    queueEvents.on(`failed`, ({ jobId, failedReason }, eventId) =>
+      this.handleFailed(jobId, eventId, failedReason),
     );
   }
 
@@ -84,7 +84,11 @@ export class QueueEventsAdapter<
     });
   }
 
-  private async handleFailed(jobId: string, eventId: string) {
+  private async handleFailed(
+    jobId: string,
+    eventId: string,
+    failedReason: string,
+  ) {
     const lazyDataGetter = this.createLazyDataGetter();
     const eventDto = await this.eventFactory.createFailedEvent({
       jobId,
@@ -107,7 +111,7 @@ export class QueueEventsAdapter<
         return lazyDataGetter(jobId);
       },
       get result() {
-        return Promise.resolve(undefined);
+        return Promise.resolve(failedReason);
       },
     });
   }


### PR DESCRIPTION
This PR adds logic for properly setting `errors` values of `LegacyProjectImportPieceComponent`s when a legacy project import piece job fails.

### Feature relevant tickets

[Set proper errors and warnings values for MarkLegacyProjectImportPieceAsFailed command when a import legacy project piece job fails](https://vizzuality.atlassian.net/browse/MARXAN-1559)