### PR TITLE
Antimeridian and bbox calc fix

### DIFF
--- a/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
@@ -28,7 +28,7 @@ export class MemoryExportRepo implements ExportRepository {
 
   async findLatestExportsFor(
     projectId: string,
-    limit: number = 5,
+    limit = 5,
     options?: {
       isStandalone?: boolean;
       isFinished?: boolean;

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
@@ -187,7 +187,7 @@ class FakeScenarioRepository {
 
 class FakeExportRepository implements ExportRepository {
   public returnUnfinishedExport = false;
-  public importResourceId: string = '';
+  public importResourceId = '';
 
   async save(exportInstance: Export): Promise<Either<SaveError, Success>> {
     throw new Error('Method not implemented.');

--- a/api/apps/api/src/modules/geo-features/geo-feature-property-sets.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature-property-sets.service.ts
@@ -10,7 +10,7 @@ import { GeoFeature } from './geo-feature.api.entity';
 import { GeoFeaturePropertySet } from './geo-feature.geo.entity';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { BBox } from 'geojson';
-import { antimeridianBbox } from '@marxan/utils/geo/bbox';
+import { antimeridianBbox } from '@marxan/utils/geo';
 
 @Injectable()
 export class GeoFeaturePropertySetService {

--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -28,7 +28,7 @@ import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { v4 } from 'uuid';
 import { UploadShapefileDTO } from '../projects/dto/upload-shapefile.dto';
 import { GeoFeaturesRequestInfo } from './geo-features-request-info';
-import { antimeridianBbox } from '@marxan-geoprocessing/utils/bbox.utils';
+import { antimeridianBbox } from '@marxan/utils/geo/bbox';
 
 const geoFeatureFilterKeyNames = [
   'featureClassName',
@@ -168,10 +168,12 @@ export class GeoFeaturesService extends AppBaseService<
      *
      */
     if (projectId && info?.params?.bbox) {
-      const {westBbox, eastBbox} = antimeridianBbox(
-        [info.params.bbox[1],info.params.bbox[3],
-        info.params.bbox[0],info.params.bbox[2]]
-      );
+      const { westBbox, eastBbox } = antimeridianBbox([
+        info.params.bbox[1],
+        info.params.bbox[3],
+        info.params.bbox[0],
+        info.params.bbox[2],
+      ]);
       const geoFeaturesWithinProjectBbox = await this.geoFeaturesGeometriesRepository
         .createQueryBuilder('geoFeatureGeometries')
         .select('"geoFeatureGeometries"."feature_id"', 'featureId')
@@ -186,10 +188,10 @@ export class GeoFeaturesService extends AppBaseService<
           ST_MakeEnvelope(-180, -90, 0, 90, 4326)),
           "geoFeatureGeometries".the_geom
       ))`,
-      {
-        westBbox: westBbox,
-        eastBbox: eastBbox,
-      },
+          {
+            westBbox: westBbox,
+            eastBbox: eastBbox,
+          },
         )
         .getRawMany()
         .then((result) => result.map((i) => i.featureId))

--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -28,6 +28,7 @@ import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { v4 } from 'uuid';
 import { UploadShapefileDTO } from '../projects/dto/upload-shapefile.dto';
 import { GeoFeaturesRequestInfo } from './geo-features-request-info';
+import { antimeridianBbox } from '@marxan-geoprocessing/utils/bbox.utils';
 
 const geoFeatureFilterKeyNames = [
   'featureClassName',
@@ -167,21 +168,28 @@ export class GeoFeaturesService extends AppBaseService<
      *
      */
     if (projectId && info?.params?.bbox) {
+      const {westBbox, eastBbox} = antimeridianBbox(
+        [info.params.bbox[1],info.params.bbox[3],
+        info.params.bbox[0],info.params.bbox[2]]
+      );
       const geoFeaturesWithinProjectBbox = await this.geoFeaturesGeometriesRepository
         .createQueryBuilder('geoFeatureGeometries')
         .select('"geoFeatureGeometries"."feature_id"', 'featureId')
         .distinctOn(['"geoFeatureGeometries"."feature_id"'])
         .where(
-          `st_intersects(
-        st_makeenvelope(:xmin, :ymin, :xmax, :ymax, 4326),
+          `(st_intersects(
+            st_intersection(st_makeenvelope(:...westBbox, 4326),
+            ST_MakeEnvelope(0, -90, 180, 90, 4326)),
         "geoFeatureGeometries".the_geom
-      )`,
-          {
-            xmin: info.params.bbox[1],
-            ymin: info.params.bbox[3],
-            xmax: info.params.bbox[0],
-            ymax: info.params.bbox[2],
-          },
+      ) or st_intersects(
+        st_intersection(st_makeenvelope(:...eastBbox, 4326),
+          ST_MakeEnvelope(-180, -90, 0, 90, 4326)),
+          "geoFeatureGeometries".the_geom
+      ))`,
+      {
+        westBbox: westBbox,
+        eastBbox: eastBbox,
+      },
         )
         .getRawMany()
         .then((result) => result.map((i) => i.featureId))

--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.command.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.command.ts
@@ -7,7 +7,6 @@ export class MarkLegacyProjectImportPieceAsFailed extends Command<void> {
     public readonly projectId: ResourceId,
     public readonly legacyProjectImportComponentId: LegacyProjectImportComponentId,
     public readonly errors: string[] = [],
-    public readonly warnings: string[] = [],
   ) {
     super();
   }

--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-piece-as-failed.handler.ts
@@ -40,7 +40,6 @@ export class MarkLegacyProjectImportPieceAsFailedHandler
     errors,
     legacyProjectImportComponentId,
     projectId,
-    warnings,
   }: MarkLegacyProjectImportPieceAsFailed): Promise<void> {
     const result = await this.legacyProjectImportRepository.transaction(
       async (repo) => {
@@ -61,7 +60,6 @@ export class MarkLegacyProjectImportPieceAsFailedHandler
         const result = aggregate.markPieceAsFailed(
           legacyProjectImportComponentId,
           errors,
-          warnings,
         );
 
         if (isLeft(result)) {

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import-component.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import-component.ts
@@ -1,4 +1,3 @@
-import { ArchiveLocation } from '@marxan/cloning/domain';
 import {
   LegacyProjectImportPiece,
   LegacyProjectImportPieceOrderResolver,
@@ -49,10 +48,9 @@ export class LegacyProjectImportComponent {
     this.warnings.push(...warnings);
   }
 
-  markAsFailed(errors: string[] = [], warnings: string[] = []) {
+  markAsFailed(errors: string[] = []) {
     this.status = this.status.markAsFailed();
     this.errors.push(...errors);
-    this.warnings.push(...warnings);
   }
 
   toSnapshot(): LegacyProjectImportComponentSnapshot {

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
@@ -190,14 +190,13 @@ export class LegacyProjectImport extends AggregateRoot {
   markPieceAsFailed(
     pieceId: LegacyProjectImportComponentId,
     errors: string[] = [],
-    warnings: string[] = [],
   ): Either<MarkLegacyProjectImportPieceAsFailedErrors, true> {
     const piece = this.pieces.find((pc) => pc.id.value === pieceId.value);
     if (!piece) return left(legacyProjectImportComponentNotFound);
     if (piece.hasFailed())
       return left(legacyProjectImportComponentAlreadyFailed);
 
-    piece.markAsFailed(errors, warnings);
+    piece.markAsFailed(errors);
 
     const hasThisBatchFinished = this.hasBatchFinished(piece.order);
     const hasThisBatchFailed = this.hasBatchFailed(piece.order);

--- a/api/apps/api/src/modules/legacy-project-import/infra/import-legacy-project-piece.events-handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/import-legacy-project-piece.events-handler.ts
@@ -99,13 +99,16 @@ export class ImportLegacyProjectPieceEventsHandler
   private async failed(event: EventData<LegacyProjectImportJobInput, unknown>) {
     const { pieceId, projectId } = await event.data;
 
+    const result = await event.result;
+    const errors: string[] = [];
+
+    if (typeof result === 'string') errors.push(result);
+
     await this.commandBus.execute(
       new MarkLegacyProjectImportPieceAsFailed(
         new ResourceId(projectId),
         new LegacyProjectImportComponentId(pieceId),
-        // TODO Obtain actual errors and/or warnings
-        [],
-        [],
+        errors,
       ),
     );
   }

--- a/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/infra/legacy-project-import.infra.module.ts
@@ -13,6 +13,7 @@ import {
 import { ScheduleDbCleanupForFailedLegacyProjectImportHandler } from './schedule-db-cleanup-for-failed-legacy-project-import.handler';
 import { LegacyProjectImportRepositoryModule } from './legacy-project-import.repository.module';
 import { ScheduleLegacyProjectImportPieceHandler } from './schedule-legacy-project-import-piece.handler';
+import { ImportLegacyProjectPieceEventsHandler } from './import-legacy-project-piece.events-handler';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ScheduleLegacyProjectImportPieceHandler } from './schedule-legacy-proje
     ScheduleDbCleanupForFailedLegacyProjectImportHandler,
     LegacyProjectImportPieceRequestedSaga,
     ScheduleLegacyProjectImportPieceHandler,
+    ImportLegacyProjectPieceEventsHandler,
     {
       provide: Logger,
       useClass: Logger,

--- a/api/apps/api/src/modules/queue-api-events/adapter.ts
+++ b/api/apps/api/src/modules/queue-api-events/adapter.ts
@@ -50,8 +50,8 @@ export class QueueEventsAdapter<
     queueEvents.on(`completed`, ({ jobId }, eventId) =>
       this.handleFinished(jobId, eventId),
     );
-    queueEvents.on(`failed`, ({ jobId }, eventId) =>
-      this.handleFailed(jobId, eventId),
+    queueEvents.on(`failed`, ({ jobId, failedReason }, eventId) =>
+      this.handleFailed(jobId, eventId, failedReason),
     );
   }
 
@@ -84,7 +84,11 @@ export class QueueEventsAdapter<
     });
   }
 
-  private async handleFailed(jobId: string, eventId: string) {
+  private async handleFailed(
+    jobId: string,
+    eventId: string,
+    failedReason: string,
+  ) {
     const lazyDataGetter = this.createLazyDataGetter();
     const eventDto = await this.eventFactory.createFailedEvent({
       jobId,
@@ -107,7 +111,7 @@ export class QueueEventsAdapter<
         return lazyDataGetter(jobId);
       },
       get result() {
-        return Promise.resolve(undefined);
+        return Promise.resolve(failedReason);
       },
     });
   }

--- a/api/apps/api/src/utils/json.type.ts
+++ b/api/apps/api/src/utils/json.type.ts
@@ -4,4 +4,4 @@ export interface JSONObject {
   [x: string]: JSONValue;
 }
 
-export interface JSONArray extends Array<JSONValue> {}
+export type JSONArray = Array<JSONValue>;

--- a/api/apps/api/test/fixtures/test-init-apidb.sql
+++ b/api/apps/api/test/fixtures/test-init-apidb.sql
@@ -5,3 +5,8 @@ VALUES
 ('bb@example.com', 'b', 'b', 'User B B', true, false, crypt('bbuserpassword', gen_salt('bf'))),
 ('cc@example.com', 'c', 'c', 'User C C', true, false, crypt('ccuserpassword', gen_salt('bf'))),
 ('dd@example.com', 'd', 'd', 'User D D', true, false, crypt('dduserpassword', gen_salt('bf')));
+
+INSERT INTO organizations (name, created_by)
+VALUES
+  ('Example Org 1', (SELECT id FROM users WHERE email = 'aa@example.com')),
+  ('Example Org 2', (SELECT id FROM users WHERE email = 'aa@example.com'));

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1653565019335-ModifyBboxCalculationTakingAntimeridian.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1653565019335-ModifyBboxCalculationTakingAntimeridian.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ModifyBboxCalculationTakingAntimeridian1653565019335
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+    CREATE OR REPLACE FUNCTION mx_bbox2json(geom geometry)
+    returns jsonb
+    language plpgsql
+   as
+    $function$
+    DECLARE
+    -- variable declaration
+        both_hemispheres RECORD;
+    BEGIN
+      -- logic https://github.com/mapbox/carmen/blob/03fac2d7397ecdfcb4f0828fcfd9d8a54c845f21/lib/util/bbox.js#L59
+      -- json form of the bbox should be in Nominatim bbox  [xmin, xmax, ymin, ymax] [W, E, S, N].
+        execute 'with region as (select st_intersection($1, geom) as the_geom,
+                  st_intersects($1, geom) intersects, pos
+                from (values (ST_MakeEnvelope(-180, -90, 0, 90, 4326), ''west''),
+                        (ST_MakeEnvelope(0, -90, 180, 90, 4326), ''east'')) as t(geom, pos)),
+          data as (select ST_XMax(the_geom), ST_XMin(the_geom),
+              ST_YMax(the_geom),ST_YMin(the_geom), pos, intersects,
+              ST_XMax(the_geom) + ABS(lag(ST_XMin(the_geom), 1) OVER ())  >
+              (180 - ST_XMin(the_geom)) + (180 - ABS(lag(ST_XMax(the_geom), 1) OVER ())) as pm_am
+              from region)
+          select bool_and(intersects) and bool_and(pm_am) result,
+                jsonb_build_array(max(st_xmax), min(st_xmin), max(st_ymax), min(st_ymin)) if_false,
+                jsonb_build_array(min(st_xmax), max(st_xmin), max(st_ymax), min(st_ymin))if_true from data;'
+        into both_hemispheres
+        using geom;
+        if both_hemispheres.result then
+          return both_hemispheres.if_true;
+        else
+          return both_hemispheres.if_false;
+        end if;
+    end;
+    $function$;
+
+    CREATE OR REPLACE FUNCTION public.tr_getbbox()
+      RETURNS trigger
+      LANGUAGE plpgsql
+    AS $function$
+        BEGIN
+          NEW.bbox := mx_bbox2json(NEW.the_geom);
+          RETURN NEW;
+        END;
+    $function$;
+
+    UPDATE admin_regions SET id = id;
+          `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+    CREATE OR REPLACE FUNCTION public.tr_getbbox()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+        BEGIN
+          NEW.bbox := jsonb_build_array(ST_XMax(NEW.the_geom), ST_XMin(NEW.the_geom),
+                                        ST_YMax(NEW.the_geom), ST_YMin(NEW.the_geom));
+          RETURN NEW;
+        END;
+    $function$;
+
+    Drop FUNCTION mx_bbox2json(geom geometry);
+
+    UPDATE admin_regions SET id = id;
+          `);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/admin-areas/admin-areas.service.ts
+++ b/api/apps/geoprocessing/src/modules/admin-areas/admin-areas.service.ts
@@ -15,7 +15,7 @@ import {
 import { Transform } from 'class-transformer';
 import { BBox } from 'geojson';
 import { AdminArea } from '@marxan/admin-regions';
-import { nominatim2bbox } from '@marxan-geoprocessing/utils/bbox.utils';
+import { nominatim2bbox } from '@marxan/utils/geo/bbox';
 import { TileRequest } from '@marxan/tiles';
 
 export class TileSpecification extends TileRequest {

--- a/api/apps/geoprocessing/src/modules/admin-areas/admin-areas.service.ts
+++ b/api/apps/geoprocessing/src/modules/admin-areas/admin-areas.service.ts
@@ -15,7 +15,7 @@ import {
 import { Transform } from 'class-transformer';
 import { BBox } from 'geojson';
 import { AdminArea } from '@marxan/admin-regions';
-import { nominatim2bbox } from '@marxan/utils/geo/bbox';
+import { nominatim2bbox } from '@marxan/utils/geo';
 import { TileRequest } from '@marxan/tiles';
 
 export class TileSpecification extends TileRequest {

--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -66,6 +66,7 @@ export class FeatureService {
 
   /**
    * @todo get attributes from Entity, based on user selection
+   * @todo simplification level based on zoom level
    */
   public findTile(
     tileSpecification: TileSpecification,
@@ -73,7 +74,7 @@ export class FeatureService {
   ): Promise<Buffer> {
     const { z, x, y, id } = tileSpecification;
     const attributes = 'feature_id, properties';
-    const table = `(select (st_dump(the_geom)).geom as the_geom, properties, feature_id from "${this.featuresRepository.metadata.tableName}")`;
+    const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, 0.1) as the_geom, properties, feature_id from "${this.featuresRepository.metadata.tableName}")`;
     const customQuery = this.buildFeaturesWhereQuery(id, bbox);
     return this.tileService.getTile({
       z,
@@ -84,4 +85,5 @@ export class FeatureService {
       attributes,
     });
   }
+
 }

--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -7,7 +7,7 @@ import { IsArray, IsNumber, IsString, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { BBox } from 'geojson';
-import { antimeridianBbox, nominatim2bbox } from '@marxan-geoprocessing/utils/bbox.utils';
+import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo/bbox';
 
 import { TileRequest } from '@marxan/tiles';
 
@@ -49,9 +49,7 @@ export class FeatureService {
     let whereQuery = `feature_id = '${id}'`;
 
     if (bbox) {
-      const {westBbox, eastBbox} = antimeridianBbox(nominatim2bbox(
-        bbox,
-      ));
+      const { westBbox, eastBbox } = antimeridianBbox(nominatim2bbox(bbox));
       whereQuery += `AND
       (st_intersects(
         st_intersection(st_makeenvelope(${eastBbox}, 4326),

--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -7,7 +7,7 @@ import { IsArray, IsNumber, IsString, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { BBox } from 'geojson';
-import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo/bbox';
+import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo';
 
 import { TileRequest } from '@marxan/tiles';
 

--- a/api/apps/geoprocessing/src/modules/planning-area/planning-area-tiles/planning-area-tiles.service.ts
+++ b/api/apps/geoprocessing/src/modules/planning-area/planning-area-tiles/planning-area-tiles.service.ts
@@ -27,7 +27,7 @@ export class PlanningAreaTilesService {
     /**
      * @todo this generation query is a bit...
      */
-    let whereQuery = `project_id = '${planningAreaId}'`;
+    const whereQuery = `project_id = '${planningAreaId}'`;
 
     return whereQuery;
   }

--- a/api/apps/geoprocessing/src/modules/planning-units/planning-units.job.ts
+++ b/api/apps/geoprocessing/src/modules/planning-units/planning-units.job.ts
@@ -123,7 +123,7 @@ export class PlanningUnitsJobProcessor {
       st_transform(ST_MakeEnvelope(-180, -90, 180, 90, 4326), 3410)) as geom
       FROM region, bboxes
       )
-SELECT
+SELECT distinct
 grid.geom
       FROM grid, region
       WHERE ST_Intersects(grid.geom, region.geom)
@@ -158,7 +158,7 @@ grid.geom
         st_transform(ST_MakeEnvelope(-180, -90, 180, 90, 4326), 3410)) as geom
         FROM region, bboxes
       )
-      SELECT
+      SELECT distinct
       		grid.geom
       FROM grid, region
       WHERE ST_Intersects(grid.geom, region.geom)

--- a/api/apps/geoprocessing/src/modules/planning-units/planning-units.service.ts
+++ b/api/apps/geoprocessing/src/modules/planning-units/planning-units.service.ts
@@ -1,5 +1,5 @@
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
-import { nominatim2bbox, antimeridianBbox } from '@marxan/utils/geo/bbox';
+import { nominatim2bbox, antimeridianBbox } from '@marxan/utils/geo';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { TileRequest } from '@marxan/tiles';
 import { Inject, Injectable, Logger } from '@nestjs/common';

--- a/api/apps/geoprocessing/src/modules/planning-units/planning-units.service.ts
+++ b/api/apps/geoprocessing/src/modules/planning-units/planning-units.service.ts
@@ -1,11 +1,11 @@
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
-import { nominatim2bbox, antimeridianBbox } from '@marxan-geoprocessing/utils/bbox.utils';
+import { nominatim2bbox, antimeridianBbox } from '@marxan/utils/geo/bbox';
 import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { TileRequest } from '@marxan/tiles';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsArray, IsIn, IsNumber, IsOptional} from 'class-validator';
+import { IsArray, IsIn, IsNumber, IsOptional } from 'class-validator';
 import { BBox } from 'geojson';
 import {
   calculateGridSize,
@@ -129,9 +129,9 @@ export class PlanningUnitsService {
     let whereQuery = ``;
 
     if (filters?.bbox) {
-      const {westBbox, eastBbox} = antimeridianBbox(nominatim2bbox(
-        filters.bbox
-      ));
+      const { westBbox, eastBbox } = antimeridianBbox(
+        nominatim2bbox(filters.bbox),
+      );
       whereQuery = `st_intersects(ST_Transform(st_intersection(ST_MakeEnvelope(${eastBbox}, 4326),
                                   ST_MakeEnvelope(0, -90, 180, 90, 4326)), 3857), the_geom)
                     OR

--- a/api/apps/geoprocessing/src/modules/protected-areas/protected-areas-tiles.service.ts
+++ b/api/apps/geoprocessing/src/modules/protected-areas/protected-areas-tiles.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, Repository } from 'typeorm';
-import { nominatim2bbox, antimeridianBbox } from '@marxan-geoprocessing/utils/bbox.utils';
+import { nominatim2bbox, antimeridianBbox } from '@marxan/utils/geo/bbox';
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
 
 import { ProtectedArea } from '@marxan/protected-areas';
@@ -73,9 +73,7 @@ export class ProtectedAreasTilesService {
         }
 
         if (bbox) {
-          const {westBbox, eastBbox} = antimeridianBbox(nominatim2bbox(
-            bbox
-          ));
+          const { westBbox, eastBbox } = antimeridianBbox(nominatim2bbox(bbox));
           subQuery.andWhere(
             `(st_intersects(ST_MakeEnvelope(:...westBbox, 4326), the_geom)
               or

--- a/api/apps/geoprocessing/src/modules/protected-areas/protected-areas-tiles.service.ts
+++ b/api/apps/geoprocessing/src/modules/protected-areas/protected-areas-tiles.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, Repository } from 'typeorm';
-import { nominatim2bbox, antimeridianBbox } from '@marxan/utils/geo/bbox';
+import { nominatim2bbox, antimeridianBbox } from '@marxan/utils/geo';
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
 
 import { ProtectedArea } from '@marxan/protected-areas';

--- a/api/apps/geoprocessing/src/modules/scenarios/comparison-difference-tile/comparison-difference-tile.service.ts
+++ b/api/apps/geoprocessing/src/modules/scenarios/comparison-difference-tile/comparison-difference-tile.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { nominatim2bbox } from '@marxan-geoprocessing/utils/bbox.utils';
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
 
 import { ScenariosPuPaDataGeo } from '@marxan/scenarios-planning-unit';

--- a/api/apps/geoprocessing/src/utils/bbox.utils.ts
+++ b/api/apps/geoprocessing/src/utils/bbox.utils.ts
@@ -3,6 +3,7 @@ import { BBox } from 'geojson';
  * Utility functions related to lower-level interaction with bbox operations.
  *
  * @debt This should be moved to a self-standing
+ * @debt there is also a mismatch in terms of the bbox creation [xmax,xmin,ymax,ymin] vs [xmin,xmax,ymin,ymax]
  */
 
 /**
@@ -15,4 +16,19 @@ export function bbox2Nominatim(bbox: BBox): BBox {
 }
 export function nominatim2bbox(nominatim: BBox): BBox {
   return [nominatim[0], nominatim[2], nominatim[1], nominatim[3]];
+}
+
+/**
+ * Check of antimeridian and division of bbox
+ * to Nominatim bbox  [xmin, xmax, ymin, ymax].
+ * @param bbox
+ * @returns {BBox, BBox} west and east bbox split
+ *
+ */
+export function antimeridianBbox(bbox: BBox): {westBbox: BBox, eastBbox: BBox} {
+  if (bbox[2] > bbox[0]) {
+    return {westBbox: [bbox[0], bbox[1], bbox[2] - 360, bbox[3]],
+            eastBbox: [bbox[0] + 360, bbox[1], bbox[2], bbox[3]]};
+  }
+  return {westBbox: bbox, eastBbox: bbox}
 }

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/export-config.project-piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/export-config.project-piece-exporter.e2e-spec.ts
@@ -96,7 +96,7 @@ const getFixtures = async () => {
   const getExpectedContent = (
     options: FixtureOptions,
   ): ProjectExportConfigContent => {
-    let scenarios: Record<string, ClonePiece[]> = {};
+    const scenarios: Record<string, ClonePiece[]> = {};
     if (options.projectWithScenario)
       scenarios[scenarioId] = [ClonePiece.ScenarioMetadata];
     return {

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-protected-areas.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-protected-areas.piece-exporter.e2e-spec.ts
@@ -85,8 +85,8 @@ const getFixtures = async () => {
   const projectId = v4();
   const scenarioId = v4();
   let customProtectedAreaId: string = v4();
-  let commonProtectedAreasWdpaids: number[] = [];
-  let commonProtectedAreasIds: string[] = [];
+  const commonProtectedAreasWdpaids: number[] = [];
+  const commonProtectedAreasIds: string[] = [];
   const organizationId = v4();
   const sut = sandbox.get(ScenarioProtectedAreasPieceExporter);
   const apiEntityManager: EntityManager = sandbox.get(

--- a/api/libs/utils/src/geo/bbox.ts
+++ b/api/libs/utils/src/geo/bbox.ts
@@ -25,10 +25,14 @@ export function nominatim2bbox(nominatim: BBox): BBox {
  * @returns {BBox, BBox} west and east bbox split
  *
  */
-export function antimeridianBbox(bbox: BBox): {westBbox: BBox, eastBbox: BBox} {
+export function antimeridianBbox(
+  bbox: BBox,
+): { westBbox: BBox; eastBbox: BBox } {
   if (bbox[2] > bbox[0]) {
-    return {westBbox: [bbox[0], bbox[1], bbox[2] - 360, bbox[3]],
-            eastBbox: [bbox[0] + 360, bbox[1], bbox[2], bbox[3]]};
+    return {
+      westBbox: [bbox[0], bbox[1], bbox[2] - 360, bbox[3]],
+      eastBbox: [bbox[0] + 360, bbox[1], bbox[2], bbox[3]],
+    };
   }
-  return {westBbox: bbox, eastBbox: bbox}
+  return { westBbox: bbox, eastBbox: bbox };
 }

--- a/api/libs/utils/src/geo/index.ts
+++ b/api/libs/utils/src/geo/index.ts
@@ -1,3 +1,4 @@
 export { defaultSrid } from './spatial-data-format';
 export { isFeatureCollection } from './is-feature-collection';
 export { decodeMvt } from './decode-mvt';
+export { bbox2Nominatim, nominatim2bbox, antimeridianBbox } from './bbox';


### PR DESCRIPTION
## Take with care  
This fix is touching almost all intersections based on bbox in the application

### Overview
So this applies 2 different fixes altogether:
BBox crosses the antimeridian, we are overpassing this in 2 steps, first, we properly calculate min and max longitude values by dividing the bbox in 2 bases on the east and west semihemisphers. 
After that both FE and backend will follow the next rule: if min long is > than max long, that means that the bbox crosses the antimeridian and we subdivide them.

Regarding the grid. So as we are already setting the equal area cost surface, I did take the license to every grid that is crossing the antimeridian will be cut in order to avoid it crossing the antimeridian. with this in place calculations should work as expected.

Also, small fixes were applied to everything that depends on bbox filtering in order to be able to overpass the bbox at the antimeridian situation. The only problem here might be a small overhead due to subdividing it into the east and west suboxes.

### Testing instructions

Up locally and setup a project in Fiji and in any other place

### Feature relevant tickets

_Link to the related task manager tickets_
https://vizzuality.atlassian.net/browse/MARXAN-985


---

## Checklist before submitting

- [x ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file