### PR TITLE
MARXAN-1580-disable-initial-export-published-projects

### DIFF
--- a/api/apps/api/src/modules/published-project/published-project-crud.service.ts
+++ b/api/apps/api/src/modules/published-project/published-project-crud.service.ts
@@ -146,6 +146,12 @@ export class PublishedProjectCrudService extends AppBaseService<
       return entitiesAndCount;
     }
 
+    const extendedEntitiesFromGetById: PublishedProject[] = await Promise.all(
+      entitiesAndCount[0].map(
+        async (entity) => await this.extendGetByIdResult(entity),
+      ),
+    );
+
     const allOwnersOfAllProjectsPlusEmail = await this.usersProjectsRepo.query(
       `
       select up.project_id, up.user_id, u.email
@@ -160,7 +166,7 @@ export class PublishedProjectCrudService extends AppBaseService<
       (item) => item.project_id,
     );
 
-    const extendedEntities: PublishedProject[] = entitiesAndCount[0].map(
+    const finalExtendedEntities: PublishedProject[] = extendedEntitiesFromGetById.map(
       (entity) => ({
         ...entity,
         ownerEmails: ownersPerProject[entity.id].map((item) => ({
@@ -170,6 +176,6 @@ export class PublishedProjectCrudService extends AppBaseService<
       }),
     );
 
-    return [extendedEntities, entitiesAndCount[1]];
+    return [finalExtendedEntities, entitiesAndCount[1]];
   }
 }

--- a/api/apps/api/src/utils/published-export.utils.ts
+++ b/api/apps/api/src/utils/published-export.utils.ts
@@ -1,0 +1,25 @@
+import { ExportId } from '@marxan-api/modules/clone';
+import { ExportRepository } from '@marxan-api/modules/clone/export/application/export-repository.port';
+import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
+
+export const exportHasFinished = async (
+  publishedProjects: PublishedProject[],
+  exportRepo: ExportRepository,
+): Promise<PublishedProject[]> => {
+  const processedPublishedProjects = await Promise.all(
+    publishedProjects.map(async (entity) => {
+      const exportIdString = entity?.exportId;
+
+      if (exportIdString) {
+        const exportId = new ExportId(exportIdString);
+        const finalExport = await exportRepo.find(exportId);
+        if (!finalExport?.hasFinished()) {
+          delete entity.exportId;
+        }
+      }
+      return entity;
+    }),
+  );
+
+  return processedPublishedProjects;
+};

--- a/api/apps/api/src/utils/published-export.utils.ts
+++ b/api/apps/api/src/utils/published-export.utils.ts
@@ -1,8 +1,12 @@
+import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
+import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
 import { ExportId } from '@marxan-api/modules/clone';
 import { ExportRepository } from '@marxan-api/modules/clone/export/application/export-repository.port';
 import { PublishedProject } from '@marxan-api/modules/published-project/entities/published-project.api.entity';
+import { groupBy } from 'lodash';
+import { Repository } from 'typeorm';
 
-export const exportHasFinished = async (
+export const removeExportIdsForUnfinishedExports = async (
   publishedProjects: PublishedProject[],
   exportRepo: ExportRepository,
 ): Promise<PublishedProject[]> => {
@@ -22,4 +26,33 @@ export const exportHasFinished = async (
   );
 
   return processedPublishedProjects;
+};
+
+export const addOwnerEmails = async (
+  publishedProjects: PublishedProject[],
+  usersProjectsRepo: Repository<UsersProjectsApiEntity>,
+): Promise<PublishedProject[]> => {
+  const allOwnersOfAllProjectsPlusEmail = await usersProjectsRepo.query(
+    `
+        select up.project_id, up.user_id, u.email
+          from users_projects as up
+             left join users as u
+                  on (u."id" = up.user_id)
+          where up.project_id IN (SELECT id FROM published_projects) AND up.role_id = $1;`,
+    [ProjectRoles.project_owner],
+  );
+  const ownersPerProject = groupBy(
+    allOwnersOfAllProjectsPlusEmail,
+    (item) => item.project_id,
+  );
+
+  const processedPublicProjects = publishedProjects.map((entity) => ({
+    ...entity,
+    ownerEmails: ownersPerProject[entity.id].map((item) => ({
+      id: item.user_id,
+      email: item.email,
+    })),
+  }));
+
+  return processedPublicProjects;
 };


### PR DESCRIPTION
-Adds and follows the same logic per `findAll` method that was already used in `getById` for published project entities.
-This means that `exportId` would only be present in a project IF and only IF the export has finished. If not, the entity would not include the `exportId` among its properties.