### PR TITLE
MARXAN-1643-modify-signup-to-include-bakground

### DIFF
--- a/api/apps/api/src/migrations/api/1655459736009-AddBackgroundColumnsToUser.ts
+++ b/api/apps/api/src/migrations/api/1655459736009-AddBackgroundColumnsToUser.ts
@@ -21,8 +21,8 @@ export class AddBackgroundColumnsToUser1655459736009
         );
 
         ALTER TABLE users
-            ADD COLUMN background background_options nullable,
-            ADD COLUMN level level_options nullable;
+            ADD COLUMN background background_options,
+            ADD COLUMN level level_options;
       `);
   }
 

--- a/api/apps/api/src/migrations/api/1655459736009-AddBackgroundColumnsToUser.ts
+++ b/api/apps/api/src/migrations/api/1655459736009-AddBackgroundColumnsToUser.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBackgroundColumnsToUser1655459736009
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        CREATE TYPE background_options AS ENUM (
+            'academic_research',
+            'conservation_planning'
+        );
+    
+        CREATE TYPE level_options AS ENUM (
+            'trainee',
+            'student',
+            'phd',
+            'faculty',
+            'ngo',
+            'private_sector',
+            'government',
+            'intergovernmental'
+        );
+
+        ALTER TABLE users
+            ADD COLUMN background background_options nullable,
+            ADD COLUMN level level_options nullable;
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE users
+            DROP COLUMN background,
+            DROP COLUMN level;
+        
+        DROP TYPE level_options;
+        DROP TYPE background_options;
+      `);
+  }
+}

--- a/api/apps/api/src/modules/authentication/authentication.service.ts
+++ b/api/apps/api/src/modules/authentication/authentication.service.ts
@@ -117,6 +117,8 @@ export class AuthenticationService {
     user.email = signupDto.email;
     user.fname = signupDto.fname;
     user.lname = signupDto.lname;
+    user.background = signupDto.background;
+    user.level = signupDto.level;
     const newUser = UsersService.getSanitizedUserMetadata(
       await this.usersRepository.save(user),
     );

--- a/api/apps/api/src/modules/authentication/dto/sign-up.dto.ts
+++ b/api/apps/api/src/modules/authentication/dto/sign-up.dto.ts
@@ -2,10 +2,27 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsDefined,
   IsEmail,
+  IsEnum,
   IsNotEmpty,
   IsOptional,
   IsString,
 } from 'class-validator';
+
+export enum Backgrounds {
+  academic_research_science = 'academic_research',
+  conservation_planning = 'conservation_planning',
+}
+
+export enum Levels {
+  trainee = 'trainee',
+  student = 'student',
+  phd = 'phd',
+  faculty = 'faculty',
+  ngo = 'ngo',
+  private_sector = 'private_sector',
+  government = 'government',
+  intergovernmental = 'intergovernmental',
+}
 
 export class SignUpDto {
   @IsOptional()
@@ -35,4 +52,14 @@ export class SignUpDto {
   @IsString()
   @ApiPropertyOptional()
   lname?: string;
+
+  @IsOptional()
+  @IsEnum(Backgrounds)
+  @ApiPropertyOptional()
+  background?: Backgrounds;
+
+  @IsOptional()
+  @IsEnum(Levels)
+  @ApiPropertyOptional()
+  level?: Levels;
 }

--- a/api/apps/api/src/modules/users/user.api.entity.ts
+++ b/api/apps/api/src/modules/users/user.api.entity.ts
@@ -12,6 +12,8 @@ import {
 import { Project } from '../projects/project.api.entity';
 import { Scenario } from '../scenarios/scenario.api.entity';
 import { BaseServiceResource } from '../../types/resource.interface';
+import { IsEnum } from 'class-validator';
+import { Backgrounds, Levels } from '../authentication/dto/sign-up.dto';
 
 export const userResource: BaseServiceResource = {
   className: 'User',
@@ -42,6 +44,16 @@ export class User {
   @ApiPropertyOptional()
   @Column('character varying')
   lname?: string | null;
+
+  @ApiPropertyOptional()
+  @Column('character varying')
+  @IsEnum(Backgrounds)
+  background?: Backgrounds;
+
+  @ApiPropertyOptional()
+  @Column('character varying')
+  @IsEnum(Levels)
+  level?: Levels;
 
   /**
    * User avatar, stored as data url.


### PR DESCRIPTION
-Adds two new columns and enums for `users` columns.
-Adapts sign-up endpoint to allow sending `background` and `level` information.