### PR TITLE
Fix/marxan 1685 make description optional legacy project import

### DIFF
--- a/api/apps/api/src/modules/legacy-project-import/application/start-legacy-project-import.command.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/start-legacy-project-import.command.ts
@@ -26,7 +26,7 @@ export class StartLegacyProjectImport extends Command<StartLegacyProjectImportRe
   constructor(
     public readonly name: string,
     public readonly ownerId: UserId,
-    public readonly description: string,
+    public readonly description?: string,
   ) {
     super();
   }

--- a/api/apps/api/src/modules/legacy-project-import/application/start-legacy-project-import.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/start-legacy-project-import.handler.ts
@@ -33,7 +33,7 @@ export class StartLegacyProjectImportHandler
   private async createShells(
     name: string,
     ownerId: string,
-    description: string,
+    description?: string,
   ) {
     try {
       const [randomOrganization] = await this.organizationRepo.find({

--- a/api/apps/api/src/modules/projects/dto/legacy-project-import.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/legacy-project-import.dto.ts
@@ -19,8 +19,9 @@ export class StartLegacyProjectImportBodyDto {
     description: 'description of the project',
     example: 'legacy project import description',
   })
+  @IsOptional()
   @IsString()
-  description!: string;
+  description?: string;
 }
 
 export class StartLegacyProjectImportResponseDto {

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -471,7 +471,7 @@ export class ProjectsService {
   async startLegacyProjectImport(
     projectName: string,
     userId: string,
-    description: string,
+    description?: string,
   ): Promise<
     Either<
       typeof forbiddenError | StartLegacyProjectImportError,

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/scenarios-pus-data.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/scenarios-pus-data.legacy-piece-importer.ts
@@ -222,9 +222,7 @@ export class ScenarioPusDataLegacyProjectPieceImporter
       );
       if (puidsNotPresentInPuDat.length)
         this.logAndThrow(
-          `pu.dat file is missing planning units data. Missing puids: ${puidsNotPresentInPuDat.join(
-            ', ',
-          )}`,
+          `pu.dat file is missing planning units data. There are ${puidsNotPresentInPuDat.length} missing puids.`,
         );
 
       await Promise.all(


### PR DESCRIPTION
This PR makes description optional for legacy project imports. It also changes the error message when pu.dat file is missing puids as it was too large.

### Feature relevant tickets

[make description optional for legacy project imports](https://vizzuality.atlassian.net/browse/MARXAN-1685)