### PR TITLE
fix: wrong update of exisiting scenario features data in migration

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1655901622494-AddApiFeatureIdToScenarioFeaturesData.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1655901622494-AddApiFeatureIdToScenarioFeaturesData.ts
@@ -10,12 +10,11 @@ export class AddApiFeatureIdToScenarioFeaturesData1653916456540
 
     await queryRunner.query(`
       update scenario_features_data 
-      set api_feature_id = (
-        select fd.feature_id 
+      set api_feature_id = fd.feature_id 
         from scenario_features_data sfd 
         inner join features_data fd on fd.id = sfd.feature_class_id 
-        );
-      `);
+        where sfd.id = scenario_features_data.id;
+    `);
 
     await queryRunner.query(
       `


### PR DESCRIPTION
This PR fixes the update of existing `scenario_features_data` rows when adding `api_feature_id`

### Feature relevant tickets
[set api_feature_id for existing features: fix migration](https://vizzuality.atlassian.net/browse/MARXAN-1674)