### PR TITLE
add dat file delimiter finder service and adapt legacy importers 

### DIFF
--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features-specification.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features-specification.legacy-piece-importer.ts
@@ -96,13 +96,13 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
   }
 
   private async getSpecDatData(files: LegacyProjectImportFileSnapshot[]) {
-    const fisrtLineReadable = await this.getFileReadable(
+    const firstLineReadable = await this.getFileReadable(
       files,
       LegacyProjectImportFileType.SpecDat,
     );
 
     const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
-      fisrtLineReadable,
+      firstLineReadable,
     );
     if (isLeft(delimiterOrError))
       this.logAndThrow(
@@ -125,13 +125,13 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
   }
 
   private async getPuvsprDatData(files: LegacyProjectImportFileSnapshot[]) {
-    const fisrtLineReadable = await this.getFileReadable(
+    const firstLineReadable = await this.getFileReadable(
       files,
       LegacyProjectImportFileType.PuvsprDat,
     );
 
     const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
-      fisrtLineReadable,
+      firstLineReadable,
     );
     if (isLeft(delimiterOrError))
       this.logAndThrow(

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features-specification.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features-specification.legacy-piece-importer.ts
@@ -24,6 +24,7 @@ import {
   specDatFeatureIdPropertyKey,
   specDatPuidPropertyKey,
 } from './features.legacy-piece-importer';
+import { DatFileDelimiterFinder } from './file-readers/dat-file.delimiter-finder';
 import {
   PuvrsprDatRow,
   PuvsprDatReader,
@@ -53,6 +54,7 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
     private readonly filesRepo: LegacyProjectImportFilesRepository,
     private readonly specDatReader: SpecDatReader,
     private readonly puvsprDatReader: PuvsprDatReader,
+    private readonly datFileDelimiterFinder: DatFileDelimiterFinder,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly apiEntityManager: EntityManager,
     @InjectRepository(GeoFeatureGeometry)
@@ -91,6 +93,64 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
       this.logAndThrow(`${type} file not found in files repo`);
 
     return readableOrError.right;
+  }
+
+  private async getSpecDatData(files: LegacyProjectImportFileSnapshot[]) {
+    const fisrtLineReadable = await this.getFileReadable(
+      files,
+      LegacyProjectImportFileType.SpecDat,
+    );
+
+    const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
+      fisrtLineReadable,
+    );
+    if (isLeft(delimiterOrError))
+      this.logAndThrow(
+        `Invalid delimiter in spec.dat file. Use either comma or tabulator as your file delimiter.`,
+      );
+
+    const fileReadable = await this.getFileReadable(
+      files,
+      LegacyProjectImportFileType.SpecDat,
+    );
+
+    const rowsOrError = await this.specDatReader.readFile(
+      fileReadable,
+      delimiterOrError.right,
+    );
+    if (isLeft(rowsOrError))
+      this.logAndThrow(`Error in spec.dat file: ${rowsOrError.left}`);
+
+    return rowsOrError.right;
+  }
+
+  private async getPuvsprDatData(files: LegacyProjectImportFileSnapshot[]) {
+    const fisrtLineReadable = await this.getFileReadable(
+      files,
+      LegacyProjectImportFileType.PuvsprDat,
+    );
+
+    const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
+      fisrtLineReadable,
+    );
+    if (isLeft(delimiterOrError))
+      this.logAndThrow(
+        `Invalid delimiter in puvspr.dat file. Use either comma or tabulator as your file delimiter.`,
+      );
+
+    const fileReadable = await this.getFileReadable(
+      files,
+      LegacyProjectImportFileType.PuvsprDat,
+    );
+
+    const rowsOrError = await this.puvsprDatReader.readFile(
+      fileReadable,
+      delimiterOrError.right,
+    );
+    if (isLeft(rowsOrError))
+      this.logAndThrow(`Error in puvspr.dat file: ${rowsOrError.left}`);
+
+    return rowsOrError.right;
   }
 
   private getFeaturesInPuvsprNotInSpec(
@@ -337,28 +397,12 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
   ): Promise<LegacyProjectImportJobOutput> {
     const { files, projectId, scenarioId } = input;
 
-    const specDatReadable = await this.getFileReadable(
-      files,
-      LegacyProjectImportFileType.SpecDat,
-    );
-    const puvsprDatReadable = await this.getFileReadable(
-      files,
-      LegacyProjectImportFileType.PuvsprDat,
-    );
-
-    const specRowsOrError = await this.specDatReader.readFile(specDatReadable);
-    const puvsprRowsOrError = await this.puvsprDatReader.readFile(
-      puvsprDatReadable,
-    );
-
-    if (isLeft(specRowsOrError))
-      this.logAndThrow(`Error in spec.dat file: ${specRowsOrError.left}`);
-    if (isLeft(puvsprRowsOrError))
-      this.logAndThrow(`Error in puvspr.dat file: ${puvsprRowsOrError.left}`);
+    const specRowsOrError = await this.getSpecDatData(files);
+    const puvsprRowsOrError = await this.getPuvsprDatData(files);
 
     const notFoundFeatureIds = this.getFeaturesInPuvsprNotInSpec(
-      specRowsOrError.right,
-      puvsprRowsOrError.right,
+      specRowsOrError,
+      puvsprRowsOrError,
     );
 
     if (notFoundFeatureIds.length) {
@@ -369,14 +413,11 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
       );
     }
 
-    const specRows = this.getPropSpecRows(
-      specRowsOrError.right,
-      puvsprRowsOrError.right,
-    );
+    const specRows = this.getPropSpecRows(specRowsOrError, puvsprRowsOrError);
     await this.runSpecification(specRows, projectId, scenarioId);
     await this.updateScenarioFeaturesData(
       specRows,
-      puvsprRowsOrError.right,
+      puvsprRowsOrError,
       scenarioId,
     );
 

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features.legacy-piece-importer.ts
@@ -85,13 +85,13 @@ export class FeaturesLegacyProjectPieceImporter
   }
 
   private async getSpecDatData(files: LegacyProjectImportFileSnapshot[]) {
-    const fisrtLineReadable = await this.getFileReadable(
+    const firstLineReadable = await this.getFileReadable(
       files,
       LegacyProjectImportFileType.SpecDat,
     );
 
     const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
-      fisrtLineReadable,
+      firstLineReadable,
     );
     if (isLeft(delimiterOrError))
       this.logAndThrow(
@@ -114,13 +114,13 @@ export class FeaturesLegacyProjectPieceImporter
   }
 
   private async getPuvsprDatData(files: LegacyProjectImportFileSnapshot[]) {
-    const fisrtLineReadable = await this.getFileReadable(
+    const firstLineReadable = await this.getFileReadable(
       files,
       LegacyProjectImportFileType.PuvsprDat,
     );
 
     const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
-      fisrtLineReadable,
+      firstLineReadable,
     );
     if (isLeft(delimiterOrError))
       this.logAndThrow(

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.comma-or-tab-finder.spec.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.comma-or-tab-finder.spec.ts
@@ -1,0 +1,88 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Test } from '@nestjs/testing';
+import { isRight, isLeft } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+import {
+  DatFileCommaOrTab,
+  DatFileCommaOrTabFinder,
+} from './dat-file.comma-or-tab-finder';
+import { invalidDelimiter } from './dat-file.delimiter-finder';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+it('fails when dat file uses invalid delimiter', async () => {
+  const fileLocation = fixtures.GivenADatFileWithInvalidDelimiter();
+  const result = await fixtures.WhenGettingDaDelimiter(fileLocation);
+  fixtures.ThenDatFileFindDelimiterOperationFails(result);
+});
+
+it('succes when dat file uses comma delimiter', async () => {
+  const fileLocation = fixtures.GivenAValidDatFileWithCommas();
+  const result = await fixtures.WhenGettingDaDelimiter(fileLocation);
+  fixtures.ThenDatDelimiterIsSuccessfullyFound(result, ',');
+});
+
+it('succes when dat file uses tab delimiter', async () => {
+  const fileLocation = fixtures.GivenAValidDatFileWithTabs();
+  const result = await fixtures.WhenGettingDaDelimiter(fileLocation);
+  fixtures.ThenDatDelimiterIsSuccessfullyFound(result, '\t');
+});
+
+const getFixtures = async () => {
+  const sandbox = await Test.createTestingModule({
+    imports: [],
+    providers: [DatFileCommaOrTabFinder],
+  }).compile();
+  await sandbox.init();
+
+  const sut = sandbox.get(DatFileCommaOrTabFinder);
+  const tabHeaders = 'id\tcost\tstatus\txloc\tyloc\n';
+  const commaHeader = tabHeaders.replace(/\t/g, ',');
+  const invalidDelimiterHeader = tabHeaders.replace(/\t/g, ' ');
+  const amountOfRows = 100;
+
+  return {
+    GivenAValidDatFileWithCommas: () => {
+      const rows = Array(amountOfRows)
+        .fill('')
+        .map((_, index) => `${index},${index * 10},0,${index},${index}`);
+
+      return Readable.from(commaHeader + rows.join('\n'));
+    },
+    GivenAValidDatFileWithTabs: () => {
+      const rows = Array(amountOfRows)
+        .fill('')
+        .map((_, index) => `${index}\t${index * 10}\t0\t${index}\t${index}`);
+
+      return Readable.from(tabHeaders + rows.join('\n'));
+    },
+    GivenADatFileWithInvalidDelimiter: () => {
+      const rows = Array(amountOfRows)
+        .fill('')
+        .map((_, index) => `${index} ${index * 10}\t0 ${index} ${index}`);
+
+      return Readable.from(invalidDelimiterHeader + rows.join('\n'));
+    },
+    WhenGettingDaDelimiter: (file: Readable) => {
+      return sut.findDelimiter(file);
+    },
+    ThenDatDelimiterIsSuccessfullyFound: (
+      delimiter: DatFileCommaOrTab,
+      expectedDelimiter: ',' | '\t',
+    ) => {
+      if (isLeft(delimiter)) throw new Error('Expected right result, got left');
+
+      expect(delimiter.right).toEqual(expectedDelimiter);
+    },
+    ThenDatFileFindDelimiterOperationFails: (delimiter: DatFileCommaOrTab) => {
+      if (isRight(delimiter))
+        throw new Error('Expected left result, got right');
+
+      expect(delimiter.left).toEqual(invalidDelimiter);
+    },
+  };
+};

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.comma-or-tab-finder.spec.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.comma-or-tab-finder.spec.ts
@@ -16,19 +16,19 @@ beforeEach(async () => {
 
 it('fails when dat file uses invalid delimiter', async () => {
   const fileLocation = fixtures.GivenADatFileWithInvalidDelimiter();
-  const result = await fixtures.WhenGettingDaDelimiter(fileLocation);
+  const result = await fixtures.WhenGettingDatDelimiter(fileLocation);
   fixtures.ThenDatFileFindDelimiterOperationFails(result);
 });
 
 it('succes when dat file uses comma delimiter', async () => {
   const fileLocation = fixtures.GivenAValidDatFileWithCommas();
-  const result = await fixtures.WhenGettingDaDelimiter(fileLocation);
+  const result = await fixtures.WhenGettingDatDelimiter(fileLocation);
   fixtures.ThenDatDelimiterIsSuccessfullyFound(result, ',');
 });
 
 it('succes when dat file uses tab delimiter', async () => {
   const fileLocation = fixtures.GivenAValidDatFileWithTabs();
-  const result = await fixtures.WhenGettingDaDelimiter(fileLocation);
+  const result = await fixtures.WhenGettingDatDelimiter(fileLocation);
   fixtures.ThenDatDelimiterIsSuccessfullyFound(result, '\t');
 });
 
@@ -67,7 +67,7 @@ const getFixtures = async () => {
 
       return Readable.from(invalidDelimiterHeader + rows.join('\n'));
     },
-    WhenGettingDaDelimiter: (file: Readable) => {
+    WhenGettingDatDelimiter: (file: Readable) => {
       return sut.findDelimiter(file);
     },
     ThenDatDelimiterIsSuccessfullyFound: (

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.comma-or-tab-finder.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.comma-or-tab-finder.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { Either, left, right } from 'fp-ts/lib/Either';
+import { createInterface } from 'readline';
+import { Readable } from 'typeorm/platform/PlatformTools';
+import {
+  DatFileDelimiterFinder,
+  invalidDelimiter,
+} from './dat-file.delimiter-finder';
+
+export type DatFileCommaOrTab = Either<typeof invalidDelimiter, ',' | '\t'>;
+
+@Injectable()
+export class DatFileCommaOrTabFinder implements DatFileDelimiterFinder {
+  async findDelimiter(file: Readable): Promise<DatFileCommaOrTab> {
+    const rl = createInterface({
+      input: file,
+    });
+
+    const result = await new Promise<DatFileCommaOrTab>((resolve) => {
+      rl.on(`line`, (line) => {
+        const { tabDelimiter, commaDelimiter } = this.commaOrTabDelimiter(line);
+
+        if (!tabDelimiter && !commaDelimiter) resolve(left(invalidDelimiter));
+
+        resolve(right(tabDelimiter ? '\t' : ','));
+      });
+    });
+
+    rl.close();
+    return result;
+  }
+
+  private commaOrTabDelimiter = (line: string) => {
+    const tabPattern = /[a-z]\t[a-z]+/;
+    const commaPattern = /[a-z],[a-z]+/;
+
+    const tabDelimiter = tabPattern.test(line);
+    const commaDelimiter = commaPattern.test(line);
+
+    return { tabDelimiter, commaDelimiter };
+  };
+}

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.delimiter-finder.fake.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.delimiter-finder.fake.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { right } from 'fp-ts/lib/Either';
+import { Readable } from 'typeorm/platform/PlatformTools';
+import {
+  DatFileDelimiter,
+  DatFileDelimiterFinder,
+} from './dat-file.delimiter-finder';
+
+@Injectable()
+export class DatFileDelimiterFinderFake implements DatFileDelimiterFinder {
+  public delimiterFound: DatFileDelimiter = right('\t');
+  async findDelimiter(file: Readable): Promise<DatFileDelimiter> {
+    return this.delimiterFound;
+  }
+}

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.delimiter-finder.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/dat-file.delimiter-finder.ts
@@ -1,0 +1,9 @@
+import { Either } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+
+export const invalidDelimiter = Symbol('invalid delitimiter');
+export type DatFileDelimiter = Either<typeof invalidDelimiter, string>;
+
+export abstract class DatFileDelimiterFinder {
+  abstract findDelimiter(file: Readable): Promise<DatFileDelimiter>;
+}

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/file-readers.module.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/file-readers.module.ts
@@ -16,6 +16,12 @@ import { SpecDatReader } from './spec-dat.reader';
     MarxanInput,
     { provide: DatFileDelimiterFinder, useClass: DatFileCommaOrTabFinder },
   ],
-  exports: [PuDatReader, SpecDatReader, PuvsprDatReader, InputDatReader],
+  exports: [
+    PuDatReader,
+    SpecDatReader,
+    PuvsprDatReader,
+    InputDatReader,
+    DatFileDelimiterFinder,
+  ],
 })
 export class FileReadersModule {}

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/file-readers.module.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/file-readers/file-readers.module.ts
@@ -1,5 +1,7 @@
 import { MarxanInput } from '@marxan/marxan-input';
 import { Module } from '@nestjs/common';
+import { DatFileCommaOrTabFinder } from './dat-file.comma-or-tab-finder';
+import { DatFileDelimiterFinder } from './dat-file.delimiter-finder';
 import { InputDatReader } from './input-dat.reader';
 import { PuDatReader } from './pu-dat.reader';
 import { PuvsprDatReader } from './puvspr-dat.reader';
@@ -12,6 +14,7 @@ import { SpecDatReader } from './spec-dat.reader';
     PuvsprDatReader,
     InputDatReader,
     MarxanInput,
+    { provide: DatFileDelimiterFinder, useClass: DatFileCommaOrTabFinder },
   ],
   exports: [PuDatReader, SpecDatReader, PuvsprDatReader, InputDatReader],
 })

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/scenarios-pus-data.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/scenarios-pus-data.legacy-piece-importer.ts
@@ -22,6 +22,7 @@ import {
   LegacyProjectImportPieceProcessor,
   LegacyProjectImportPieceProcessorProvider,
 } from '../pieces/legacy-project-import-piece-processor';
+import { DatFileDelimiterFinder } from './file-readers/dat-file.delimiter-finder';
 import { PuDatReader, PuDatRow } from './file-readers/pu-dat.reader';
 
 @Injectable()
@@ -31,6 +32,7 @@ export class ScenarioPusDataLegacyProjectPieceImporter
   constructor(
     private readonly filesRepo: LegacyProjectImportFilesRepository,
     private readonly puDatReader: PuDatReader,
+    private readonly datFileDelimiterFinder: DatFileDelimiterFinder,
     @InjectEntityManager(geoprocessingConnections.default.name)
     private readonly geoEntityManager: EntityManager,
     private readonly logger: Logger,
@@ -45,6 +47,37 @@ export class ScenarioPusDataLegacyProjectPieceImporter
   private logAndThrow(message: string): never {
     this.logger.error(message);
     throw new Error(message);
+  }
+
+  private async getPuDatReabale(fileLocation: string) {
+    const readable = await this.filesRepo.get(fileLocation);
+    if (isLeft(readable))
+      this.logAndThrow('pu.dat file not found in files repo');
+
+    return readable.right;
+  }
+
+  private async getPuDatData(fileLocation: string) {
+    const fisrtLineReadable = await this.getPuDatReabale(fileLocation);
+
+    const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
+      fisrtLineReadable,
+    );
+    if (isLeft(delimiterOrError))
+      this.logAndThrow(
+        'Invalid delimiter in pu.dat file. Use either comma or tabulator as your file delimiter.',
+      );
+
+    const fileReadable = await this.getPuDatReabale(fileLocation);
+
+    const rowsOrError = await this.puDatReader.readFile(
+      fileReadable,
+      delimiterOrError.right,
+    );
+    if (isLeft(rowsOrError))
+      this.logAndThrow(`Error in pu.dat file: ${rowsOrError.left}`);
+
+    return rowsOrError.right;
   }
 
   private getNotFoundPuids(
@@ -161,15 +194,9 @@ export class ScenarioPusDataLegacyProjectPieceImporter
     if (!puDatFile)
       this.logAndThrow('pu.dat file not found inside input files array');
 
-    const readable = await this.filesRepo.get(puDatFile.location);
-    if (isLeft(readable))
-      this.logAndThrow('pu.dat file not found in files repo');
+    const rowsOrError = await this.getPuDatData(puDatFile.location);
 
-    const rowsOrError = await this.puDatReader.readFile(readable.right);
-    if (isLeft(rowsOrError))
-      this.logAndThrow(`Error in pu.dat file: ${rowsOrError.left}`);
-
-    const duplicatePuids = this.checkPuidsUniqueness(rowsOrError.right);
+    const duplicatePuids = this.checkPuidsUniqueness(rowsOrError);
     if (duplicatePuids.length)
       this.logAndThrow(
         `pu.dat file contains rows with the same puid. Duplicate puids: ${duplicatePuids.join(
@@ -191,7 +218,7 @@ export class ScenarioPusDataLegacyProjectPieceImporter
 
       const puidsNotPresentInPuDat = this.checkThatEveryProjectPuIsInPuDatRows(
         projectPuIdByPuid,
-        rowsOrError.right,
+        rowsOrError,
       );
       if (puidsNotPresentInPuDat.length)
         this.logAndThrow(
@@ -201,7 +228,7 @@ export class ScenarioPusDataLegacyProjectPieceImporter
         );
 
       await Promise.all(
-        chunk(rowsOrError.right, chunkSize).map(async (chunk) => {
+        chunk(rowsOrError, chunkSize).map(async (chunk) => {
           const notFound = this.getNotFoundPuids(chunk, projectPuIdByPuid);
           notFoundPuids.push(...notFound);
 

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/scenarios-pus-data.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/scenarios-pus-data.legacy-piece-importer.ts
@@ -58,10 +58,10 @@ export class ScenarioPusDataLegacyProjectPieceImporter
   }
 
   private async getPuDatData(fileLocation: string) {
-    const fisrtLineReadable = await this.getPuDatReabale(fileLocation);
+    const firstLineReadable = await this.getPuDatReabale(fileLocation);
 
     const delimiterOrError = await this.datFileDelimiterFinder.findDelimiter(
-      fisrtLineReadable,
+      firstLineReadable,
     );
     if (isLeft(delimiterOrError))
       this.logAndThrow(

--- a/api/apps/geoprocessing/test/integration/legacy-project-import/features-specification.legacy-piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/legacy-project-import/features-specification.legacy-piece-importer.e2e-spec.ts
@@ -1,4 +1,9 @@
 import {
+  DatFileDelimiterFinder,
+  invalidDelimiter,
+} from '@marxan-geoprocessing/legacy-project-import/legacy-piece-importers/file-readers/dat-file.delimiter-finder';
+import { DatFileDelimiterFinderFake } from '@marxan-geoprocessing/legacy-project-import/legacy-piece-importers/file-readers/dat-file.delimiter-finder.fake';
+import {
   PuvrsprDatRow,
   PuvsprDatReader,
 } from '@marxan-geoprocessing/legacy-project-import/legacy-piece-importers/file-readers/puvspr-dat.reader';
@@ -79,6 +84,19 @@ describe(FeaturesSpecificationLegacyProjectPieceImporter, () => {
       .ThenADatFileNotFoundInFilesRepoErrorShouldBeThrown(specDatFileType);
   });
 
+  it('fails when invalid delimiter is used on spec.dat', async () => {
+    const specDatFileType = LegacyProjectImportFileType.SpecDat;
+    const location = await fixtures.GivenDatFileIsAvailableInFilesRepository(
+      specDatFileType,
+    );
+    const job = fixtures.GivenJobInput({ specDatFileLocation: location });
+    fixtures.GivenSpecDatFileWithInvalidDelimiter();
+
+    await fixtures
+      .WhenPieceImporterIsInvoked(job)
+      .ThenADatFileInvalidDelimiterErrorShouldBeThrown(specDatFileType);
+  });
+
   it('fails when read operation on spec.dat fails', async () => {
     const specDatFileType = LegacyProjectImportFileType.SpecDat;
     const puvsprDatFileType = LegacyProjectImportFileType.PuvsprDat;
@@ -110,6 +128,7 @@ describe(FeaturesSpecificationLegacyProjectPieceImporter, () => {
     );
 
     const job = fixtures.GivenJobInput({ specDatFileLocation });
+    fixtures.GivenValidSpecDatFile();
 
     await fixtures
       .WhenPieceImporterIsInvoked(job)
@@ -128,6 +147,7 @@ describe(FeaturesSpecificationLegacyProjectPieceImporter, () => {
       specDatFileLocation,
       puvsprDatFileLocation: 'wrong location',
     });
+    fixtures.GivenValidSpecDatFile();
 
     await fixtures
       .WhenPieceImporterIsInvoked(job)
@@ -345,6 +365,10 @@ const getFixtures = async () => {
         useClass: FakePuvsprDatReader,
       },
       {
+        provide: DatFileDelimiterFinder,
+        useClass: DatFileDelimiterFinderFake,
+      },
+      {
         provide: HttpService,
         useClass: FakeHttpService,
       },
@@ -366,6 +390,9 @@ const getFixtures = async () => {
   const filesRepo = sandbox.get(LegacyProjectImportFilesRepository);
   const fakeSpecDatReader: FakeSpecDatReader = sandbox.get(SpecDatReader);
   const fakePuvsprDatReader: FakePuvsprDatReader = sandbox.get(PuvsprDatReader);
+  const fakeDatFileDelimiterFinder: DatFileDelimiterFinderFake = sandbox.get(
+    DatFileDelimiterFinder,
+  );
   const fakeHttpService: FakeHttpService = sandbox.get(HttpService);
 
   const apiEntityManager = sandbox.get<EntityManager>(
@@ -391,6 +418,8 @@ const getFixtures = async () => {
 
   const readOperationError = (file: LegacyProjectImportFileType) =>
     `error reading ${file} file`;
+  const invalidDelimiterError = (file: LegacyProjectImportFileType) =>
+    `Invalid delimiter in ${file} file. Use either comma or tabulator as your file delimiter.`;
 
   const featuresIds: string[] = [];
 
@@ -539,6 +568,9 @@ const getFixtures = async () => {
         { id: 2, prop: 0.5, name: 'first' },
       ]);
     },
+    GivenSpecDatFileWithInvalidDelimiter: () => {
+      fakeDatFileDelimiterFinder.delimiterFound = left(invalidDelimiter);
+    },
     GivenInvalidSpecDatFile: () => {
       fakeSpecDatReader.readOperationResult = left(
         readOperationError(specDatFileType),
@@ -664,6 +696,13 @@ const getFixtures = async () => {
         ) => {
           await expect(sut.run(input)).rejects.toThrow(
             new RegExp(`${file} file not found in files repo`, 'gi'),
+          );
+        },
+        ThenADatFileInvalidDelimiterErrorShouldBeThrown: async (
+          file: LegacyProjectImportFileType,
+        ) => {
+          await expect(sut.run(input)).rejects.toThrow(
+            invalidDelimiterError(file),
           );
         },
         ThenADatFileReadOperationErrorShouldBeThrown: async (


### PR DESCRIPTION
This PR adds `DatFileDelimiterFinder` service and adapts legacy importers so they can read dat files using commas and tabs as delimiters 

### Feature relevant tickets
[Support tabs and commas as delimiters when reading dat files](https://vizzuality.atlassian.net/browse/MARXAN-1639)

