### PR TITLE
Feat/marxan 1675 export and import puvspr calculations

### DIFF
--- a/api/apps/api/src/migrations/api/1657091494184-AddClonePiceForProjectPuvsprCalculations.ts
+++ b/api/apps/api/src/migrations/api/1657091494184-AddClonePiceForProjectPuvsprCalculations.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddClonePieceForProjectPuvsprCalculations1657091494184
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE clone_piece_enum ADD VALUE 'project-puvspr-calculations'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+    CREATE TYPE "clone_piece_enum_tmp" AS ENUM(
+      'export-config',
+      'project-metadata',
+      'project-custom-protected-areas',
+      'planning-area-gadm',
+      'planning-area-custom',
+      'planning-area-custom-geojson',
+      'planning-units-grid',
+      'planning-units-grid-geojson',
+      'scenario-metadata',
+      'scenario-planning-units-data',
+      'scenario-run-results',
+      'scenario-protected-areas',
+      'project-custom-features',
+      'features-specification',
+      'scenario-features-data',
+      'scenario-input-folder',
+      'scenario-output-folder',
+      'marxan-execution-metadata'
+    );
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE export_components
+      ALTER COLUMN piece TYPE clone_piece_enum_tmp;
+    `);
+    await queryRunner.query(`
+      ALTER TABLE import_components
+      ALTER COLUMN piece TYPE clone_piece_enum_tmp;
+    `);
+
+    await queryRunner.query(`
+      DROP TYPE clone_piece_enum;
+    `);
+    await queryRunner.query(`
+      ALTER TYPE clone_piece_enum_tmp RENAME TO clone_piece_enum;
+    `);
+  }
+}

--- a/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.spec.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.spec.ts
@@ -98,6 +98,7 @@ const getFixtures = async () => {
       ClonePiece.PlanningUnitsGridGeojson,
       ClonePiece.ProjectCustomProtectedAreas,
       ClonePiece.ProjectCustomFeatures,
+      ClonePiece.ProjectPuvsprCalculations,
     ];
   };
 

--- a/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.ts
+++ b/api/apps/api/src/modules/clone/export/adapters/export-resource-pieces.adapter.ts
@@ -56,6 +56,7 @@ export class ExportResourcePiecesAdapter implements ExportResourcePieces {
       ExportComponent.newOne(id, ClonePiece.PlanningUnitsGridGeojson),
       ExportComponent.newOne(id, ClonePiece.ProjectCustomProtectedAreas),
       ExportComponent.newOne(id, ClonePiece.ProjectCustomFeatures),
+      ExportComponent.newOne(id, ClonePiece.ProjectPuvsprCalculations),
       ...scenarioPieces,
     ];
 

--- a/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
@@ -1,5 +1,6 @@
 import { GeoCloningFilesRepositoryModule } from '@marxan-geoprocessing/modules/cloning-files-repository';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
 import { ScenarioFeaturesData } from '@marxan/features';
 import {
   MarxanExecutionMetadataGeoEntity,
@@ -35,6 +36,7 @@ import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-ex
     TypeOrmModule.forFeature([], geoprocessingConnections.apiDB),
     TypeOrmModule.forFeature(
       [
+        ProjectsPuEntity,
         ScenarioFeaturesData,
         OutputScenariosFeaturesDataGeoEntity,
         MarxanExecutionMetadataGeoEntity,

--- a/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/pieces-exporters.module.ts
@@ -5,6 +5,7 @@ import {
   MarxanExecutionMetadataGeoEntity,
   OutputScenariosFeaturesDataGeoEntity,
 } from '@marxan/marxan-output';
+import { PuvsprCalculationsModule } from '@marxan/puvspr-calculations';
 import { HttpModule, Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ExportConfigProjectPieceExporter } from './export-config.project-piece-exporter';
@@ -18,6 +19,7 @@ import { PlanningUnitsGridPieceExporter } from './planning-units-grid.piece-expo
 import { ProjectCustomFeaturesPieceExporter } from './project-custom-features.piece-exporter';
 import { ProjectCustomProtectedAreasPieceExporter } from './project-custom-protected-areas.piece-exporter';
 import { ProjectMetadataPieceExporter } from './project-metadata.piece-exporter';
+import { ProjectPuvsprCalculationsPieceExporter } from './project-puvspr-calculations.piece-exporter';
 import { ScenarioFeaturesDataPieceExporter } from './scenario-features-data.piece-exporter';
 import { ScenarioFeaturesSpecificationPieceExporter } from './scenario-features-specification.piece-exporter';
 import { ScenarioInputFolderPieceExporter } from './scenario-input-folder.piece-exporter';
@@ -39,6 +41,7 @@ import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-ex
       ],
       geoprocessingConnections.default,
     ),
+    PuvsprCalculationsModule.for(geoprocessingConnections.default.name!),
     HttpModule,
   ],
   providers: [
@@ -61,6 +64,7 @@ import { ScenarioRunResultsPieceExporter } from './scenario-run-results.piece-ex
     ScenarioOutputFolderPieceExporter,
     ScenarioFeaturesSpecificationPieceExporter,
     MarxanExecutionMetadataPieceExporter,
+    ProjectPuvsprCalculationsPieceExporter,
     Logger,
   ],
 })

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-puvspr-calculations.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-puvspr-calculations.piece-exporter.ts
@@ -1,0 +1,175 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
+import { CloningFilesRepository } from '@marxan/cloning-files-repository';
+import { ComponentLocation, ResourceKind } from '@marxan/cloning/domain';
+import { ClonePieceRelativePathResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
+import { ProjectPuvsprCalculationsContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-puvspr-calculations';
+import { SingleConfigFeatureValueStripped } from '@marxan/features-hash';
+import {
+  FeatureAmountPerPlanningUnit,
+  PuvsprCalculationsRepository,
+} from '@marxan/puvspr-calculations';
+import { SpecificationOperation } from '@marxan/specification';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+import { EntityManager } from 'typeorm';
+import {
+  ExportPieceProcessor,
+  PieceExportProvider,
+} from '../pieces/export-piece-processor';
+
+type FeaturesSelectResult = {
+  featureName: string;
+  isCustom: boolean;
+  id: string;
+};
+
+type ProjectFeaturesSelectResult = {
+  featureName: string;
+  geoOperation: SingleConfigFeatureValueStripped;
+};
+
+type FeatureByIdMap = Record<string, Omit<FeaturesSelectResult, 'id'>>;
+
+@Injectable()
+@PieceExportProvider()
+export class ProjectPuvsprCalculationsPieceExporter
+  implements ExportPieceProcessor {
+  constructor(
+    private readonly fileRepository: CloningFilesRepository,
+    private readonly puvsprCalculationsRepo: PuvsprCalculationsRepository,
+    @InjectEntityManager(geoprocessingConnections.apiDB)
+    private readonly apiEntityManager: EntityManager,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ProjectPuvsprCalculationsPieceExporter.name);
+  }
+
+  isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
+    return (
+      piece === ClonePiece.ProjectPuvsprCalculations &&
+      kind === ResourceKind.Project
+    );
+  }
+
+  async run(input: ExportJobInput): Promise<ExportJobOutput> {
+    const projectId = input.resourceId;
+
+    const featureAmountPerPlanningUnit = await this.puvsprCalculationsRepo.getAmountPerPlanningUnitAndFeatureInProject(
+      projectId,
+    );
+
+    const featureIds = featureAmountPerPlanningUnit.map(
+      ({ featureId }) => featureId,
+    );
+
+    const featuresById = await this.getFeaturesById(featureIds);
+
+    const featuresAmountPerPlanningUnitParsed = this.parseFeatureAmountPerPlanningUnit(
+      featureAmountPerPlanningUnit,
+      featuresById,
+    );
+
+    const projectFeaturesGeoOperations = await this.getProjectFeaturesGeoOperations(
+      projectId,
+    );
+
+    const fileContent: ProjectPuvsprCalculationsContent = {
+      puvsprCalculations: featuresAmountPerPlanningUnitParsed,
+      projectFeaturesGeoOperations,
+    };
+
+    const relativePath = ClonePieceRelativePathResolver.resolveFor(
+      ClonePiece.ProjectPuvsprCalculations,
+    );
+
+    const outputFile = await this.fileRepository.saveCloningFile(
+      input.exportId,
+      Readable.from(JSON.stringify(fileContent)),
+      relativePath,
+    );
+
+    if (isLeft(outputFile)) {
+      const errorMessage = `${ProjectPuvsprCalculationsPieceExporter.name} - Project - couldn't save file - ${outputFile.left.description}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return {
+      ...input,
+      uris: [new ComponentLocation(outputFile.right, relativePath)],
+    };
+  }
+
+  private async getFeaturesById(featureIds: string[]) {
+    const result: FeatureByIdMap = {};
+
+    if (!featureIds.length) return result;
+
+    const features: FeaturesSelectResult[] = await this.apiEntityManager
+      .createQueryBuilder()
+      .select('feature_class_name', 'featureName')
+      .addSelect('id')
+      .addSelect('is_custom', 'isCustom')
+      .from('features', 'f')
+      .where('id IN (:...featureIds)', { featureIds })
+      .execute();
+
+    return features.reduce((prev, { id, ...rest }) => {
+      prev[id] = rest;
+      return prev;
+    }, result);
+  }
+
+  private parseFeatureAmountPerPlanningUnit(
+    featureAmountPerPlanningUnit: FeatureAmountPerPlanningUnit[],
+    featuresByIdMap: FeatureByIdMap,
+  ) {
+    return featureAmountPerPlanningUnit.map(({ featureId, ...rest }) => {
+      const feature = featuresByIdMap[featureId];
+      return {
+        ...rest,
+        featureName: feature.featureName,
+        isCustom: feature.isCustom,
+      };
+    });
+  }
+
+  private async getProjectFeaturesGeoOperations(projectId: string) {
+    const derivedFeatures: ProjectFeaturesSelectResult[] = await this.apiEntityManager
+      .createQueryBuilder()
+      .select('feature_class_name', 'featureName')
+      .addSelect('from_geoprocessing_ops', 'geoOperation')
+      .from('features', 'f')
+      .where('project_id = :projectId', { projectId })
+      .andWhere('from_geoprocessing_ops IS NOT NULL')
+      .execute();
+
+    const dataFeatureIds = derivedFeatures.map(({ geoOperation }) => {
+      if (geoOperation.operation !== SpecificationOperation.Split) {
+        const errorMessage = 'Can only proccess split features';
+        this.logger.error(errorMessage);
+        throw new Error(errorMessage);
+      }
+
+      return geoOperation.baseFeatureId;
+    });
+
+    const dataFeaturesById = await this.getFeaturesById(dataFeatureIds);
+
+    return derivedFeatures.map(({ featureName, geoOperation }) => ({
+      featureName,
+      geoOperation: {
+        operation: geoOperation.operation,
+        splitByProperty: geoOperation.splitByProperty,
+        value: geoOperation.value,
+        baseFeatureName:
+          dataFeaturesById[geoOperation.baseFeatureId].featureName,
+        baseFeatureIsCustom:
+          dataFeaturesById[geoOperation.baseFeatureId].isCustom,
+      },
+    }));
+  }
+}

--- a/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
@@ -1,5 +1,6 @@
 import { GeoCloningFilesRepositoryModule } from '@marxan-geoprocessing/modules/cloning-files-repository';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { PuvsprCalculationsEntity } from '@marxan/puvspr-calculations';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScenariosOutputResultsApiEntity } from '../../../../../libs/marxan-output/src';
@@ -10,6 +11,7 @@ import { PlanningUnitsGridPieceImporter } from './planning-units-grid.piece-impo
 import { ProjectCustomFeaturesPieceImporter } from './project-custom-features.piece-importer';
 import { ProjectCustomProtectedAreasPieceImporter } from './project-custom-protected-areas.piece-importer';
 import { ProjectMetadataPieceImporter } from './project-metadata.piece-importer';
+import { ProjectPuvsprCalculationsPieceImporter } from './project-puvspr-calculations.piece-importer';
 import { ScenarioFeaturesDataPieceImporter } from './scenario-features-data.piece-importer';
 import { ScenarioFeaturesSpecificationPieceImporter } from './scenario-features-specification.piece-importer';
 import { ScenarioMetadataPieceImporter } from './scenario-metadata.piece-importer';
@@ -24,6 +26,7 @@ import { ScenarioRunResultsPieceImporter } from './scenario-run-results.piece-im
       [ScenariosOutputResultsApiEntity],
       geoprocessingConnections.apiDB,
     ),
+    TypeOrmModule.forFeature([PuvsprCalculationsEntity]),
   ],
   providers: [
     ProjectMetadataPieceImporter,
@@ -39,6 +42,7 @@ import { ScenarioRunResultsPieceImporter } from './scenario-run-results.piece-im
     ScenarioFeaturesDataPieceImporter,
     ScenarioFeaturesSpecificationPieceImporter,
     MarxanExecutionMetadataPieceImporter,
+    ProjectPuvsprCalculationsPieceImporter,
     { provide: Logger, useClass: Logger, scope: Scope.TRANSIENT },
   ],
 })

--- a/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/pieces-importers.module.ts
@@ -1,5 +1,6 @@
 import { GeoCloningFilesRepositoryModule } from '@marxan-geoprocessing/modules/cloning-files-repository';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
 import { PuvsprCalculationsEntity } from '@marxan/puvspr-calculations';
 import { Logger, Module, Scope } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -26,7 +27,7 @@ import { ScenarioRunResultsPieceImporter } from './scenario-run-results.piece-im
       [ScenariosOutputResultsApiEntity],
       geoprocessingConnections.apiDB,
     ),
-    TypeOrmModule.forFeature([PuvsprCalculationsEntity]),
+    TypeOrmModule.forFeature([PuvsprCalculationsEntity, ProjectsPuEntity]),
   ],
   providers: [
     ProjectMetadataPieceImporter,

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-puvspr-calculations.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-puvspr-calculations.piece-importer.ts
@@ -1,0 +1,255 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ImportJobInput, ImportJobOutput } from '@marxan/cloning';
+import { CloningFilesRepository } from '@marxan/cloning-files-repository';
+import { ResourceKind } from '@marxan/cloning/domain';
+import {
+  FeatureAmountPerPlanningUnit,
+  ProjectFeatureGeoOperation,
+  ProjectPuvsprCalculationsContent,
+} from '@marxan/cloning/infrastructure/clone-piece-data/project-puvspr-calculations';
+import { PuvsprCalculationsEntity } from '@marxan/puvspr-calculations';
+import { SpecificationOperation } from '@marxan/specification';
+import { readableToBuffer } from '@marxan/utils';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/lib/Either';
+import { EntityManager } from 'typeorm';
+import {
+  ImportPieceProcessor,
+  PieceImportProvider,
+} from '../pieces/import-piece-processor';
+
+type FeatureSelectResult = {
+  id: string;
+  feature_class_name: string;
+};
+
+@Injectable()
+@PieceImportProvider()
+export class ProjectPuvsprCalculationsPieceImporter
+  implements ImportPieceProcessor {
+  constructor(
+    private readonly fileRepository: CloningFilesRepository,
+    @InjectEntityManager(geoprocessingConnections.apiDB)
+    private readonly apiEntityManager: EntityManager,
+    @InjectEntityManager(geoprocessingConnections.default)
+    private readonly geoEntityManager: EntityManager,
+    private readonly logger: Logger,
+  ) {
+    this.logger.setContext(ProjectPuvsprCalculationsPieceImporter.name);
+  }
+
+  isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
+    return (
+      piece === ClonePiece.ProjectPuvsprCalculations &&
+      kind === ResourceKind.Project
+    );
+  }
+
+  async run(input: ImportJobInput): Promise<ImportJobOutput> {
+    const { uris, pieceResourceId, projectId, piece } = input;
+
+    if (uris.length !== 1) {
+      const errorMessage = `uris array has an unexpected amount of elements: ${uris.length}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    const [puvsprCalculationsLocation] = uris;
+
+    const readableOrError = await this.fileRepository.get(
+      puvsprCalculationsLocation.uri,
+    );
+    if (isLeft(readableOrError)) {
+      const errorMessage = `File with piece data for ${piece}/${pieceResourceId} is not available at ${puvsprCalculationsLocation.uri}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const buffer = await readableToBuffer(readableOrError.right);
+    const stringPuvsprCalculationsOrError = buffer.toString();
+
+    const {
+      puvsprCalculations,
+      projectFeaturesGeoOperations,
+    }: ProjectPuvsprCalculationsContent = JSON.parse(
+      stringPuvsprCalculationsOrError,
+    );
+
+    const parsedPuvsprCalculations = await this.parsePuvsprCalculations(
+      puvsprCalculations,
+      projectId,
+    );
+
+    const parsedProjectFeaturesGeoOperations = await this.parseProjectFeaturesGeoOperations(
+      projectFeaturesGeoOperations,
+      projectId,
+    );
+
+    await this.geoEntityManager.transaction(async (em) => {
+      const puvsprRepo = em.getRepository(PuvsprCalculationsEntity);
+      await puvsprRepo.save(parsedPuvsprCalculations);
+
+      await this.apiEntityManager.transaction(async (em) => {
+        await Promise.all(
+          parsedProjectFeaturesGeoOperations.map(
+            ({ featureId, geoOperation }) =>
+              em
+                .createQueryBuilder()
+                .update('features')
+                .set({ from_geoprocessing_ops: geoOperation })
+                .where('id = :featureId', { featureId })
+                .execute(),
+          ),
+        );
+      });
+    });
+
+    return {
+      importId: input.importId,
+      componentId: input.componentId,
+      pieceResourceId,
+      projectId,
+      piece: input.piece,
+    };
+  }
+
+  private async parsePuvsprCalculations(
+    puvsprCalculations: FeatureAmountPerPlanningUnit[],
+    projectId: string,
+  ) {
+    const customFeaturesNames = puvsprCalculations
+      .filter(({ isCustom }) => isCustom)
+      .map(({ featureName }) => featureName);
+
+    const customFeaturesMap = await this.getCustomFeaturesByFeatureName(
+      customFeaturesNames,
+      projectId,
+    );
+
+    const platformFeaturesNames = puvsprCalculations
+      .filter(({ isCustom }) => !isCustom)
+      .map(({ featureName }) => featureName);
+
+    const platformFeaturesMap = await this.getPlatformFeaturesByFeatureName(
+      platformFeaturesNames,
+    );
+
+    return puvsprCalculations.map(({ isCustom, featureName, amount, puid }) => {
+      const featureId = isCustom
+        ? customFeaturesMap[featureName]
+        : platformFeaturesMap[featureName];
+
+      return { amount, puid, featureId, projectId: projectId };
+    });
+  }
+
+  private async getCustomFeaturesByFeatureName(
+    customFeaturesNames: string[],
+    projectId: string,
+  ) {
+    if (!customFeaturesNames.length) return {};
+
+    const features: FeatureSelectResult[] = await this.apiEntityManager
+      .createQueryBuilder()
+      .select('id, feature_class_name')
+      .from('features', 'f')
+      .where('feature_class_name IN (:...customFeaturesNames)', {
+        customFeaturesNames,
+      })
+      .andWhere('project_id = :projectId', { projectId })
+      .execute();
+
+    const res: Record<string, string> = {};
+
+    return features.reduce((prev, { feature_class_name, id }) => {
+      prev[feature_class_name] = id;
+      return prev;
+    }, res);
+  }
+
+  private async getPlatformFeaturesByFeatureName(
+    platformFeaturesNames: string[],
+  ) {
+    if (!platformFeaturesNames.length) return {};
+
+    const features: FeatureSelectResult[] = await this.apiEntityManager
+      .createQueryBuilder()
+      .select('id, feature_class_name')
+      .from('features', 'f')
+      .where('feature_class_name IN (:...platformFeaturesNames)', {
+        platformFeaturesNames,
+      })
+      .andWhere('project_id IS NULL')
+      .execute();
+
+    const res: Record<string, string> = {};
+
+    return features.reduce((prev, { feature_class_name, id }) => {
+      prev[feature_class_name] = id;
+      return prev;
+    }, res);
+  }
+
+  private async parseProjectFeaturesGeoOperations(
+    projectFeaturesGeoOperations: ProjectFeatureGeoOperation[],
+    projectId: string,
+  ) {
+    const projectFeaturestNames = projectFeaturesGeoOperations.map(
+      ({ featureName }) => featureName,
+    );
+
+    const projectFeaturesByName = await this.getCustomFeaturesByFeatureName(
+      projectFeaturestNames,
+      projectId,
+    );
+
+    const splitOperationsFeatures: {
+      featureName: string;
+      isCustom: boolean;
+    }[] = [];
+
+    projectFeaturesGeoOperations.forEach(({ geoOperation }) => {
+      if (geoOperation.operation === SpecificationOperation.Split) {
+        splitOperationsFeatures.push({
+          featureName: geoOperation.baseFeatureName,
+          isCustom: geoOperation.baseFeatureIsCustom,
+        });
+      }
+    });
+
+    const customSplitOperationsFeaturesMap = await this.getCustomFeaturesByFeatureName(
+      splitOperationsFeatures
+        .filter(({ isCustom }) => isCustom)
+        .map(({ featureName }) => featureName),
+      projectId,
+    );
+
+    const platformSplitOperationsFeaturesMap = await this.getPlatformFeaturesByFeatureName(
+      splitOperationsFeatures
+        .filter(({ isCustom }) => !isCustom)
+        .map(({ featureName }) => featureName),
+    );
+
+    return projectFeaturesGeoOperations
+      .filter(
+        ({ geoOperation }) =>
+          geoOperation.operation === SpecificationOperation.Split,
+      )
+      .map(({ featureName, geoOperation }) => {
+        const featureId = projectFeaturesByName[featureName];
+        const baseFeatureName = geoOperation.baseFeatureName;
+        const baseFeatureId = geoOperation.baseFeatureIsCustom
+          ? customSplitOperationsFeaturesMap[baseFeatureName]
+          : platformSplitOperationsFeaturesMap[baseFeatureName];
+        return {
+          featureId,
+          geoOperation: {
+            operation: geoOperation.operation,
+            value: geoOperation.value,
+            splitByProperty: geoOperation.splitByProperty,
+            baseFeatureId,
+          },
+        };
+      });
+  }
+}

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1655901622494-AddApiFeatureIdToScenarioFeaturesData.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1655901622494-AddApiFeatureIdToScenarioFeaturesData.ts
@@ -29,12 +29,10 @@ export class AddApiFeatureIdToScenarioFeaturesData1653916456540
 
     await queryRunner.query(`
       update scenario_features_preparation 
-      set api_feature_id = (
-        select fd.feature_id 
+      set api_feature_id = fd.feature_id 
         from scenario_features_preparation sfp
         inner join features_data fd on fd.id = sfp.feature_class_id 
-        where sfp.id = scenario_features_preparation.id
-        );
+        where sfp.id = scenario_features_preparation.id;
     `);
 
     await queryRunner.query(

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-puvspr-calculations.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-puvspr-calculations.piece-exporter.e2e-spec.ts
@@ -1,0 +1,331 @@
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ClonePiece, ExportJobInput } from '@marxan/cloning';
+import { ResourceKind } from '@marxan/cloning/domain';
+import { CloningFilesRepository } from '@marxan/cloning-files-repository';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  getEntityManagerToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
+import { isLeft, Right } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+import { EntityManager, In, Repository } from 'typeorm';
+import { v4 } from 'uuid';
+import {
+  DeleteProjectAndOrganization,
+  GivenFeatures,
+  GivenProjectExists,
+  readSavedFile,
+} from '../fixtures';
+import { GeoCloningFilesRepositoryModule } from '@marxan-geoprocessing/modules/cloning-files-repository';
+import { ProjectPuvsprCalculationsPieceExporter } from '@marxan-geoprocessing/export/pieces-exporters/project-puvspr-calculations.piece-exporter';
+import { ProjectPuvsprCalculationsContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-puvspr-calculations';
+import {
+  PuvsprCalculationsEntity,
+  PuvsprCalculationsModule,
+  PuvsprCalculationsRepository,
+} from '@marxan/puvspr-calculations';
+import { isDefined } from '@marxan/utils';
+import {
+  SingleConfigFeatureValueStripped,
+  SingleSplitConfigFeatureValueStripped,
+} from '@marxan/features-hash';
+import { SpecificationOperation } from '@marxan/specification';
+
+type FeatureData = {
+  id: string;
+  feature_class_name: string;
+  tag: string;
+  creation_status: string;
+  project_id: string | null;
+  from_geoprocessing_ops?: SingleSplitConfigFeatureValueStripped;
+};
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+describe(ProjectPuvsprCalculationsPieceExporter, () => {
+  beforeEach(async () => {
+    fixtures = await getFixtures();
+  }, 10_000);
+
+  afterEach(async () => {
+    await fixtures?.cleanUp();
+  });
+
+  it("saves an empty file when project doesn't have neither derived features and puvspr calculations", async () => {
+    const input = fixtures.GivenAProjectPuvsprCalculationsExportJob();
+    await fixtures.GivenProjectExist();
+    await fixtures.GivenACustomAndAPlatformFeatureForProject();
+    fixtures.GivenNoDerivedFeaturesForProject();
+    fixtures.GivenProjectDoesNotHavePuvsprCalculations();
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenAnEmptyProjectPuvsprCalculationsFileIsSaved();
+  });
+
+  it('saves succesfully puvspr calculations for a custom feature ', async () => {
+    const input = fixtures.GivenAProjectPuvsprCalculationsExportJob();
+    await fixtures.GivenProjectExist();
+    const {
+      customFeature,
+    } = await fixtures.GivenACustomAndAPlatformFeatureForProject();
+    await fixtures.GivenProjectHasPuvsprCalculations(customFeature.id);
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenPuvsprCalculationsFileHasPuvsprCalculationsForFeature(customFeature);
+  });
+
+  it('saves succesfully puvspr calculations for a platform feature ', async () => {
+    const input = fixtures.GivenAProjectPuvsprCalculationsExportJob();
+    await fixtures.GivenProjectExist();
+    const {
+      platformFeature,
+    } = await fixtures.GivenACustomAndAPlatformFeatureForProject();
+    await fixtures.GivenProjectHasPuvsprCalculations(platformFeature.id);
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenPuvsprCalculationsFileHasPuvsprCalculationsForFeature(
+        platformFeature,
+      );
+  });
+
+  it('saves succesfully a split derived feature from a platform feature', async () => {
+    const input = fixtures.GivenAProjectPuvsprCalculationsExportJob();
+    await fixtures.GivenProjectExist();
+    const {
+      platformFeature,
+    } = await fixtures.GivenACustomAndAPlatformFeatureForProject();
+    const derivedFeature = await fixtures.GivenASplitDerivedFeatureForProject(
+      platformFeature.id,
+    );
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenPuvsprCalculationsFileHasASplitDerivedFeature(
+        derivedFeature,
+        platformFeature,
+      );
+  });
+
+  it('saves succesfully a split derived features from a custom feature', async () => {
+    const input = fixtures.GivenAProjectPuvsprCalculationsExportJob();
+    await fixtures.GivenProjectExist();
+    const {
+      customFeature,
+    } = await fixtures.GivenACustomAndAPlatformFeatureForProject();
+    const derivedFeature = await fixtures.GivenASplitDerivedFeatureForProject(
+      customFeature.id,
+    );
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenPuvsprCalculationsFileHasASplitDerivedFeature(
+        derivedFeature,
+        customFeature,
+      );
+  });
+});
+
+const getFixtures = async () => {
+  const sandbox = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.apiDB,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.default,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forFeature([]),
+      GeoCloningFilesRepositoryModule,
+      PuvsprCalculationsModule.for(geoprocessingConnections.default.name!),
+    ],
+    providers: [
+      ProjectPuvsprCalculationsPieceExporter,
+      { provide: Logger, useValue: { error: () => {}, setContext: () => {} } },
+    ],
+  }).compile();
+
+  await sandbox.init();
+  const projectId = v4();
+  const organizationId = v4();
+  const sut = sandbox.get(ProjectPuvsprCalculationsPieceExporter);
+  const apiEntityManager: EntityManager = sandbox.get(
+    getEntityManagerToken(geoprocessingConnections.apiDB),
+  );
+  const geoEntityManager: EntityManager = sandbox.get(
+    getEntityManagerToken(geoprocessingConnections.default),
+  );
+  const fileRepository = sandbox.get(CloningFilesRepository);
+  const puvsprCalculationsRepo = sandbox.get(PuvsprCalculationsRepository);
+
+  const amountOfCustomFeatures = 1;
+  const amountOfPlatformFeatures = 1;
+  const amountOfPuvsrCalculationsPerFeature = 3;
+  const expectedAmountPerPu = 20;
+  let featureIds: string[] = [];
+
+  return {
+    cleanUp: async () => {
+      await DeleteProjectAndOrganization(
+        apiEntityManager,
+        projectId,
+        organizationId,
+      );
+      if (featureIds.length)
+        await apiEntityManager
+          .createQueryBuilder()
+          .delete()
+          .from('features')
+          .where('id IN (:...featureIds)', { featureIds })
+          .execute();
+
+      const puvsprCalculationsRepo: Repository<PuvsprCalculationsEntity> = sandbox.get(
+        getRepositoryToken(PuvsprCalculationsEntity),
+      );
+
+      await puvsprCalculationsRepo.delete({});
+    },
+    GivenAProjectPuvsprCalculationsExportJob: (): ExportJobInput => {
+      return {
+        allPieces: [
+          { resourceId: projectId, piece: ClonePiece.ProjectMetadata },
+          {
+            resourceId: projectId,
+            piece: ClonePiece.ProjectPuvsprCalculations,
+          },
+        ],
+        componentId: v4(),
+        exportId: v4(),
+        piece: ClonePiece.ProjectPuvsprCalculations,
+        resourceId: projectId,
+        resourceKind: ResourceKind.Project,
+      };
+    },
+    GivenProjectExist: async () => {
+      return GivenProjectExists(apiEntityManager, projectId, organizationId);
+    },
+    GivenACustomAndAPlatformFeatureForProject: async () => {
+      const { customFeatures, platformFeatures } = await GivenFeatures(
+        apiEntityManager,
+        amountOfPlatformFeatures,
+        amountOfCustomFeatures,
+        projectId,
+      );
+      featureIds = [platformFeatures[0].id];
+      return {
+        customFeature: customFeatures[0],
+        platformFeature: platformFeatures[0],
+      };
+    },
+    GivenASplitDerivedFeatureForProject: async (baseFeatureId: string) => {
+      const derivedFeatureId = v4();
+      const geoOperation: SingleConfigFeatureValueStripped = {
+        baseFeatureId,
+        operation: SpecificationOperation.Split,
+        splitByProperty: 'random-property',
+        value: 'random-value',
+      };
+      const derivedFeature = {
+        id: derivedFeatureId,
+        feature_class_name: 'derived-feature',
+        tag: 'species',
+        creation_status: 'created',
+        project_id: projectId,
+        from_geoprocessing_ops: geoOperation,
+      };
+      await apiEntityManager
+        .createQueryBuilder()
+        .insert()
+        .into('features')
+        .values(derivedFeature)
+        .execute();
+
+      return derivedFeature;
+    },
+    GivenNoDerivedFeaturesForProject: () => {},
+    GivenProjectHasPuvsprCalculations: async (featureId: string) => {
+      const puvsprCalculations = Array(amountOfPuvsrCalculationsPerFeature)
+        .fill(0)
+        .map((_, index) => ({
+          amount: expectedAmountPerPu,
+          featureId,
+          puid: index,
+        }));
+      return puvsprCalculationsRepo.saveAmountPerPlanningUnitAndFeature(
+        projectId,
+        puvsprCalculations,
+      );
+    },
+    GivenProjectDoesNotHavePuvsprCalculations: () => {},
+    WhenPieceExporterIsInvoked: (input: ExportJobInput) => {
+      return {
+        ThenAnEmptyProjectPuvsprCalculationsFileIsSaved: async () => {
+          const result = await sut.run(input);
+          const file = await fileRepository.get(result.uris[0].uri);
+          expect((file as Right<Readable>).right).toBeDefined();
+          if (isLeft(file)) throw new Error();
+          const savedStrem = file.right;
+          const content = await readSavedFile<ProjectPuvsprCalculationsContent>(
+            savedStrem,
+          );
+          expect(content.projectFeaturesGeoOperations).toEqual([]);
+          expect(content.puvsprCalculations).toEqual([]);
+        },
+        ThenPuvsprCalculationsFileHasPuvsprCalculationsForFeature: async (
+          feature: FeatureData,
+        ) => {
+          const result = await sut.run(input);
+          const file = await fileRepository.get(result.uris[0].uri);
+          expect((file as Right<Readable>).right).toBeDefined();
+          if (isLeft(file)) throw new Error();
+          const savedStrem = file.right;
+          const content = await readSavedFile<ProjectPuvsprCalculationsContent>(
+            savedStrem,
+          );
+          expect(
+            content.puvsprCalculations.every(
+              ({ amount, featureName, isCustom }) =>
+                amount === expectedAmountPerPu &&
+                featureName === feature.feature_class_name &&
+                isCustom === isDefined(feature.project_id),
+            ),
+          ).toEqual(true);
+          expect(content.puvsprCalculations).toHaveLength(
+            amountOfPuvsrCalculationsPerFeature,
+          );
+        },
+        ThenPuvsprCalculationsFileHasASplitDerivedFeature: async (
+          derivedFeature: FeatureData,
+          baseFeature: FeatureData,
+        ) => {
+          const result = await sut.run(input);
+          const file = await fileRepository.get(result.uris[0].uri);
+          expect((file as Right<Readable>).right).toBeDefined();
+          if (isLeft(file)) throw new Error();
+          const savedStrem = file.right;
+          const content = await readSavedFile<ProjectPuvsprCalculationsContent>(
+            savedStrem,
+          );
+          expect(content.projectFeaturesGeoOperations).toHaveLength(1);
+          const derivedFeatureContent = content.projectFeaturesGeoOperations[0];
+          const derivedFeatureOperation = derivedFeature.from_geoprocessing_ops!;
+          expect(derivedFeatureContent).toEqual({
+            featureName: derivedFeature.feature_class_name,
+            geoOperation: {
+              operation: derivedFeatureOperation.operation,
+              splitByProperty: derivedFeatureOperation.splitByProperty,
+              value: derivedFeatureOperation.value,
+              baseFeatureName: baseFeature.feature_class_name,
+              baseFeatureIsCustom: isDefined(baseFeature.project_id),
+            },
+          });
+        },
+      };
+    },
+  };
+};

--- a/api/apps/geoprocessing/test/integration/cloning/piece-importers/project-puvspr-calculations.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-importers/project-puvspr-calculations.piece-importer.e2e-spec.ts
@@ -1,0 +1,297 @@
+import { ProjectCustomFeaturesPieceImporter } from '@marxan-geoprocessing/import/pieces-importers/project-custom-features.piece-importer';
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ImportJobInput } from '@marxan/cloning';
+import { CloningFilesRepository } from '@marxan/cloning-files-repository';
+import {
+  ArchiveLocation,
+  ClonePiece,
+  ResourceKind,
+} from '@marxan/cloning/domain';
+import { ClonePieceRelativePathResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  getEntityManagerToken,
+  getRepositoryToken,
+  TypeOrmModule,
+} from '@nestjs/typeorm';
+import { isLeft } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+import { EntityManager, Repository } from 'typeorm';
+import { v4 } from 'uuid';
+import {
+  DeleteProjectAndOrganization,
+  GivenFeatures,
+  GivenProjectExists,
+} from '../fixtures';
+import { GeoCloningFilesRepositoryModule } from '@marxan-geoprocessing/modules/cloning-files-repository';
+import { ProjectPuvsprCalculationsPieceImporter } from '@marxan-geoprocessing/import/pieces-importers/project-puvspr-calculations.piece-importer';
+import { ProjectPuvsprCalculationsContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-puvspr-calculations';
+import { SpecificationOperation } from '@marxan/specification';
+import { SingleConfigFeatureValueStripped } from '@marxan/features-hash';
+import {
+  PuvsprCalculationsEntity,
+  PuvsprCalculationsModule,
+  PuvsprCalculationsRepository,
+} from '@marxan/puvspr-calculations';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+describe(ProjectCustomFeaturesPieceImporter, () => {
+  beforeEach(async () => {
+    fixtures = await getFixtures();
+  }, 10_000);
+
+  afterEach(async () => {
+    await fixtures?.cleanUp();
+  });
+
+  it('fails when project puvspr calculations file uri is missing in uris array', async () => {
+    const input = fixtures.GivenJobInputWithoutUris();
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenAnUrisArrayErrorShouldBeThrown();
+  });
+
+  it('fails when the file cannot be retrieved from file repo', async () => {
+    const archiveLocation = fixtures.GivenNoProjectPuvsprCalculationsFileIsAvailable();
+    const input = fixtures.GivenJobInput(archiveLocation);
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenADataNotAvailableErrorShouldBeThrown();
+  });
+
+  it('imports project puvspr calculations', async () => {
+    await fixtures.GivenProject();
+    const archiveLocation = await fixtures.GivenValidProjectPuvsprCalculationsFile();
+    const input = fixtures.GivenJobInput(archiveLocation);
+    await fixtures
+      .WhenPieceImporterIsInvoked(input)
+      .ThenPuvsprCalculationsAreImportedAndDerivedFeaturesAreUpdated();
+  });
+});
+
+const getFixtures = async () => {
+  const sandbox = await Test.createTestingModule({
+    imports: [
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.default,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forRoot({
+        ...geoprocessingConnections.apiDB,
+        keepConnectionAlive: true,
+        logging: false,
+      }),
+      TypeOrmModule.forFeature(
+        [PuvsprCalculationsEntity],
+        geoprocessingConnections.default,
+      ),
+      GeoCloningFilesRepositoryModule,
+      PuvsprCalculationsModule.for(geoprocessingConnections.default.name!),
+    ],
+    providers: [
+      ProjectPuvsprCalculationsPieceImporter,
+      { provide: Logger, useValue: { error: () => {}, setContext: () => {} } },
+    ],
+  }).compile();
+
+  await sandbox.init();
+  const projectId = v4();
+  const organizationId = v4();
+  const userId = v4();
+
+  const geoEntityManager = sandbox.get<EntityManager>(getEntityManagerToken());
+  const apiEntityManager = sandbox.get<EntityManager>(
+    getEntityManagerToken(geoprocessingConnections.apiDB.name),
+  );
+
+  const sut = sandbox.get(ProjectPuvsprCalculationsPieceImporter);
+  const fileRepository = sandbox.get(CloningFilesRepository);
+  const puvsprCalculationsRepo = sandbox.get(PuvsprCalculationsRepository);
+
+  const amountOfPuvsprCalculations = 5;
+  let featureIds: string[] = [];
+  const getFeaturesImported = async () => {
+    const projectFeatures: {
+      id: string;
+      geoOperation: SingleConfigFeatureValueStripped | null;
+    }[] = await apiEntityManager
+      .createQueryBuilder()
+      .select('id')
+      .addSelect('from_geoprocessing_ops', 'geoOperation')
+      .from('features', 'f')
+      .where('project_id = :projectId', { projectId })
+      .execute();
+
+    return projectFeatures;
+  };
+
+  const getFeatureById = async (featureId: string) => {
+    const feature: {
+      id: string;
+      geoOperation: SingleConfigFeatureValueStripped | null;
+    }[] = await apiEntityManager
+      .createQueryBuilder()
+      .select('id')
+      .from('features', 'f')
+      .addSelect('from_geoprocessing_ops', 'geoOperation')
+      .where('id = :featureId', { featureId })
+      .execute();
+
+    return feature.length ? feature[0] : undefined;
+  };
+
+  return {
+    cleanUp: async () => {
+      await DeleteProjectAndOrganization(
+        apiEntityManager,
+        projectId,
+        organizationId,
+      );
+
+      if (featureIds.length)
+        await apiEntityManager
+          .createQueryBuilder()
+          .delete()
+          .from('features')
+          .where('id IN (:...featureIds)', { featureIds })
+          .execute();
+
+      const puvsprCalculationsRepo: Repository<PuvsprCalculationsEntity> = sandbox.get(
+        getRepositoryToken(PuvsprCalculationsEntity),
+      );
+
+      await puvsprCalculationsRepo.delete({});
+    },
+    GivenProject: () =>
+      GivenProjectExists(apiEntityManager, projectId, organizationId),
+    GivenJobInput: (archiveLocation: ArchiveLocation): ImportJobInput => {
+      const relativePath = ClonePieceRelativePathResolver.resolveFor(
+        ClonePiece.ProjectCustomFeatures,
+      );
+      return {
+        componentId: v4(),
+        pieceResourceId: v4(),
+        importId: v4(),
+        projectId,
+        piece: ClonePiece.ProjectCustomFeatures,
+        resourceKind: ResourceKind.Project,
+        uris: [{ relativePath, uri: archiveLocation.value }],
+        ownerId: userId,
+      };
+    },
+    GivenJobInputWithoutUris: (): ImportJobInput => {
+      return {
+        componentId: v4(),
+        pieceResourceId: v4(),
+        importId: v4(),
+        projectId,
+        piece: ClonePiece.ProjectCustomFeatures,
+        resourceKind: ResourceKind.Project,
+        uris: [],
+        ownerId: userId,
+      };
+    },
+    GivenNoProjectPuvsprCalculationsFileIsAvailable: () => {
+      return new ArchiveLocation('not found');
+    },
+    GivenValidProjectPuvsprCalculationsFile: async () => {
+      const { platformFeatures, customFeatures } = await GivenFeatures(
+        apiEntityManager,
+        1,
+        1,
+        projectId,
+      );
+      const basePlatformFeature = platformFeatures[0];
+      featureIds = [basePlatformFeature.id];
+      const importedSplitDerivedFeature = customFeatures[0];
+      const validProjectPuvsprCalculationsFile: ProjectPuvsprCalculationsContent = {
+        projectFeaturesGeoOperations: [
+          {
+            featureName: importedSplitDerivedFeature.feature_class_name,
+            geoOperation: {
+              baseFeatureIsCustom: false,
+              baseFeatureName: basePlatformFeature.feature_class_name,
+              operation: SpecificationOperation.Split,
+              splitByProperty: 'random-property',
+            },
+          },
+        ],
+        puvsprCalculations: Array(amountOfPuvsprCalculations)
+          .fill(0)
+          .map((_, index) => ({
+            amount: 200,
+            featureName: basePlatformFeature.feature_class_name,
+            isCustom: false,
+            puid: index,
+          })),
+      };
+
+      const exportId = v4();
+      const relativePath = ClonePieceRelativePathResolver.resolveFor(
+        ClonePiece.ProjectPuvsprCalculations,
+      );
+
+      const uriOrError = await fileRepository.saveCloningFile(
+        exportId,
+        Readable.from(JSON.stringify(validProjectPuvsprCalculationsFile)),
+        relativePath,
+      );
+
+      if (isLeft(uriOrError)) throw new Error("couldn't save file");
+      return new ArchiveLocation(uriOrError.right);
+    },
+    WhenPieceImporterIsInvoked: (input: ImportJobInput) => {
+      return {
+        ThenAnUrisArrayErrorShouldBeThrown: async () => {
+          await expect(sut.run(input)).rejects.toThrow(/uris/gi);
+        },
+        ThenADataNotAvailableErrorShouldBeThrown: async () => {
+          await expect(sut.run(input)).rejects.toThrow(
+            /File with piece data for/gi,
+          );
+        },
+        ThenPuvsprCalculationsAreImportedAndDerivedFeaturesAreUpdated: async () => {
+          const projectFeaturesImported = 1;
+          const featuresAlreadyImported = await getFeaturesImported();
+          expect(
+            featuresAlreadyImported.every(
+              ({ geoOperation }) => geoOperation === null,
+            ),
+          );
+          expect(featuresAlreadyImported).toHaveLength(projectFeaturesImported);
+          const projectPuvsprCalculations = await puvsprCalculationsRepo.getAmountPerPlanningUnitAndFeatureInProject(
+            projectId,
+          );
+          expect(projectPuvsprCalculations).toEqual([]);
+
+          await sut.run(input);
+
+          const featuresAfterImport = await getFeaturesImported();
+          expect(featuresAfterImport).toHaveLength(projectFeaturesImported);
+          const splitDerivedFeature = featuresAfterImport[0];
+          expect(splitDerivedFeature.geoOperation).not.toEqual(null);
+          const baseFeatureId = splitDerivedFeature.geoOperation!.baseFeatureId;
+          const baseFeature = await getFeatureById(baseFeatureId);
+          expect(baseFeature).toBeDefined();
+          expect(baseFeature!.geoOperation).toEqual(null);
+
+          const puvsprCalculationsAfterImport = await puvsprCalculationsRepo.getAmountPerPlanningUnitAndFeatureInProject(
+            projectId,
+          );
+          expect(puvsprCalculationsAfterImport).toHaveLength(
+            amountOfPuvsprCalculations,
+          );
+          expect(
+            puvsprCalculationsAfterImport.every(
+              ({ featureId }) => baseFeatureId === featureId,
+            ),
+          );
+        },
+      };
+    },
+  };
+};

--- a/api/libs/cloning/src/domain/clone-piece.ts
+++ b/api/libs/cloning/src/domain/clone-piece.ts
@@ -3,6 +3,7 @@ export enum ClonePiece {
   ProjectMetadata = 'project-metadata',
   ProjectCustomProtectedAreas = 'project-custom-protected-areas',
   ProjectCustomFeatures = 'project-custom-features',
+  ProjectPuvsprCalculations = 'project-puvspr-calculations',
   PlanningAreaGAdm = 'planning-area-gadm',
   PlanningAreaCustom = 'planning-area-custom',
   PlanningUnitsGrid = 'planning-units-grid',

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/index.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/index.ts
@@ -12,6 +12,7 @@ import { planningUnitsGridGeoJSONRelativePath } from './planning-units-grid-geoj
 import { projectCustomFeaturesRelativePath } from './project-custom-features';
 import { projectCustomProtectedAreasRelativePath } from './project-custom-protected-areas';
 import { projectMetadataRelativePath } from './project-metadata';
+import { projectPuvsprCalculationsRelativePath } from './project-puvspr-calculations';
 import { scenarioFeaturesDataRelativePath } from './scenario-features-data';
 import { featuresSpecificationRelativePath } from './scenario-features-specification';
 import { scenarioInputFolderRelativePath } from './scenario-input-folder';
@@ -61,6 +62,7 @@ export const clonePieceImportOrder: Record<ClonePiece, number> = {
   [ClonePiece.ProjectCustomProtectedAreas]: 1,
   [ClonePiece.ProjectCustomFeatures]: 1,
   //
+  [ClonePiece.ProjectPuvsprCalculations]: 2,
   [ClonePiece.ScenarioProtectedAreas]: 2,
   [ClonePiece.ScenarioPlanningUnitsData]: 2,
   [ClonePiece.ScenarioFeaturesData]: 2,
@@ -89,6 +91,8 @@ export class ClonePieceRelativePathResolver {
     [ClonePiece.ProjectCustomProtectedAreas]: () =>
       projectCustomProtectedAreasRelativePath,
     [ClonePiece.ProjectCustomFeatures]: () => projectCustomFeaturesRelativePath,
+    [ClonePiece.ProjectPuvsprCalculations]: () =>
+      projectPuvsprCalculationsRelativePath,
     [ClonePiece.FeaturesSpecification]: ClonePieceRelativePathResolver.scenarioPieceRelativePathResolver(
       featuresSpecificationRelativePath,
     ),

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-puvspr-calculations.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-puvspr-calculations.ts
@@ -1,0 +1,26 @@
+import { SingleSplitConfigFeatureValueStripped } from '@marxan/features-hash';
+
+export type FeatureAmountPerPlanningUnit = {
+  featureName: string;
+  isCustom: boolean;
+  amount: number;
+  puid: number;
+};
+
+export type GeoOperation = Omit<
+  SingleSplitConfigFeatureValueStripped,
+  'baseFeatureId'
+> & { baseFeatureName: string; baseFeatureIsCustom: boolean };
+
+export type ProjectFeatureGeoOperation = {
+  featureName: string;
+  geoOperation: GeoOperation;
+};
+
+export type ProjectPuvsprCalculationsContent = {
+  puvsprCalculations: FeatureAmountPerPlanningUnit[];
+  projectFeaturesGeoOperations: ProjectFeatureGeoOperation[];
+};
+
+export const projectPuvsprCalculationsRelativePath =
+  'project-puvspr-calculations.json';


### PR DESCRIPTION
This PR adds `puvspr calculations` piece exporter and importer.

Also, update on existing `scenario_features_preparation` rows has been modified , despite the change is not in this branch we have already change how `scenario_features_data` rows are updated. ?Do we want to keep the change for `scenario_features_data` rows?

### Feature relevant tickets

[export and import puvspr_calculations](https://vizzuality.atlassian.net/browse/MARXAN-1675)