### PR TITLE
avoid uncaught error on nfs warnings on copy in k8s [MARXAN-1628]

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -168,7 +168,9 @@ export class GeoFeaturesService extends AppBaseService<
      *
      */
     if (projectId && info?.params?.bbox) {
-      const { westBbox, eastBbox } = antimeridianBbox(nominatim2bbox(info.params.bbox));
+      const { westBbox, eastBbox } = antimeridianBbox(
+        nominatim2bbox(info.params.bbox),
+      );
       const geoFeaturesWithinProjectBbox = await this.geoFeaturesGeometriesRepository
         .createQueryBuilder('geoFeatureGeometries')
         .select('"geoFeatureGeometries"."feature_id"', 'featureId')

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/asset-factory.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/asset-factory.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { copySync, writeFileSync } from 'fs-extra';
+import { writeFileSync } from 'fs-extra';
 import { Workspace } from '../ports/workspace';
 import { Assets } from './blm-input-files';
 import { resolve } from 'path';
 import { FileReader } from '@marxan-geoprocessing/marxan-sandboxed-runner/adapters-single/file-reader';
+import { execSync } from 'child_process';
 
 @Injectable()
 export class AssetFactory {
@@ -19,10 +20,16 @@ export class AssetFactory {
       `copy assets from [${from.workingDirectory}] to ${to.workingDirectory} -> for blm of ${blmValueForCurrentRun}`,
     );
 
-    copySync(from.workingDirectory, to.workingDirectory, {
-      // Marxan binary is already linked
-      filter: (src) => !src.match(/marxan/),
-    });
+    /**
+     * The original implementation using fs-extra.copySync() would throw an
+     * exception (and fail to copy assets over) when used over a CIFS mount.
+     * This could be avoided by tuning the CIFS mount options, however "just"
+     * using plain `cp` (which does emit warnings about ownership and
+     * permissions not being retained, but copies files successfully
+     * nevertheless) seems more robust overall (until we can rely on `cp` being
+     * available in the base image, of course).
+     */
+    execSync(`cp -a -f ${from.workingDirectory}/* ${to.workingDirectory}`);
 
     const inputDat = this.getInputDat(assets);
     if (!inputDat) throw new Error('No URL for input.dat found');

--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -85,5 +85,4 @@ export class FeatureService {
       attributes,
     });
   }
-
 }


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MARXAN-1628

- replace `fs-extra.copySync()` with `child_process.execSync('cp ...')` to avoid permissions issues with k8s volumes (and to avoid having to depend on specific mount options)