### PR TITLE
forbid changes to legacy project imports [MARXAN-1612]

### DIFF
--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-finished.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-finished.handler.ts
@@ -1,3 +1,5 @@
+import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
+import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
 import { ApiEventsService } from '@marxan-api/modules/api-events';
 import { API_EVENT_KINDS } from '@marxan/api-events';
 import { ResourceId } from '@marxan/cloning/domain';
@@ -7,7 +9,9 @@ import {
   CommandHandler,
   IInferredCommandHandler,
 } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/lib/Either';
+import { Repository } from 'typeorm';
 import { LegacyProjectImportRepository } from '../domain/legacy-project-import/legacy-project-import.repository';
 import { MarkLegacyProjectImportAsFailed } from './mark-legacy-project-import-as-failed.command';
 import { MarkLegacyProjectImportAsFinished } from './mark-legacy-project-import-as-finished.command';
@@ -19,6 +23,8 @@ export class MarkLegacyProjectImportAsFinishedHandler
     private readonly apiEvents: ApiEventsService,
     private readonly legacyProjectImportRepository: LegacyProjectImportRepository,
     private readonly commandBus: CommandBus,
+    @InjectRepository(UsersProjectsApiEntity)
+    private readonly usersRepo: Repository<UsersProjectsApiEntity>,
     private readonly logger: Logger,
   ) {
     this.logger.setContext(MarkLegacyProjectImportAsFinishedHandler.name);
@@ -60,6 +66,12 @@ export class MarkLegacyProjectImportAsFinishedHandler
         scenarioId,
         ownerId,
       },
+    });
+
+    await this.usersRepo.save({
+      userId: ownerId,
+      projectId: projectId.value,
+      roleName: ProjectRoles.project_owner,
     });
   }
 }

--- a/api/apps/api/src/modules/legacy-project-import/application/run-legacy-project-import.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/run-legacy-project-import.handler.ts
@@ -1,5 +1,4 @@
 import { forbiddenError } from '@marxan-api/modules/access-control';
-import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
 import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
 import {
   CommandHandler,
@@ -53,12 +52,6 @@ export class RunLegacyProjectImportHandler
 
     if (isLeft(legacyProjectImportSaveError))
       return legacyProjectImportSaveError;
-
-    await this.usersRepo.save({
-      userId: ownerId,
-      projectId: projectId.value,
-      roleName: ProjectRoles.project_owner,
-    });
 
     legacyProjectImport.commit();
 

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.module.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { LegacyProjectImportRepositoryModule } from '../../infra/legacy-project-import.repository.module';
+import { LegacyProjectImportChecker } from './legacy-project-import-checker.service';
+import { MarxanLegacyProjectImportChecker } from './marxan-legacy-project-import-checker.service';
+
+@Module({
+  imports: [LegacyProjectImportRepositoryModule],
+  providers: [
+    {
+      provide: LegacyProjectImportChecker,
+      useClass: MarxanLegacyProjectImportChecker,
+    },
+  ],
+  exports: [LegacyProjectImportChecker],
+})
+export class LegacyProjectImportCheckerModule {}

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service-fake.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service-fake.ts
@@ -1,0 +1,40 @@
+import {
+  LegacyProjectImportChecker,
+  LegacyProjectImportDoesntExist,
+  legacyProjectImportDoesntExist,
+} from '@marxan-api/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service';
+import { LegacyProjectImportRepository } from '@marxan-api/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.repository';
+import { ResourceId } from '@marxan/cloning/domain';
+import { Injectable } from '@nestjs/common';
+import { Either, left, right } from 'fp-ts/lib/Either';
+
+@Injectable()
+export class LegacyProjectImportCheckerFake
+  implements LegacyProjectImportChecker {
+  private legacyProjectImportWithPendingImports: string[] = [];
+
+  constructor(
+    private readonly legacyProjectImportRepo: LegacyProjectImportRepository,
+  ) {}
+
+  async hasImportedLegacyProjectImport(
+    projectId: string,
+  ): Promise<Either<LegacyProjectImportDoesntExist, boolean>> {
+    const legacyProjectImport = await this.legacyProjectImportRepo.find(
+      new ResourceId(projectId),
+    );
+    if (!legacyProjectImport) return left(legacyProjectImportDoesntExist);
+
+    return right(
+      !this.legacyProjectImportWithPendingImports.includes(projectId),
+    );
+  }
+
+  addPendingLegacyProjecImport(projectId: string) {
+    this.legacyProjectImportWithPendingImports.push(projectId);
+  }
+
+  clear() {
+    this.legacyProjectImportWithPendingImports = [];
+  }
+}

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service-fake.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service-fake.ts
@@ -17,7 +17,7 @@ export class LegacyProjectImportCheckerFake
     private readonly legacyProjectImportRepo: LegacyProjectImportRepository,
   ) {}
 
-  async hasImportedLegacyProjectImport(
+  async isLegacyProjectImportCompletedFor(
     projectId: string,
   ): Promise<Either<LegacyProjectImportDoesntExist, boolean>> {
     const legacyProjectImport = await this.legacyProjectImportRepo.find(

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.spec.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.spec.ts
@@ -19,7 +19,7 @@ beforeEach(async () => {
   fixtures = await getFixtures();
 });
 
-it(`hasImportedLegacyProjectImport() should return legacyProjectImportdoesntExist if the project is not a legacy project`, async () => {
+it(`isLegacyProjectImportCompletedFor() should return legacyProjectImportdoesntExist if the project does not have a legacy project import`, async () => {
   const res = fixtures.GivenProjectIsNotALegacyProject();
 
   const result = await fixtures.WhenHasImportedLegacyProjectMethodIsCalled(res);
@@ -32,11 +32,9 @@ it.each(
     (kind) => kind !== LegacyProjectImportStatuses.Completed,
   ),
 )(
-  `hasImportedLegacyProjectImport() should return false if given legacy project import has status %s`,
+  `isLegacyProjectImportCompletedFor() should return false if given project has a legacy project import with status %s`,
   async (kind) => {
-    const id = await fixtures.GivenLegacyProjectImport(
-      LegacyProjectImportStatuses.AcceptingFiles,
-    );
+    const id = await fixtures.GivenLegacyProjectImport(kind);
 
     const result = await fixtures.WhenHasImportedLegacyProjectMethodIsCalled(
       id,
@@ -46,7 +44,7 @@ it.each(
   },
 );
 
-it(`hasImportedLegacyProjectImport() should return true if given legacy project import has already imported`, async () => {
+it(`isLegacyProjectImportCompletedFor() should return true if given project has an already completed legacy project import`, async () => {
   const id = await fixtures.GivenLegacyProjectImport(
     LegacyProjectImportStatuses.Completed,
   );
@@ -93,7 +91,7 @@ async function getFixtures() {
       return projectId;
     },
     WhenHasImportedLegacyProjectMethodIsCalled: (projectId: string) => {
-      return sut.hasImportedLegacyProjectImport(projectId);
+      return sut.isLegacyProjectImportCompletedFor(projectId);
     },
     ThenLegacyProjectImportDoesntExistIsReturned: (
       result: Either<LegacyProjectImportDoesntExist, boolean>,

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.spec.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.spec.ts
@@ -1,0 +1,123 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Test } from '@nestjs/testing';
+import { Either } from 'fp-ts/lib/Either';
+import { v4 } from 'uuid';
+import { LegacyProjectImportMemoryRepository } from '../../infra/legacy-project-import-memory.repository';
+import { LegacyProjectImport } from '../legacy-project-import/legacy-project-import';
+import { LegacyProjectImportStatuses } from '../legacy-project-import/legacy-project-import-status';
+import { LegacyProjectImportRepository } from '../legacy-project-import/legacy-project-import.repository';
+import {
+  LegacyProjectImportChecker,
+  legacyProjectImportDoesntExist,
+  LegacyProjectImportDoesntExist,
+} from './legacy-project-import-checker.service';
+import { MarxanLegacyProjectImportChecker } from './marxan-legacy-project-import-checker.service';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+it(`hasImportedLegacyProjectImport() should return legacyProjectImportdoesntExist if the project is not a legacy project`, async () => {
+  const res = fixtures.GivenProjectIsNotALegacyProject();
+
+  const result = await fixtures.WhenHasImportedLegacyProjectMethodIsCalled(res);
+
+  fixtures.ThenLegacyProjectImportDoesntExistIsReturned(result);
+});
+
+it.each(
+  Object.values(LegacyProjectImportStatuses).filter(
+    (kind) => kind !== LegacyProjectImportStatuses.Completed,
+  ),
+)(
+  `hasImportedLegacyProjectImport() should return false if given legacy project import has status %s`,
+  async (kind) => {
+    const id = await fixtures.GivenLegacyProjectImport(
+      LegacyProjectImportStatuses.AcceptingFiles,
+    );
+
+    const result = await fixtures.WhenHasImportedLegacyProjectMethodIsCalled(
+      id,
+    );
+
+    fixtures.ThenFalseIsReturned(result);
+  },
+);
+
+it(`hasImportedLegacyProjectImport() should return true if given legacy project import has already imported`, async () => {
+  const id = await fixtures.GivenLegacyProjectImport(
+    LegacyProjectImportStatuses.Completed,
+  );
+
+  const result = await fixtures.WhenHasImportedLegacyProjectMethodIsCalled(id);
+
+  fixtures.ThenTrueIsReturned(result);
+});
+
+async function getFixtures() {
+  const testingModule = await Test.createTestingModule({
+    providers: [
+      {
+        provide: LegacyProjectImportChecker,
+        useClass: MarxanLegacyProjectImportChecker,
+      },
+      {
+        provide: LegacyProjectImportRepository,
+        useClass: LegacyProjectImportMemoryRepository,
+      },
+    ],
+  }).compile();
+  const sut = testingModule.get(LegacyProjectImportChecker);
+  const repo = testingModule.get(LegacyProjectImportRepository);
+  const projectId = v4();
+
+  return {
+    GivenProjectIsNotALegacyProject: () => {
+      return projectId;
+    },
+    GivenLegacyProjectImport: async (status: LegacyProjectImportStatuses) => {
+      const legacyProjectImport = LegacyProjectImport.fromSnapshot({
+        files: [],
+        pieces: [],
+        id: v4(),
+        ownerId: v4(),
+        projectId,
+        scenarioId: v4(),
+        status,
+        toBeRemoved: false,
+      });
+      await repo.save(legacyProjectImport);
+
+      return projectId;
+    },
+    WhenHasImportedLegacyProjectMethodIsCalled: (projectId: string) => {
+      return sut.hasImportedLegacyProjectImport(projectId);
+    },
+    ThenLegacyProjectImportDoesntExistIsReturned: (
+      result: Either<LegacyProjectImportDoesntExist, boolean>,
+    ) => {
+      expect(result).toEqual({
+        _tag: 'Left',
+        left: legacyProjectImportDoesntExist,
+      });
+    },
+    ThenFalseIsReturned: (
+      result: Either<LegacyProjectImportDoesntExist, boolean>,
+    ) => {
+      expect(result).toEqual({
+        _tag: 'Right',
+        right: false,
+      });
+    },
+    ThenTrueIsReturned: (
+      result: Either<LegacyProjectImportDoesntExist, boolean>,
+    ) => {
+      expect(result).toEqual({
+        _tag: 'Right',
+        right: true,
+      });
+    },
+  };
+}

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.ts
@@ -1,0 +1,12 @@
+import { Either } from 'fp-ts/Either';
+
+export const legacyProjectImportDoesntExist = Symbol(
+  `doesn't exist legacy project import`,
+);
+export type LegacyProjectImportDoesntExist = typeof legacyProjectImportDoesntExist;
+
+export abstract class LegacyProjectImportChecker {
+  abstract hasImportedLegacyProjectImport(
+    projectId: string,
+  ): Promise<Either<LegacyProjectImportDoesntExist, boolean>>;
+}

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service.ts
@@ -6,7 +6,7 @@ export const legacyProjectImportDoesntExist = Symbol(
 export type LegacyProjectImportDoesntExist = typeof legacyProjectImportDoesntExist;
 
 export abstract class LegacyProjectImportChecker {
-  abstract hasImportedLegacyProjectImport(
+  abstract isLegacyProjectImportCompletedFor(
     projectId: string,
   ): Promise<Either<LegacyProjectImportDoesntExist, boolean>>;
 }

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/marxan-legacy-project-import-checker.service.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/marxan-legacy-project-import-checker.service.ts
@@ -14,7 +14,7 @@ export class MarxanLegacyProjectImportChecker
   constructor(
     private readonly legacyProjectImportRepo: LegacyProjectImportRepository,
   ) {}
-  async hasImportedLegacyProjectImport(
+  async isLegacyProjectImportCompletedFor(
     projectId: string,
   ): Promise<Either<LegacyProjectImportDoesntExist, boolean>> {
     const legacyProjectImport = await this.legacyProjectImportRepo.find(

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/marxan-legacy-project-import-checker.service.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import-checker/marxan-legacy-project-import-checker.service.ts
@@ -1,0 +1,29 @@
+import { ResourceId } from '@marxan/cloning/domain';
+import { Injectable } from '@nestjs/common';
+import { Either, isLeft, left, right } from 'fp-ts/Either';
+import { LegacyProjectImportRepository } from '../legacy-project-import/legacy-project-import.repository';
+import {
+  legacyProjectImportDoesntExist,
+  LegacyProjectImportChecker,
+  LegacyProjectImportDoesntExist,
+} from './legacy-project-import-checker.service';
+
+@Injectable()
+export class MarxanLegacyProjectImportChecker
+  implements LegacyProjectImportChecker {
+  constructor(
+    private readonly legacyProjectImportRepo: LegacyProjectImportRepository,
+  ) {}
+  async hasImportedLegacyProjectImport(
+    projectId: string,
+  ): Promise<Either<LegacyProjectImportDoesntExist, boolean>> {
+    const legacyProjectImport = await this.legacyProjectImportRepo.find(
+      new ResourceId(projectId),
+    );
+
+    if (isLeft(legacyProjectImport))
+      return left(legacyProjectImportDoesntExist);
+
+    return right(legacyProjectImport.right.hasImportedLegacyProject());
+  }
+}

--- a/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
+++ b/api/apps/api/src/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.ts
@@ -134,6 +134,10 @@ export class LegacyProjectImport extends AggregateRoot {
     return !this.status.isAcceptingFiles();
   }
 
+  public hasImportedLegacyProject() {
+    return this.status.hasCompleted();
+  }
+
   public areRequiredFilesUploaded(): boolean {
     const requiredFilesTypes = [
       LegacyProjectImportFileType.PlanningGridShapefile,

--- a/api/apps/api/src/modules/projects/block-guard/block-guard.module.ts
+++ b/api/apps/api/src/modules/projects/block-guard/block-guard.module.ts
@@ -8,11 +8,13 @@ import { PlanningAreasModule } from '@marxan-api/modules/planning-areas';
 import { MarxanBlockGuard } from '@marxan-api/modules/projects/block-guard/marxan-block-guard.service';
 import { ScenarioCheckerModule } from '@marxan-api/modules/scenarios/scenario-checker/scenario-checker.module';
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { LegacyProjectImportCheckerModule } from '@marxan-api/modules/legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.module';
 
 @Module({
   imports: [
     ProjectCheckerModule,
     ScenarioCheckerModule,
+    LegacyProjectImportCheckerModule,
     PlanningAreasModule,
     ApiEventsModule,
     TypeOrmModule.forFeature([Project, Scenario]),

--- a/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.spec.ts
+++ b/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.spec.ts
@@ -98,7 +98,7 @@ describe('MarxanBlockGuard - ensureThatProjectIsNotBlocked', () => {
       .ThenAPendingMarxanRunErrorIsThrown();
   });
 
-  it(`throws an exception if the given project has not imported the legacy project import`, async () => {
+  it(`while a legacy project import process is ongoing, the project should be marked as non-editable`, async () => {
     const [projectId] = await fixtures.GivenProjectWasCreated();
 
     fixtures.WhenProjectHasAnOngoingLegacyProjectImport(projectId);
@@ -196,7 +196,7 @@ describe('MarxanBlockGuard - ensureThatScenarioIsNotBlocked', () => {
       .ThenAPendingMarxanRunErrorIsThrown();
   });
 
-  it(`throws an exception if the given scenario's parent project has not imported the legacy project import`, async () => {
+  it(`while a legacy project import process is ongoing, scenarios within the project should be marked as non-editable`, async () => {
     const [projectId, scenarioId] = await fixtures.GivenProjectWasCreated();
 
     fixtures.WhenProjectHasAnOngoingLegacyProjectImport(projectId);

--- a/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.ts
+++ b/api/apps/api/src/modules/projects/block-guard/marxan-block-guard.service.ts
@@ -45,7 +45,9 @@ export class MarxanBlockGuard implements BlockGuard {
       this.projectChecker.hasPendingImports(projectId),
       this.projectChecker.hasPendingBlmCalibration(projectId),
       this.projectChecker.hasPendingMarxanRun(projectId),
-      this.legacyProjectImportChecker.hasImportedLegacyProjectImport(projectId),
+      this.legacyProjectImportChecker.isLegacyProjectImportCompletedFor(
+        projectId,
+      ),
     ]);
 
     if (isRight(hasPendingExports) && hasPendingExports.right)
@@ -97,7 +99,7 @@ export class MarxanBlockGuard implements BlockGuard {
       this.scenarioChecker.hasPendingImport(scenarioId),
       this.projectChecker.hasPendingExports(scenario.projectId),
       this.projectChecker.hasPendingImports(scenario.projectId),
-      this.legacyProjectImportChecker.hasImportedLegacyProjectImport(
+      this.legacyProjectImportChecker.isLegacyProjectImportCompletedFor(
         scenario.projectId,
       ),
     ]);

--- a/api/apps/api/src/modules/scenarios/scenarios.module.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.module.ts
@@ -1,7 +1,6 @@
 import { forwardRef, HttpModule, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CqrsModule } from '@nestjs/cqrs';
-
 import { MarxanInput } from '@marxan/marxan-input/marxan-input';
 import { ScenariosController } from './scenarios.controller';
 import { Scenario } from './scenario.api.entity';
@@ -33,7 +32,6 @@ import { ScenarioPlanningUnitSerializer } from './dto/scenario-planning-unit.ser
 import { ScenarioPlanningUnitsService } from './planning-units/scenario-planning-units.service';
 import { ScenarioPlanningUnitsLinkerService } from './planning-units/scenario-planning-units-linker-service';
 import { AdminAreasModule } from '../admin-areas/admin-areas.module';
-
 import { SpecificationModule } from './specification';
 import { ScenarioFeaturesGapDataSerializer } from './dto/scenario-feature-gap-data.serializer';
 import { ScenarioFeaturesOutputGapDataSerializer } from './dto/scenario-feature-output-gap-data.serializer';
@@ -52,6 +50,7 @@ import { LockService } from '../access-control/scenarios-acl/locks/lock.service'
 import { IssuedAuthnToken } from '../authentication/issued-authn-token.api.entity';
 import { WebshotModule } from '@marxan/webshot';
 import { DeleteScenarioModule } from './delete-scenario/delete-scenario.module';
+import { LegacyProjectImportCheckerModule } from '../legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.module';
 
 @Module({
   imports: [
@@ -73,6 +72,7 @@ import { DeleteScenarioModule } from './delete-scenario/delete-scenario.module';
     ),
     BlockGuardModule,
     ProjectCheckerModule,
+    LegacyProjectImportCheckerModule,
     PlanningAreasModule,
     UsersModule,
     ScenarioFeaturesModule,

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -8,7 +8,7 @@ import {
 import { FetchSpecification } from 'nestjs-base-service';
 import { classToClass } from 'class-transformer';
 import * as stream from 'stream';
-import { Either, isLeft, left, right } from 'fp-ts/Either';
+import { Either, isLeft, isRight, left, right } from 'fp-ts/Either';
 import { pick } from 'lodash';
 import { MarxanInput, MarxanParameters } from '@marxan/marxan-input';
 import { AppInfoDTO } from '@marxan-api/dto/info.dto';
@@ -116,6 +116,7 @@ import {
   DeleteScenario as DeleteScenarioUnusedResources,
   deleteScenarioFailed,
 } from './delete-scenario/delete-scenario.command';
+import { LegacyProjectImportChecker } from '../legacy-project-import/domain/legacy-project-import-checker/legacy-project-import-checker.service';
 
 /** @debt move to own module */
 const EmptyGeoFeaturesSpecification: GeoFeatureSetSpecification = {
@@ -174,6 +175,7 @@ export class ScenariosService {
     private readonly costService: CostRangeService,
     private readonly blockGuard: BlockGuard,
     private readonly projectChecker: ProjectChecker,
+    private readonly legacyProjectChecker: LegacyProjectImportChecker,
     private readonly protectedArea: ProtectedAreaService,
     private readonly queryBus: QueryBus,
     private readonly commandBus: CommandBus,
@@ -281,6 +283,13 @@ export class ScenariosService {
         return left(projectNotReady);
       }
     }
+    const isLegacyProjectCompleted = await this.legacyProjectChecker.isLegacyProjectImportCompletedFor(
+      input.projectId,
+    );
+
+    if (isRight(isLegacyProjectCompleted) && !isLegacyProjectCompleted.right)
+      return left(projectNotReady);
+
     const scenario = await this.crudService.create(validatedMetadata, info);
     const blmCreationResult = await this.commandBus.execute(
       new CreateInitialScenarioBlm(scenario.id, scenario.projectId),


### PR DESCRIPTION
This PR adds:

- `LegacyProjectImportChecker` service. Now block guard checks if a project is blocked depending if there is an ongoing legacy project import for the given project.

### Feature relevant tickets
[Block legacy projects being imported](https://vizzuality.atlassian.net/browse/MARXAN-1612)


