### PR TITLE
Feat/marxan 250 cascade deletion of projects to associated resources

### DIFF
--- a/api/apps/api/src/modules/projects/delete-project/delete-project.command.ts
+++ b/api/apps/api/src/modules/projects/delete-project/delete-project.command.ts
@@ -1,0 +1,14 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+import { Either } from 'fp-ts/lib/Either';
+
+export const deleteProjectFailed = Symbol('delete-project-failed');
+
+export type DeleteProjectFailed = typeof deleteProjectFailed;
+
+export type DeleteProjectResponse = Either<DeleteProjectFailed, true>;
+
+export class DeleteProject extends Command<DeleteProjectResponse> {
+  constructor(public readonly projectId: string) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/projects/delete-project/delete-project.handler.spec.ts
+++ b/api/apps/api/src/modules/projects/delete-project/delete-project.handler.spec.ts
@@ -1,0 +1,111 @@
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import { FakeLogger } from '@marxan-api/utils/__mocks__/fake-logger';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Injectable, Logger } from '@nestjs/common';
+import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { v4 } from 'uuid';
+import { ProjectDeleted } from '../events/project-deleted.event';
+import { Project } from '../project.api.entity';
+import { DeleteProject } from './delete-project.command';
+import { DeleteProjectHandler } from './delete-project.handler';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+it('deletes a project and emits a ProjectDeleted event', async () => {
+  const projectId = fixtures.GivenProjectExits();
+
+  await fixtures.WhenAProjectIsDeleted(projectId);
+  await fixtures.ThenProjectIsDeletedDeleted(projectId);
+  fixtures.ThenAProjectDeletedEventIsEmitted(projectId);
+});
+
+it.todo('fails to delete a project ', async () => {});
+
+const getFixtures = async () => {
+  const projectCustomFeaturesIds = [v4(), v4(), v4()];
+  const sandbox = await Test.createTestingModule({
+    imports: [CqrsModule],
+    providers: [
+      { provide: getRepositoryToken(Project), useClass: FakeProjectRepo },
+      {
+        provide: getRepositoryToken(GeoFeature),
+        useValue: {
+          find: async () =>
+            projectCustomFeaturesIds.map((featureId) => ({ id: featureId })),
+        },
+      },
+      {
+        provide: Logger,
+        useClass: FakeLogger,
+      },
+      DeleteProjectHandler,
+    ],
+  }).compile();
+  await sandbox.init();
+
+  const scenarioIds = [v4(), v4(), v4()];
+
+  const events: IEvent[] = [];
+
+  const sut = sandbox.get(DeleteProjectHandler);
+  const projectsRepo: FakeProjectRepo = sandbox.get(
+    getRepositoryToken(Project),
+  );
+
+  sandbox.get(EventBus).subscribe((event) => {
+    events.push(event);
+  });
+
+  return {
+    GivenProjectExits: () => {
+      const projectId = v4();
+      projectsRepo.projects.push({
+        id: projectId,
+        scenarios: scenarioIds.map((scenarioId) => ({
+          id: scenarioId,
+        })),
+      });
+      return projectId;
+    },
+    WhenAProjectIsDeleted: async (projectId: string) => {
+      return sut.execute(new DeleteProject(projectId));
+    },
+    ThenProjectIsDeletedDeleted: async (projectId: string) => {
+      const project = await projectsRepo.find({ where: { projectId } });
+      expect(project).toBeUndefined();
+    },
+    ThenAProjectDeletedEventIsEmitted: (projectId: string) => {
+      const projectDeletedEvent = events[0];
+
+      expect(projectDeletedEvent).toMatchObject({
+        projectId,
+        scenarioIds,
+        projectCustomFeaturesIds,
+      });
+      expect(projectDeletedEvent).toBeInstanceOf(ProjectDeleted);
+    },
+  };
+};
+
+@Injectable()
+class FakeProjectRepo {
+  public projects: { id: string; scenarios: { id: string }[] }[] = [];
+  async find(conditions: { where: { projectId: string } }) {
+    const res = this.projects.find(
+      (project) => project.id === conditions.where.projectId,
+    );
+    return res ? [res] : undefined;
+  }
+  async delete(projectId: string) {
+    const index = this.projects.findIndex(
+      (project) => project.id === projectId,
+    );
+    this.projects.splice(index, 1);
+  }
+}

--- a/api/apps/api/src/modules/projects/delete-project/delete-project.handler.ts
+++ b/api/apps/api/src/modules/projects/delete-project/delete-project.handler.ts
@@ -1,0 +1,59 @@
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import {
+  CommandHandler,
+  EventBus,
+  IInferredCommandHandler,
+} from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { left, right } from 'fp-ts/lib/Either';
+import { Repository } from 'typeorm';
+import { ProjectDeleted } from '../events/project-deleted.event';
+import { Project } from '../project.api.entity';
+import {
+  DeleteProject,
+  deleteProjectFailed,
+  DeleteProjectResponse,
+} from './delete-project.command';
+
+@CommandHandler(DeleteProject)
+export class DeleteProjectHandler
+  implements IInferredCommandHandler<DeleteProject> {
+  constructor(
+    @InjectRepository(Project)
+    private readonly projectRepo: Repository<Project>,
+    @InjectRepository(GeoFeature)
+    private readonly featuresRepo: Repository<GeoFeature>,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute({ projectId }: DeleteProject): Promise<DeleteProjectResponse> {
+    try {
+      const [project] = await this.projectRepo.find({
+        where: { projectId },
+        relations: ['scenarios'],
+      });
+
+      const scenarioIds: string[] = [];
+      if (project.scenarios) {
+        project.scenarios.forEach((scenario) => scenarioIds.push(scenario.id));
+      }
+
+      const customProjectFeatures = await this.featuresRepo.find({
+        where: { projectId },
+      });
+      const customProjectFeaturesIds = customProjectFeatures.map(
+        (customFeature) => customFeature.id,
+      );
+
+      await this.projectRepo.delete(projectId);
+
+      this.eventBus.publish(
+        new ProjectDeleted(projectId, scenarioIds, customProjectFeaturesIds),
+      );
+
+      return right(true);
+    } catch (error) {
+      return left(deleteProjectFailed);
+    }
+  }
+}

--- a/api/apps/api/src/modules/projects/delete-project/delete-project.handler.ts
+++ b/api/apps/api/src/modules/projects/delete-project/delete-project.handler.ts
@@ -29,7 +29,7 @@ export class DeleteProjectHandler
   async execute({ projectId }: DeleteProject): Promise<DeleteProjectResponse> {
     try {
       const [project] = await this.projectRepo.find({
-        where: { projectId },
+        where: { id: projectId },
         relations: ['scenarios'],
       });
 

--- a/api/apps/api/src/modules/projects/delete-project/delete-project.module.ts
+++ b/api/apps/api/src/modules/projects/delete-project/delete-project.module.ts
@@ -1,0 +1,27 @@
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import { QueueApiEventsModule } from '@marxan-api/modules/queue-api-events';
+import { Logger, Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Project } from '../project.api.entity';
+import { DeleteProjectHandler } from './delete-project.handler';
+import { ProjectDeletedSaga } from './project-deleted.saga';
+import { ScheduleCleanupForProjectUnusedResourcesHandler } from './schedule-project-unused-resources-cleanup.handler';
+import { unusedResourcesCleanupQueueProvider } from './unused-resources-cleanup-queue.provider';
+
+@Module({
+  imports: [
+    CqrsModule,
+    QueueApiEventsModule,
+    TypeOrmModule.forFeature([Project, GeoFeature]),
+  ],
+  providers: [
+    unusedResourcesCleanupQueueProvider,
+    ProjectDeletedSaga,
+    DeleteProjectHandler,
+    ScheduleCleanupForProjectUnusedResourcesHandler,
+    Logger,
+  ],
+  exports: [],
+})
+export class DeleteProjectModule {}

--- a/api/apps/api/src/modules/projects/delete-project/project-deleted.saga.ts
+++ b/api/apps/api/src/modules/projects/delete-project/project-deleted.saga.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { ProjectDeleted } from '../events/project-deleted.event';
+import { ScheduleCleanupForProjectUnusedResources } from './schedule-project-unused-resources-cleanup.command';
+
+@Injectable()
+export class ProjectDeletedSaga {
+  @Saga()
+  calculateBlmDefaults = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(ProjectDeleted),
+      map(
+        (event) =>
+          new ScheduleCleanupForProjectUnusedResources(
+            event.projectId,
+            event.scenarioIds,
+            event.projectCustomFeaturesIds,
+          ),
+      ),
+    );
+}

--- a/api/apps/api/src/modules/projects/delete-project/schedule-project-unused-resources-cleanup.command.ts
+++ b/api/apps/api/src/modules/projects/delete-project/schedule-project-unused-resources-cleanup.command.ts
@@ -1,0 +1,11 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+
+export class ScheduleCleanupForProjectUnusedResources extends Command<void> {
+  constructor(
+    public readonly projectId: string,
+    public readonly scenarioIds: string[],
+    public readonly projectCustomFeaturesIds: string[],
+  ) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/projects/delete-project/schedule-project-unused-resources-cleanup.handler.ts
+++ b/api/apps/api/src/modules/projects/delete-project/schedule-project-unused-resources-cleanup.handler.ts
@@ -1,0 +1,39 @@
+import { UnusedResourcesCleanupJobInput } from '@marxan/unused-resources-cleanup';
+import { Inject, Logger } from '@nestjs/common';
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { Queue } from 'bullmq';
+import { ScheduleCleanupForProjectUnusedResources } from './schedule-project-unused-resources-cleanup.command';
+import { unusedResourcesCleanupQueueToken } from './unused-resources-cleanup-queue.provider';
+
+@CommandHandler(ScheduleCleanupForProjectUnusedResources)
+export class ScheduleCleanupForProjectUnusedResourcesHandler
+  implements IInferredCommandHandler<ScheduleCleanupForProjectUnusedResources> {
+  constructor(
+    @Inject(unusedResourcesCleanupQueueToken)
+    private readonly queue: Queue<UnusedResourcesCleanupJobInput>,
+    private logger: Logger,
+  ) {
+    this.logger.setContext(
+      ScheduleCleanupForProjectUnusedResourcesHandler.name,
+    );
+  }
+
+  async execute({
+    projectId,
+    projectCustomFeaturesIds,
+    scenarioIds,
+  }: ScheduleCleanupForProjectUnusedResources): Promise<void> {
+    const job = await this.queue.add(`project-unused-resources-cleanup`, {
+      projectId,
+      projectCustomFeaturesIds,
+      scenarioIds,
+    });
+
+    if (!job) {
+      this.logger.error(
+        `project-unused-resources-cleanup job couldn't be added to queue`,
+      );
+      return;
+    }
+  }
+}

--- a/api/apps/api/src/modules/projects/delete-project/unused-resources-cleanup-queue.provider.ts
+++ b/api/apps/api/src/modules/projects/delete-project/unused-resources-cleanup-queue.provider.ts
@@ -1,0 +1,22 @@
+import { QueueBuilder } from '@marxan-api/modules/queue';
+import {
+  UnusedResourcesCleanupJobInput,
+  unusedResourcesCleanupQueueName,
+} from '@marxan/unused-resources-cleanup';
+
+import { FactoryProvider } from '@nestjs/common';
+import { Queue } from 'bullmq';
+
+export const unusedResourcesCleanupQueueToken = Symbol(
+  'failed import db cleanup queue token',
+);
+
+export const unusedResourcesCleanupQueueProvider: FactoryProvider<
+  Queue<UnusedResourcesCleanupJobInput>
+> = {
+  provide: unusedResourcesCleanupQueueToken,
+  useFactory: (queueBuilder: QueueBuilder<UnusedResourcesCleanupJobInput>) => {
+    return queueBuilder.buildQueue(unusedResourcesCleanupQueueName);
+  },
+  inject: [QueueBuilder],
+};

--- a/api/apps/api/src/modules/projects/events/project-deleted.event.ts
+++ b/api/apps/api/src/modules/projects/events/project-deleted.event.ts
@@ -1,0 +1,9 @@
+import { IEvent } from '@nestjs/cqrs';
+
+export class ProjectDeleted implements IEvent {
+  constructor(
+    public readonly projectId: string,
+    public readonly scenarioIds: string[],
+    public readonly projectCustomFeaturesIds: string[],
+  ) {}
+}

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -142,6 +142,7 @@ import {
   AddFileToLegacyProjectImportBodyDto,
   AddFileToLegacyProjectImportResponseDto,
 } from './dto/legacy-project-import.dto';
+import { deleteProjectFailed } from './delete-project/delete-project.command';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -468,9 +469,14 @@ export class ProjectsController {
     const result = await this.projectsService.remove(id, req.user.id);
 
     if (isLeft(result)) {
-      throw new ForbiddenException();
+      switch (result.left) {
+        case deleteProjectFailed:
+          throw new InternalServerErrorException();
+        case false:
+          throw new ForbiddenException();
+      }
     }
-    return result.right;
+    return;
   }
 
   @IsMissingAclImplementation()

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -41,6 +41,7 @@ import { ExportComponentLocationEntity } from '../clone/export/adapters/entities
 import { ExportRepository } from '../clone/export/application/export-repository.port';
 import { TypeormExportRepository } from '../clone/export/adapters/typeorm-export.repository';
 import { LegacyProjectImportModule } from '../legacy-project-import/legacy-project-import.module';
+import { DeleteProjectModule } from './delete-project/delete-project.module';
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { LegacyProjectImportModule } from '../legacy-project-import/legacy-proje
     AccessControlModule,
     BlockGuardModule,
     ProjectCheckerModule,
+    DeleteProjectModule,
   ],
   providers: [
     ProjectsCrudService,

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -83,6 +83,10 @@ import {
 } from '../legacy-project-import/application/delete-file-from-legacy-project-import.command';
 import { GetLegacyProjectImportErrors } from '../legacy-project-import/application/get-legacy-project-import-errors.query';
 import { CancelLegacyProjectImport } from '../legacy-project-import/application/cancel-legacy-project-import.command';
+import {
+  DeleteProject,
+  DeleteProjectFailed,
+} from './delete-project/delete-project.command';
 
 export { validationFailed } from '../planning-areas';
 
@@ -442,13 +446,14 @@ export class ProjectsService {
   async remove(
     projectId: string,
     userId: string,
-  ): Promise<Either<Permit, void>> {
+  ): Promise<Either<Permit | DeleteProjectFailed, true>> {
     await this.blockGuard.ensureThatProjectIsNotBlocked(projectId);
 
     if (!(await this.projectAclService.canDeleteProject(userId, projectId))) {
       return left(false);
     }
-    return right(await this.projectsCrud.remove(projectId));
+
+    return this.commandBus.execute(new DeleteProject(projectId));
   }
 
   async getJobStatusFor(projectId: string, info: ProjectsRequest) {

--- a/api/apps/api/test/jest-e2e.json
+++ b/api/apps/api/test/jest-e2e.json
@@ -73,6 +73,8 @@
     "@marxan/cloning": "<rootDir>/../../../libs/cloning/src",
     "@marxan/legacy-project-import/(.*)": "<rootDir>/../../../libs/legacy-project-import/src/$1",
     "@marxan/legacy-project-import": "<rootDir>/../../../libs/legacy-project-import/src",
+    "@marxan/unused-resources-cleanup/(.*)": "<rootDir>/../../../libs/unused-resources-cleanup/src/$1",
+    "@marxan/unused-resources-cleanup": "<rootDir>/../../../libs/unused-resources-cleanup/src",
     "@marxan/webshot/(.*)": "<rootDir>../../../libs/webshot/src/$1",
     "@marxan/webshot": "<rootDir>../../../libs/webshot/src",
     "@marxan/geofeatures/(.*)": "<rootDir>/../../../libs/geofeatures/src/$1",

--- a/api/apps/api/test/project/delete-project.e2e-spec.ts
+++ b/api/apps/api/test/project/delete-project.e2e-spec.ts
@@ -17,6 +17,8 @@ test(`deleting a project should work`, async () => {
   await fixtures.WhenProjectIsDeleted();
 
   await fixtures.ThenProjectIsNotFound();
+
+  fixtures.ThenProjectDeleteEventHasBeenSent();
 });
 
 test(`deleting a project does not work if user is not in project`, async () => {

--- a/api/apps/geoprocessing/src/app.module.ts
+++ b/api/apps/geoprocessing/src/app.module.ts
@@ -20,6 +20,7 @@ import { ExportModule } from '@marxan-geoprocessing/export/export.module';
 import { ImportModule } from '@marxan-geoprocessing/import/import.module';
 import { PingController } from '@marxan-geoprocessing/modules/ping/ping.controller';
 import { LegacyProjectImportModule } from './legacy-project-import/legacy-project-import.module';
+import { UnusedResourcesCleanUpModule } from './modules/unused-resources-cleanup/unused-resources-cleanup.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { LegacyProjectImportModule } from './legacy-project-import/legacy-projec
     ExportModule,
     ImportModule,
     LegacyProjectImportModule,
+    UnusedResourcesCleanUpModule,
   ],
   controllers: [AppController, PingController],
   providers: [AppService],

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-project-unused-resources.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-project-unused-resources.ts
@@ -1,0 +1,58 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { ResourceKind } from '@marxan/cloning/domain';
+import { GeoFeatureGeometry } from '@marxan/geofeatures';
+import { PlanningArea } from '@marxan/planning-area-repository/planning-area.geo.entity';
+import { ProtectedArea } from '@marxan/protected-areas';
+import { DeleteUnsusedReosurces } from '@marxan/unused-resources-cleanup';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
+
+type DeleteProjectUnsusedReosurcesData = { projectCustomFeaturesIds: string[] };
+
+@Injectable()
+export class DeleteProjectUnsusedReosurces
+  implements DeleteUnsusedReosurces<DeleteProjectUnsusedReosurcesData> {
+  constructor(
+    @InjectEntityManager(geoprocessingConnections.apiDB)
+    private readonly apiEntityManager: EntityManager,
+    @InjectRepository(PlanningArea)
+    private readonly planningAreasRepo: Repository<PlanningArea>,
+    @InjectRepository(ProtectedArea)
+    private readonly protectedAreasRepo: Repository<ProtectedArea>,
+    @InjectRepository(GeoFeatureGeometry)
+    private readonly featuresDataRepo: Repository<GeoFeatureGeometry>,
+    @InjectRepository(ProjectsPuEntity)
+    private readonly projectsPuRepo: Repository<ProjectsPuEntity>,
+  ) {}
+  async removeUnusedResources(
+    projectId: string,
+    data: DeleteProjectUnsusedReosurcesData,
+  ): Promise<void> {
+    await this.apiEntityManager
+      .createQueryBuilder()
+      .delete()
+      .from('exports')
+      .where('resource_kind = :kind', { kind: ResourceKind.Project })
+      .andWhere('resource_id = :projectId', { projectId })
+      .execute();
+
+    await this.apiEntityManager
+      .createQueryBuilder()
+      .delete()
+      .from('imports')
+      .where('resource_kind = :kind', { kind: ResourceKind.Project })
+      .andWhere('resource_id = :projectId', { projectId })
+      .execute();
+
+    await this.planningAreasRepo.delete({ projectId });
+    //should we delete protected areas?
+    await this.protectedAreasRepo.delete({ projectId });
+    await this.featuresDataRepo.delete({
+      featureId: In(data.projectCustomFeaturesIds),
+    });
+
+    await this.projectsPuRepo.delete({ projectId });
+  }
+}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-scenario-unused-resources.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-scenario-unused-resources.ts
@@ -1,0 +1,10 @@
+import { DeleteUnsusedReosurces } from '@marxan/unused-resources-cleanup';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DeleteScenarioUnsusedReosurces
+  implements DeleteUnsusedReosurces<{}> {
+  async removeUnusedResources(scenarioId: string): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-unused-resources.module.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-unused-resources.module.ts
@@ -1,0 +1,39 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { BlmFinalResultEntity } from '@marxan/blm-calibration';
+import { ScenarioFeaturesData } from '@marxan/features';
+import { GeoFeatureGeometry } from '@marxan/geofeatures';
+import {
+  MarxanExecutionMetadataGeoEntity,
+  OutputScenariosPuDataGeoEntity,
+} from '@marxan/marxan-output';
+import { PlanningArea } from '@marxan/planning-area-repository/planning-area.geo.entity';
+import { ProtectedArea } from '@marxan/protected-areas';
+import { ScenariosPuPaDataGeo } from '@marxan/scenarios-planning-unit';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DeleteProjectUnsusedReosurces } from './delete-project-unused-resources';
+import { DeleteScenarioUnsusedReosurces } from './delete-scenario-unused-resources';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([], geoprocessingConnections.apiDB),
+    TypeOrmModule.forFeature(
+      [
+        BlmFinalResultEntity,
+        ScenariosPuPaDataGeo,
+        OutputScenariosPuDataGeoEntity,
+        PlanningArea,
+        ProtectedArea,
+        GeoFeatureGeometry,
+        ProjectsPuEntity,
+        ScenarioFeaturesData,
+        MarxanExecutionMetadataGeoEntity,
+      ],
+      geoprocessingConnections.default,
+    ),
+  ],
+  providers: [DeleteProjectUnsusedReosurces, DeleteScenarioUnsusedReosurces],
+  exports: [DeleteProjectUnsusedReosurces, DeleteScenarioUnsusedReosurces],
+})
+export class UnusedResourcesCleanUpModule {}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-unused-resources.module.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/delete-unused-resources/delete-unused-resources.module.ts
@@ -36,4 +36,4 @@ import { DeleteScenarioUnsusedReosurces } from './delete-scenario-unused-resourc
   providers: [DeleteProjectUnsusedReosurces, DeleteScenarioUnsusedReosurces],
   exports: [DeleteProjectUnsusedReosurces, DeleteScenarioUnsusedReosurces],
 })
-export class UnusedResourcesCleanUpModule {}
+export class DeleteUnusedResourcesModule {}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.module.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { WorkerModule } from '../worker';
+import { DeleteUnusedResourcesModule } from './delete-unused-resources/delete-unused-resources.module';
 import { UnusedResourcesCleanupProcessor } from './unused-resources-cleanup.processor';
 import { UnusedResourcesCleanupWorker } from './unused-resources-cleanup.worker';
 
 @Module({
-  imports: [WorkerModule],
+  imports: [WorkerModule, DeleteUnusedResourcesModule],
   providers: [UnusedResourcesCleanupWorker, UnusedResourcesCleanupProcessor],
 })
 export class UnusedResourcesCleanUpModule {}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.module.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WorkerModule } from '../worker';
+import { UnusedResourcesCleanupProcessor } from './unused-resources-cleanup.processor';
+import { UnusedResourcesCleanupWorker } from './unused-resources-cleanup.worker';
+
+@Module({
+  imports: [WorkerModule],
+  providers: [UnusedResourcesCleanupWorker, UnusedResourcesCleanupProcessor],
+})
+export class UnusedResourcesCleanUpModule {}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.processor.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.processor.ts
@@ -1,0 +1,59 @@
+import {
+  isUnusedScenarioResourcesCleanupJobInput,
+  UnusedProjectResourcesCleanupJobInput,
+  UnusedResourcesCleanupJobInput,
+  UnusedResourcesCleanupJobOutput,
+  UnusedScenarioResourcesCleanupJobInput,
+} from '@marxan/unused-resources-cleanup';
+import { Injectable } from '@nestjs/common';
+import { DeleteProjectUnsusedReosurces } from './delete-unused-resources/delete-project-unused-resources';
+import { DeleteScenarioUnsusedReosurces } from './delete-unused-resources/delete-scenario-unused-resources';
+
+@Injectable()
+export class UnusedResourcesCleanupProcessor {
+  constructor(
+    private readonly deleteProjectUnsusedReosurces: DeleteProjectUnsusedReosurces,
+    private readonly deleteScenarioUnsusedReosurces: DeleteScenarioUnsusedReosurces,
+  ) {}
+
+  private async cleanProjectAndScenariosResources({
+    projectId,
+    scenarioIds,
+    projectCustomFeaturesIds,
+  }: UnusedProjectResourcesCleanupJobInput) {
+    if (scenarioIds.length === 0)
+      return this.deleteProjectUnsusedReosurces.removeUnusedResources(
+        projectId,
+        { projectCustomFeaturesIds },
+      );
+
+    await Promise.all(
+      scenarioIds.map((scenarioId) =>
+        this.deleteScenarioUnsusedReosurces.removeUnusedResources(scenarioId),
+      ),
+    );
+
+    return this.deleteProjectUnsusedReosurces.removeUnusedResources(projectId, {
+      projectCustomFeaturesIds,
+    });
+  }
+
+  async run(
+    input: UnusedResourcesCleanupJobInput,
+  ): Promise<UnusedResourcesCleanupJobOutput> {
+    const isScenarioCleanUp = isUnusedScenarioResourcesCleanupJobInput(input);
+
+    if (isScenarioCleanUp) {
+      await this.deleteScenarioUnsusedReosurces.removeUnusedResources(
+        (input as UnusedScenarioResourcesCleanupJobInput).scenarioId,
+      );
+      return input;
+    }
+
+    await this.cleanProjectAndScenariosResources(
+      input as UnusedProjectResourcesCleanupJobInput,
+    );
+
+    return input;
+  }
+}

--- a/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.worker.ts
+++ b/api/apps/geoprocessing/src/modules/unused-resources-cleanup/unused-resources-cleanup.worker.ts
@@ -1,0 +1,32 @@
+import { failedImportDbCleanupQueueName } from '@marxan/cloning';
+import {
+  UnusedResourcesCleanupJobInput,
+  UnusedResourcesCleanupJobOutput,
+  unusedResourcesCleanupQueueName,
+} from '@marxan/unused-resources-cleanup';
+import { Injectable } from '@nestjs/common';
+import { Worker } from 'bullmq';
+import { WorkerBuilder } from '../worker';
+import { UnusedResourcesCleanupProcessor } from './unused-resources-cleanup.processor';
+
+@Injectable()
+export class UnusedResourcesCleanupWorker {
+  #worker: Worker<
+    UnusedResourcesCleanupJobInput,
+    UnusedResourcesCleanupJobOutput
+  >;
+
+  constructor(
+    private readonly wrapper: WorkerBuilder,
+    private readonly unusedResourcesCleanupProcessor: UnusedResourcesCleanupProcessor,
+  ) {
+    this.#worker = wrapper.build<
+      UnusedResourcesCleanupJobInput,
+      UnusedResourcesCleanupJobOutput
+    >(unusedResourcesCleanupQueueName, {
+      process: (job) => {
+        return this.unusedResourcesCleanupProcessor.run(job.data);
+      },
+    });
+  }
+}

--- a/api/apps/geoprocessing/test/jest-e2e.json
+++ b/api/apps/geoprocessing/test/jest-e2e.json
@@ -77,6 +77,8 @@
     "@marxan/cloning": "<rootDir>/../../libs/cloning/src",
     "@marxan/legacy-project-import/(.*)": "<rootDir>/../../libs/legacy-project-import/src/$1",
     "@marxan/legacy-project-import": "<rootDir>/../../libs/legacy-project-import/src",
+    "@marxan/unused-resources-cleanup/(.*)": "<rootDir>/../../libs/unused-resources-cleanup/src/$1",
+    "@marxan/unused-resources-cleanup": "<rootDir>/../../libs/unused-resources-cleanup/src",
     "@marxan/geofeatures/(.*)": "<rootDir>/../../libs/geofeatures/src/$1",
     "@marxan/geofeatures": "<rootDir>/../../libs/geofeatures/src",
     "@marxan/webshot/(.*)": "<rootDir>../../libs/webshot/src/$1",

--- a/api/libs/unused-resources-cleanup/src/delete-unused-resources.port.ts
+++ b/api/libs/unused-resources-cleanup/src/delete-unused-resources.port.ts
@@ -1,0 +1,3 @@
+export abstract class DeleteUnsusedReosurces<T> {
+  abstract removeUnusedResources(resourceId: string, data: T): Promise<void>;
+}

--- a/api/libs/unused-resources-cleanup/src/index.ts
+++ b/api/libs/unused-resources-cleanup/src/index.ts
@@ -1,0 +1,9 @@
+export { DeleteUnsusedReosurces } from './delete-unused-resources.port';
+export { unusedResourcesCleanupQueueName } from './unused-resources-cleanup-queue-name';
+export {
+  isUnusedScenarioResourcesCleanupJobInput,
+  UnusedProjectResourcesCleanupJobInput,
+  UnusedScenarioResourcesCleanupJobInput,
+  UnusedResourcesCleanupJobInput,
+} from './job-input';
+export { UnusedResourcesCleanupJobOutput } from './job-output';

--- a/api/libs/unused-resources-cleanup/src/job-input.ts
+++ b/api/libs/unused-resources-cleanup/src/job-input.ts
@@ -1,0 +1,19 @@
+export type UnusedProjectResourcesCleanupJobInput = {
+  projectId: string;
+  scenarioIds: string[];
+  projectCustomFeaturesIds: string[];
+};
+export type UnusedScenarioResourcesCleanupJobInput = { scenarioId: string };
+
+export type UnusedResourcesCleanupJobInput =
+  | UnusedProjectResourcesCleanupJobInput
+  | UnusedScenarioResourcesCleanupJobInput;
+
+export function isUnusedScenarioResourcesCleanupJobInput(
+  jobInput: UnusedResourcesCleanupJobInput,
+): jobInput is UnusedScenarioResourcesCleanupJobInput {
+  return (
+    (jobInput as UnusedScenarioResourcesCleanupJobInput).scenarioId !==
+    undefined
+  );
+}

--- a/api/libs/unused-resources-cleanup/src/job-output.ts
+++ b/api/libs/unused-resources-cleanup/src/job-output.ts
@@ -1,0 +1,3 @@
+import { UnusedResourcesCleanupJobInput } from './job-input';
+
+export type UnusedResourcesCleanupJobOutput = UnusedResourcesCleanupJobInput;

--- a/api/libs/unused-resources-cleanup/src/unused-resources-cleanup-queue-name.ts
+++ b/api/libs/unused-resources-cleanup/src/unused-resources-cleanup-queue-name.ts
@@ -1,0 +1,1 @@
+export const unusedResourcesCleanupQueueName = `unused-resources-cleanup-queue-name`;

--- a/api/libs/unused-resources-cleanup/tsconfig.lib.json
+++ b/api/libs/unused-resources-cleanup/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+      "declaration": true,
+      "outDir": "../../dist/libs/unused-resources-cleanup"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+  }
+  

--- a/api/package.json
+++ b/api/package.json
@@ -241,6 +241,8 @@
       "@marxan/cloning": "<rootDir>/libs/cloning/src",
       "@marxan/legacy-project-import/(.*)": "<rootDir>/libs/legacy-project-import/src/$1",
       "@marxan/legacy-project-import": "<rootDir>/libs/legacy-project-import/src",
+      "@marxan/unused-resources-cleanup/(.*)": "<rootDir>/libs/unused-resources-cleanup/src/$1",
+      "@marxan/unused-resources-cleanup": "<rootDir>/libs/unused-resources-cleanup/src",
       "@marxan/code-guide/(.*)": "<rootDir>/libs/code-guide/src/$1",
       "@marxan/code-guide": "<rootDir>/libs/code-guide/src",
       "@marxan/webshot/(.*)": "<rootDir>/libs/webshot/src/$1",

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -85,6 +85,8 @@
       "@marxan/legacy-project-import/*": ["libs/legacy-project-import/src/*"],
       "@marxan/cloning": ["libs/cloning/src"],
       "@marxan/cloning/*": ["libs/cloning/src/*"],
+      "@marxan/unused-resources-cleanup": ["libs/unused-resources-cleanup/src"],
+      "@marxan/unused-resources-cleanup/*": ["libs/unused-resources-cleanup/src/*"],
       "@marxan/code-guide": ["libs/code-guide/src"],
       "@marxan/code-guide/*": ["libs/code-guide/src/*"],
       "@marxan/webshot": ["libs/webshot/src"],


### PR DESCRIPTION
This PR adds the following features:

- `DeleteProject` command. Now when the user tries to delete a project,  a DeleteProject command will be send.
- `ProjectDeleted` event. Once the project has been successfully deleted in `DeleteProjectHandler`, the `ProjectDeleted` event will be emitted.
- `ScheduleCleanupForProjectUnusedResources` command. When the `ProjectDeleted` event is emitted, it triggers the `ScheduleCleanupForProjectUnusedResources` command to be sent.
- `UnusedResourcesCleanupWorker` worker. `ScheduleCleanupForProjectUnusedResourcesHandler` handler will add a job to `UnusedResourcesCleanupWorker` queue. 
- `UnusedResourcesCleanupProcessor` processor. `UnusedResourcesCleanupWorker` worker calls `UnusedResourcesCleanupProcessor` processor to run the jobs submitted to the queue 

### Feature relevant tickets

[[debt] Cascade deletion of projects to all associated resources (project-level geo data, scenarios...)](https://vizzuality.atlassian.net/browse/MARXAN-250)
