### PR TITLE
downgrade PostgreSQL to v13.x [MARXAN-1664]

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ details.
 
 - [NodeJS](https://nodejs.org/en/) v14.18 and v16.14
 - [Yarn](https://classic.yarnpkg.com/) v1
-- [PostgreSQL](https://www.postgresql.org/) v14
+- [PostgreSQL](https://www.postgresql.org/) v13
 - [Postgis](https://postgis.net/) v3
 - [Redis](https://redis.io/) v6
 - A [Sparkpost](https://www.sparkpost.com/) account

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1611221157285-InitialGeoDBSetup.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1611221157285-InitialGeoDBSetup.ts
@@ -6,7 +6,6 @@ export class InitialGeoDBSetup1611221157285 implements MigrationInterface {
     // Only CREATEDB privilege required in 13+ rather than SUPERUSER (ht @agnessa)
     if (await PostgreSQLUtils.version13Plus()) {
       await queryRunner.query(`
-    CREATE EXTENSION IF NOT EXISTS tablefunc;
     CREATE EXTENSION IF NOT EXISTS plpgsql;
     CREATE EXTENSION IF NOT EXISTS postgis;
     CREATE EXTENSION IF NOT EXISTS postgis_raster; -- OPTIONAL
@@ -201,7 +200,6 @@ export class InitialGeoDBSetup1611221157285 implements MigrationInterface {
       DROP EXTENSION postgis_raster; -- OPTIONAL
       DROP EXTENSION postgis;
       DROP EXTENSION plpgsql;
-      DROP EXTENSION tablefunc;
       `);
     }
   }

--- a/api/apps/geoprocessing/test/tiles/protected-area.fixtures.ts
+++ b/api/apps/geoprocessing/test/tiles/protected-area.fixtures.ts
@@ -73,7 +73,14 @@ export const getFixtures = async () => {
       );
 
       expect(customFeature.length).toEqual(1);
-      expect(features.length).toEqual(17);
+      /**
+       * Note: this was expected toEqual(17) originally; when switching from
+       * PostgreSQL 14+PostGIS 3.1 to PostgreSQL 13+PostGIS 3.2 (to match the
+       * versions available in Azure Database for PostgreSQL - Flexible Server),
+       * processing of the features leads to a count of 18 features (this is
+       * due, specifically, to the PostGIS 3.1->3.2 part of the down-up-grade).
+       */
+      expect(features.length).toEqual(18);
 
       /**
        * TODO maybe:

--- a/api/libs/geofeatures/src/geo-feature.geo.entity.ts
+++ b/api/libs/geofeatures/src/geo-feature.geo.entity.ts
@@ -26,6 +26,6 @@ export class GeoFeatureGeometry {
   featureId?: string;
 
   @ApiProperty()
-  @Column('text', { name: 'hash', nullable: false })
+  @Column({ name: 'hash', insert: false, update: false })
   hash!: string;
 }

--- a/postgresql/apidb.Dockerfile
+++ b/postgresql/apidb.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.4-alpine3.16
+FROM postgres:13.7-alpine3.16
 LABEL maintainer="hello@vizzuality.com"
 
 CMD ["postgres", "-c", "max_stack_depth=7MB"]

--- a/postgresql/geodb.Dockerfile
+++ b/postgresql/geodb.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:14-3.1-alpine
+FROM postgis/postgis:13-3.2-alpine
 LABEL maintainer="hello@vizzuality.com"
 
 CMD ["postgres", "-c", "max_stack_depth=7MB"]


### PR DESCRIPTION
**DO NOT MERGE**: even if/when we are happy with these changes after having magnificently verified everything for functional and performance regressions, we should keep these changes in a parallel universe of a PR stack that includes changes needed for infra/tf, so that we can keep fast-tracking urgent changes into `develop` in the meanwhile for any fixes that may be needed for instances where demos/training sessions are running.

https://vizzuality.atlassian.net/browse/MARXAN-1664

Part of spike to check if all works as expected (bar any tolerable performance regressions) if we run both apidb and geodb on PostgreSQL v13, in preparation to moving the database instances in k8s setups to the Azure database for PostgreSQL Flexible service, which currently supports PostgreSQL up to version 13.

We have been using PostGIS v3.1 so far, and this PR also bumps up PostGIS to v3.2 (as this is the version currently supported in the PostgreSQL v13 Azure managed service).

In theory, functional regressions are not expected with this downgrade of PostgreSQL, as the key functionality needed for vector tiles is provided by PostGIS v3.x and we're keeping (and actually bumping up) this extension's version.

Some performance regressions are expected, instead, with the PostgreSQL downgrade at least in terms of some lesser parallelization of queries in some cases: the assumption here is however that we may be trading some tolerable performance regressions in some cases with the ability to run the PostgreSQL databases on the Azure managed service, which provide both functional advantages (backups, restores, other managed affordances) as well as the ability to potentially use read replicas in
the future to better balance read loads.
