### PR TITLE
Feat/marxan 1653 remove exports and imports rows

### DIFF
--- a/api/apps/api/src/migrations/api/1655657559840-AddsExportIdToImportsTable.ts
+++ b/api/apps/api/src/migrations/api/1655657559840-AddsExportIdToImportsTable.ts
@@ -2,41 +2,11 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddExportIdToImport1655657559840 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const { id } = await queryRunner.query(
+    await queryRunner.query(
       `
-        SELECT id 
-        FROM exports
-        LIMIT 1;
+        DELETE FROM imports;
       `,
     );
-
-    if (id) {
-      await queryRunner.query(
-        `
-          ALTER TABLE imports
-          ADD COLUMN export_id uuid NOT NULL DEFAULT '${id}';
-        `,
-      );
-
-      await queryRunner.query(
-        `
-          ALTER TABLE imports
-          ALTER COLUMN export_id DROP DEFAULT;
-        `,
-      );
-
-      await queryRunner.query(
-        `
-          ALTER TABLE imports 
-          ADD FOREIGN KEY (export_id) 
-          REFERENCES exports(id)
-          ON DELETE CASCADE;
-        `,
-      );
-
-      return;
-    }
-
     await queryRunner.query(
       `
         ALTER TABLE imports

--- a/api/apps/api/src/migrations/api/1655657559840-AdsExportIdToImportsTable.ts
+++ b/api/apps/api/src/migrations/api/1655657559840-AdsExportIdToImportsTable.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddExportIdToImport1655657559840 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const { id } = await queryRunner.query(
+      `
+        SELECT id 
+        FROM exports
+        LIMIT 1;
+      `,
+    );
+
+    if (id) {
+      await queryRunner.query(
+        `
+          ALTER TABLE imports
+          ADD COLUMN export_id uuid NOT NULL DEFAULT '${id}';
+        `,
+      );
+
+      await queryRunner.query(
+        `
+          ALTER TABLE imports
+          ALTER COLUMN export_id DROP DEFAULT;
+        `,
+      );
+
+      await queryRunner.query(
+        `
+          ALTER TABLE imports 
+          ADD FOREIGN KEY (export_id) 
+          REFERENCES exports(id)
+          ON DELETE CASCADE;
+        `,
+      );
+
+      return;
+    }
+
+    await queryRunner.query(
+      `
+        ALTER TABLE imports
+        ADD COLUMN export_id uuid NOT NULL;
+      `,
+    );
+
+    await queryRunner.query(
+      `
+        ALTER TABLE imports 
+        ADD FOREIGN KEY (export_id) 
+        REFERENCES exports(id)
+        ON DELETE CASCADE;
+      `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+        ALTER TABLE imports
+        DROP COLUMN export_id;
+      `,
+    );
+  }
+}

--- a/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/memory-export.repository.ts
@@ -26,6 +26,10 @@ export class MemoryExportRepo implements ExportRepository {
     return right(true);
   }
 
+  async delete(exportId: ExportId): Promise<void> {
+    delete this.#memory[exportId.value];
+  }
+
   async findLatestExportsFor(
     projectId: string,
     limit = 5,

--- a/api/apps/api/src/modules/clone/export/adapters/typeorm-export.repository.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/typeorm-export.repository.ts
@@ -72,6 +72,10 @@ export class TypeormExportRepository implements ExportRepository {
     return right(true);
   }
 
+  async delete(exportId: ExportId): Promise<void> {
+    await this.exportRepo.delete({ id: exportId.value });
+  }
+
   async findLatestExportsFor(
     projectId: string,
     limit: number,

--- a/api/apps/api/src/modules/clone/export/application/export-repository.port.ts
+++ b/api/apps/api/src/modules/clone/export/application/export-repository.port.ts
@@ -11,6 +11,8 @@ export abstract class ExportRepository {
 
   abstract find(exportId: ExportId): Promise<Export | undefined>;
 
+  abstract delete(exportId: ExportId): Promise<void>;
+
   abstract findLatestExportsFor(
     projectId: string,
     limit: number,

--- a/api/apps/api/src/modules/clone/import/adapters/entities/imports.api.entity.ts
+++ b/api/apps/api/src/modules/clone/import/adapters/entities/imports.api.entity.ts
@@ -1,3 +1,4 @@
+import { ExportEntity } from '@marxan-api/modules/clone/export/adapters/entities/exports.api.entity';
 import { ResourceKind } from '@marxan/cloning/domain';
 import {
   Column,
@@ -51,6 +52,9 @@ export class ImportEntity {
   })
   isCloning!: boolean;
 
+  @Column({ type: 'uuid', name: 'export_id' })
+  exporttId!: string;
+
   @OneToMany(() => ImportComponentEntity, (component) => component.import, {
     cascade: true,
   })
@@ -64,6 +68,15 @@ export class ImportEntity {
     referencedColumnName: 'id',
   })
   owner!: User;
+
+  @ManyToOne(() => ExportEntity, (originExport) => originExport.id, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'export_id',
+    referencedColumnName: 'id',
+  })
+  export!: ExportEntity;
 
   static fromAggregate(importAggregate: Import): ImportEntity {
     const snapshot = importAggregate.toSnapshot();
@@ -80,6 +93,7 @@ export class ImportEntity {
     );
     entity.ownerId = snapshot.ownerId;
     entity.isCloning = snapshot.isCloning;
+    entity.exporttId = snapshot.exporttId;
     entity.resourceName = snapshot.resourceName;
 
     return entity;
@@ -95,6 +109,7 @@ export class ImportEntity {
       importPieces: this.components.map((component) => component.toSnapshot()),
       ownerId: this.ownerId,
       isCloning: this.isCloning,
+      exporttId: this.exporttId,
       resourceName: this.resourceName,
     });
   }

--- a/api/apps/api/src/modules/clone/import/adapters/entities/imports.api.entity.ts
+++ b/api/apps/api/src/modules/clone/import/adapters/entities/imports.api.entity.ts
@@ -53,7 +53,7 @@ export class ImportEntity {
   isCloning!: boolean;
 
   @Column({ type: 'uuid', name: 'export_id' })
-  exporttId!: string;
+  exportId!: string;
 
   @OneToMany(() => ImportComponentEntity, (component) => component.import, {
     cascade: true,
@@ -93,7 +93,7 @@ export class ImportEntity {
     );
     entity.ownerId = snapshot.ownerId;
     entity.isCloning = snapshot.isCloning;
-    entity.exporttId = snapshot.exporttId;
+    entity.exportId = snapshot.exportId;
     entity.resourceName = snapshot.resourceName;
 
     return entity;
@@ -109,7 +109,7 @@ export class ImportEntity {
       importPieces: this.components.map((component) => component.toSnapshot()),
       ownerId: this.ownerId,
       isCloning: this.isCloning,
-      exporttId: this.exporttId,
+      exportId: this.exportId,
       resourceName: this.resourceName,
     });
   }

--- a/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/complete-import-piece.handler.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
 import { v4 } from 'uuid';
+import { ExportId } from '../../export';
 import { MarkImportAsFailed } from '../../infra/import/mark-import-as-failed.command';
 import { MemoryImportRepository } from '../adapters/memory-import.repository.adapter';
 import {
@@ -149,6 +150,7 @@ const getFixtures = async () => {
   return {
     GivenImportWasRequested: async () => {
       const importResourceId = ResourceId.create();
+      const exportId = ExportId.create();
       const isCloning = false;
       const projectId = importResourceId;
       const pieces = [
@@ -164,6 +166,7 @@ const getFixtures = async () => {
         new ArchiveLocation('/tmp/location.zip'),
         pieces,
         isCloning,
+        exportId,
       );
 
       await repo.save(importInstance);

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.spec.ts
@@ -1,11 +1,9 @@
 import {
-  ArchiveLocation,
   ClonePiece,
   ComponentId,
   ResourceId,
   ResourceKind,
 } from '@marxan/cloning/domain';
-import { ExportConfigContent } from '@marxan/cloning/infrastructure/clone-piece-data/export-config';
 import { UserId } from '@marxan/domain-ids';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
@@ -27,11 +25,7 @@ import {
   PieceImportRequested,
 } from '../domain';
 import { ImportComponentStatuses } from '../domain/import/import-component-status';
-import { ExportConfigReader } from './export-config-reader';
-import {
-  ImportProject,
-  ImportProjectCommandResult,
-} from './import-project.command';
+import { ImportProject } from './import-project.command';
 import { ImportProjectHandler } from './import-project.handler';
 import { ImportResourcePieces } from './import-resource-pieces.port';
 import { ImportRepository, Success } from './import.repository.port';
@@ -221,6 +215,10 @@ class FakeExportRepository implements ExportRepository {
     },
   ): Promise<Export[]> {
     return [];
+  }
+
+  delete(exportId: ExportId): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   transaction<T>(code: (repo: ExportRepository) => Promise<T>): Promise<T> {

--- a/api/apps/api/src/modules/clone/import/application/import-project.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-project.handler.ts
@@ -80,6 +80,7 @@ export class ImportProjectHandler
         archiveLocation,
         pieces,
         isCloning,
+        exportId,
         projectName,
       ),
     );

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.spec.ts
@@ -219,6 +219,10 @@ class FakeExportRepository implements ExportRepository {
     return [];
   }
 
+  delete(exportId: ExportId): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
   transaction<T>(code: (repo: ExportRepository) => Promise<T>): Promise<T> {
     throw new Error('Method not implemented.');
   }

--- a/api/apps/api/src/modules/clone/import/application/import-scenario.handler.ts
+++ b/api/apps/api/src/modules/clone/import/application/import-scenario.handler.ts
@@ -88,6 +88,7 @@ export class ImportScenarioHandler
         archiveLocation,
         pieces,
         isCloning,
+        exportId,
       ),
     );
 

--- a/api/apps/api/src/modules/clone/import/domain/events/all-pieces-imported.event.ts
+++ b/api/apps/api/src/modules/clone/import/domain/events/all-pieces-imported.event.ts
@@ -1,3 +1,4 @@
+import { ExportId } from '@marxan-api/modules/clone/export';
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { IEvent } from '@nestjs/cqrs';
 import { ImportId } from '../import/import.id';
@@ -5,6 +6,7 @@ import { ImportId } from '../import/import.id';
 export class AllPiecesImported implements IEvent {
   constructor(
     public readonly importId: ImportId,
+    public readonly exportId: ExportId,
     public readonly resourceId: ResourceId,
     public readonly resourceKind: ResourceKind,
     public readonly isCloning: boolean,

--- a/api/apps/api/src/modules/clone/import/domain/import/import.snapshot.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.snapshot.ts
@@ -10,5 +10,6 @@ export interface ImportSnapshot {
   projectId: string;
   ownerId: string;
   isCloning: boolean;
+  exporttId: string;
   resourceName?: string;
 }

--- a/api/apps/api/src/modules/clone/import/domain/import/import.snapshot.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.snapshot.ts
@@ -10,6 +10,6 @@ export interface ImportSnapshot {
   projectId: string;
   ownerId: string;
   isCloning: boolean;
-  exporttId: string;
+  exportId: string;
   resourceName?: string;
 }

--- a/api/apps/api/src/modules/clone/import/domain/import/import.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.ts
@@ -15,6 +15,7 @@ import { PieceImported } from '../events/piece-imported.event';
 import { ImportComponent } from './import-component';
 import { ImportId } from './import.id';
 import { ImportSnapshot } from './import.snapshot';
+import { ExportId } from '@marxan-api/modules/clone/export';
 
 export const componentNotFound = Symbol(`component not found`);
 export const componentAlreadyCompleted = Symbol(`component already completed`);
@@ -38,6 +39,7 @@ export class Import extends AggregateRoot {
     private readonly archiveLocation: ArchiveLocation,
     private readonly pieces: ImportComponent[],
     private readonly isCloning: boolean,
+    private readonly exportId: ExportId,
     private readonly resourceName?: string,
   ) {
     super();
@@ -68,6 +70,7 @@ export class Import extends AggregateRoot {
       new ArchiveLocation(snapshot.archiveLocation),
       snapshot.importPieces.map(ImportComponent.fromSnapshot),
       snapshot.isCloning,
+      new ExportId(snapshot.exporttId),
       snapshot.resourceName,
     );
   }
@@ -80,6 +83,7 @@ export class Import extends AggregateRoot {
     archiveLocation: ArchiveLocation,
     pieces: ImportComponent[],
     isCloning: boolean,
+    exportId: ExportId,
     resourceName?: string,
   ): Import {
     const id = ImportId.create();
@@ -92,6 +96,7 @@ export class Import extends AggregateRoot {
       archiveLocation,
       pieces,
       isCloning,
+      exportId,
       resourceName,
     );
 
@@ -178,6 +183,7 @@ export class Import extends AggregateRoot {
       this.apply(
         new AllPiecesImported(
           this.importId,
+          this.exportId,
           this.resourceId,
           this.resourceKind,
           this.isCloning,
@@ -206,6 +212,7 @@ export class Import extends AggregateRoot {
       projectId: this.projectId.value,
       ownerId: this.ownerId.value,
       isCloning: this.isCloning,
+      exporttId: this.exportId.value,
       resourceName: this.resourceName,
     };
   }

--- a/api/apps/api/src/modules/clone/import/domain/import/import.ts
+++ b/api/apps/api/src/modules/clone/import/domain/import/import.ts
@@ -70,7 +70,7 @@ export class Import extends AggregateRoot {
       new ArchiveLocation(snapshot.archiveLocation),
       snapshot.importPieces.map(ImportComponent.fromSnapshot),
       snapshot.isCloning,
-      new ExportId(snapshot.exporttId),
+      new ExportId(snapshot.exportId),
       snapshot.resourceName,
     );
   }
@@ -212,7 +212,7 @@ export class Import extends AggregateRoot {
       projectId: this.projectId.value,
       ownerId: this.ownerId.value,
       isCloning: this.isCloning,
-      exporttId: this.exportId.value,
+      exportId: this.exportId.value,
       resourceName: this.resourceName,
     };
   }

--- a/api/apps/api/src/modules/clone/infra/import/all-pieces-imported.saga.ts
+++ b/api/apps/api/src/modules/clone/infra/import/all-pieces-imported.saga.ts
@@ -12,13 +12,17 @@ export class AllPiecesImportedSaga {
   finalizeArchive = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
       ofType(AllPiecesImported),
-      mergeMap(({ importId, resourceId, resourceKind, isCloning }) => {
-        if (isCloning)
+      mergeMap(
+        ({ importId, exportId, resourceId, resourceKind, isCloning }) => {
+          if (isCloning)
+            return of(
+              new MarkCloneAsFinished(exportId, resourceId, resourceKind),
+              new MarkImportAsFinished(importId, resourceId, resourceKind),
+            );
           return of(
-            new MarkImportAsFinished(importId),
-            new MarkCloneAsFinished(resourceId, resourceKind),
+            new MarkImportAsFinished(importId, resourceId, resourceKind),
           );
-        return of(new MarkImportAsFinished(importId));
-      }),
+        },
+      ),
     );
 }

--- a/api/apps/api/src/modules/clone/infra/import/mark-clone-as-finished.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-clone-as-finished.command.ts
@@ -1,8 +1,10 @@
 import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { Command } from '@nestjs-architects/typed-cqrs';
+import { ExportId } from '../../export';
 
 export class MarkCloneAsFinished extends Command<void> {
   constructor(
+    public readonly exportId: ExportId,
     public readonly resourceId: ResourceId,
     public readonly resourceKind: ResourceKind,
   ) {

--- a/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.command.ts
+++ b/api/apps/api/src/modules/clone/infra/import/mark-import-as-finished.command.ts
@@ -1,8 +1,13 @@
+import { ResourceId, ResourceKind } from '@marxan/cloning/domain';
 import { Command } from '@nestjs-architects/typed-cqrs';
 import { ImportId } from '../../import/domain';
 
 export class MarkImportAsFinished extends Command<void> {
-  constructor(public readonly importId: ImportId) {
+  constructor(
+    public readonly importId: ImportId,
+    public readonly resourceId: ResourceId,
+    public readonly resourceKind: ResourceKind,
+  ) {
     super();
   }
 }

--- a/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
+++ b/api/apps/api/src/modules/clone/infra/import/schedule-piece-import.handler.spec.ts
@@ -12,6 +12,7 @@ import { Logger } from '@nestjs/common';
 import { CommandBus, CommandHandler, CqrsModule, ICommand } from '@nestjs/cqrs';
 import { Test } from '@nestjs/testing';
 import { ApiEventsService } from '../../../api-events';
+import { ExportId } from '../../export';
 import { MemoryImportRepository } from '../../import/adapters/memory-import.repository.adapter';
 import { ImportRepository } from '../../import/application/import.repository.port';
 import { Import, ImportComponent, ImportId } from '../../import/domain';
@@ -129,6 +130,7 @@ const getFixtures = async () => {
       const importResourceId = ResourceId.create();
       const isCloning = false;
       const projectId = importResourceId;
+      const exportId = ExportId.create();
       const importComponent = ImportComponent.newOne(
         projectId,
         ClonePiece.ProjectMetadata,
@@ -143,6 +145,7 @@ const getFixtures = async () => {
         new ArchiveLocation('/tmp/foo.zip'),
         [importComponent],
         isCloning,
+        exportId,
       );
       await importRepo.save(importInstance);
 

--- a/api/apps/api/test/integration/typeorm-import.repository.integration.e2e-spec.ts
+++ b/api/apps/api/test/integration/typeorm-import.repository.integration.e2e-spec.ts
@@ -224,7 +224,7 @@ const getFixtures = async () => {
       expect(importSnapshot.resourceKind).toBe(ResourceKind.Project);
       expect(importSnapshot.resourceId).toBe(importResourceId.value);
       expect(importSnapshot.isCloning).toBe(true);
-      expect(importSnapshot.exporttId).toEqual(exportInstance.id.value);
+      expect(importSnapshot.exportId).toEqual(exportInstance.id.value);
 
       expect(importSnapshot.importPieces).toHaveLength(1);
 


### PR DESCRIPTION
This PR adds :

- `exportId` property to `imports` aggregate and table
- `delete` method in `exports` repository
- If scenario clones success, deletes the associated `export` ( and `import`)

### Feature relevant tickets

[remove exports and imports rows for a cloned scenario once the destination scenario has been fully cloned (or if the export or import fails)](https://vizzuality.atlassian.net/browse/MARXAN-1653)

