### PR TITLE
use geodb for queries that need PostGIS [MARXAN-1167]

### DIFF
--- a/api/apps/geoprocessing/src/import/pieces-importers/planning-units-grid.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/planning-units-grid.piece-importer.ts
@@ -2,7 +2,6 @@ import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
 import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
 import {
-  ComponentLocationSnapshot,
   ResourceKind,
 } from '@marxan/cloning/domain';
 import { CloningFilesRepository } from '@marxan/cloning-files-repository';
@@ -12,7 +11,6 @@ import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/lib/Either';
 import { Readable, Transform } from 'stream';
 import { EntityManager } from 'typeorm';
-import { ParseOne } from 'unzipper';
 import {
   ImportPieceProcessor,
   PieceImportProvider,

--- a/api/apps/geoprocessing/test/integration/cloning/piece-importers/planning-area-custom.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-importers/planning-area-custom.piece-importer.e2e-spec.ts
@@ -99,6 +99,9 @@ const getFixtures = async () => {
   const entityManager = sandbox.get<EntityManager>(
     getEntityManagerToken(geoprocessingConnections.apiDB.name),
   );
+  const geoEntityManager = sandbox.get<EntityManager>(
+    getEntityManagerToken(geoprocessingConnections.default.name),
+  );
   const planningAreaRepo = sandbox.get<Repository<PlanningArea>>(
     getRepositoryToken(PlanningArea, geoprocessingConnections.default.name),
   );
@@ -147,7 +150,7 @@ const getFixtures = async () => {
       return new ArchiveLocation('not found');
     },
     GivenValidCustomPlanningAreaFile: async () => {
-      const [geom] = await GenerateRandomGeometries(entityManager, 1, true);
+      const [geom] = await GenerateRandomGeometries(geoEntityManager, 1, true);
 
       const validCustomPlanningAreaFile: PlanningAreaCustomContent = {
         puAreaKm2: 100,


### PR DESCRIPTION
leftover from the transition to plain PostgreSQL (without PostGIS extension) for apidb.