### PR TITLE
mark as failed stuck async jobs [MARXAN-1554]

### DIFF
--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -36,6 +36,7 @@ import { BlmValuesModule } from '@marxan-api/modules/blm';
 import { AccessControlModule } from '@marxan-api/modules/access-control';
 import { CloneModule } from './modules/clone';
 import { ApiCloningFilesRepositoryModule } from './modules/cloning-file-repository/api-cloning-file-repository.module';
+import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-collector';
 
 @Module({
   imports: [
@@ -71,6 +72,7 @@ import { ApiCloningFilesRepositoryModule } from './modules/cloning-file-reposito
     AccessControlModule,
     ApiCloningFilesRepositoryModule,
     CloneModule,
+    AsyncJobsGarbageCollectorModule,
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs-garbage-collector-finished.event.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs-garbage-collector-finished.event.ts
@@ -1,0 +1,5 @@
+import { IEvent } from '@nestjs/cqrs';
+
+export class AsyncJobsGarbageCollectorFinished implements IEvent {
+  constructor(public readonly userId: string) {}
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs.garbage-collector.module.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs.garbage-collector.module.ts
@@ -7,11 +7,13 @@ import { GarbageCollectAsyncJobsHandler } from './garbage-collect-async-jobs.han
 import { UsersProjectsApiEntity } from '../access-control/projects-acl/entity/users-projects.api.entity';
 import { UsersScenariosApiEntity } from '../access-control/scenarios-acl/entity/users-scenarios.api.entity';
 import { UserLoggedInSaga } from './user-logged-in.saga';
+import { CqrsModule } from '@nestjs/cqrs';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([UsersProjectsApiEntity, UsersScenariosApiEntity]),
     AsyncJobsModule,
+    CqrsModule,
   ],
   providers: [
     UserLoggedInSaga,
@@ -20,5 +22,6 @@ import { UserLoggedInSaga } from './user-logged-in.saga';
     ScenarioAsyncJobsGarbageCollector,
     GarbageCollectAsyncJobsHandler,
   ],
+  exports: [UserLoggedInSaga],
 })
 export class AsyncJobsGarbageCollectorModule {}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs.garbage-collector.module.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs.garbage-collector.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AsyncJobsModule } from './async-jobs/async-jobs.module';
+import { ProjectAsyncJobsGarbageCollector } from './project-async-jobs.garbage-collector';
+import { ScenarioAsyncJobsGarbageCollector } from './scenario-async-jobs.garbage-collector';
+import { GarbageCollectAsyncJobsHandler } from './garbage-collect-async-jobs.handler';
+import { UsersProjectsApiEntity } from '../access-control/projects-acl/entity/users-projects.api.entity';
+import { UsersScenariosApiEntity } from '../access-control/scenarios-acl/entity/users-scenarios.api.entity';
+import { UserLoggedInSaga } from './user-logged-in.saga';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([UsersProjectsApiEntity, UsersScenariosApiEntity]),
+    AsyncJobsModule,
+  ],
+  providers: [
+    UserLoggedInSaga,
+    GarbageCollectAsyncJobsHandler,
+    ProjectAsyncJobsGarbageCollector,
+    ScenarioAsyncJobsGarbageCollector,
+    GarbageCollectAsyncJobsHandler,
+  ],
+})
+export class AsyncJobsGarbageCollectorModule {}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs.garbage-collector.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs.garbage-collector.ts
@@ -1,0 +1,3 @@
+export interface AsyncJobsGarbageCollector {
+  sendFailedApiEventsForStuckAsyncJobs(resourceId: string): Promise<void>;
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.spec.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.spec.ts
@@ -122,7 +122,7 @@ class AsyncJobFake extends AsyncJob {
   protected getAllAsyncJobStates(): API_EVENT_KINDS[] {
     return this.allAsyncJobStates;
   }
-  protected getEndAsynJobStates(): API_EVENT_KINDS[] {
+  protected getEndAsyncJobStates(): API_EVENT_KINDS[] {
     return this.endAsyncJobStates;
   }
   protected getFailedAsyncJobState(

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.spec.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.spec.ts
@@ -1,0 +1,136 @@
+import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { ApiEventByTopicAndKind } from '@marxan-api/modules/api-events/api-event.topic+kind.api.entity';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { v4 } from 'uuid';
+import { AsyncJob } from './async-job';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+it(`does not send a failed api event when async job has not started`, async () => {
+  fixtures.GivenAsyncJobHasNotStarted();
+  await fixtures.WhenSendingFailedApiEventForStuckAsyncJob();
+  fixtures.ThenNoApiEventHasBeenSent();
+});
+
+it(`does not send a failed api event for a finished async job`, async () => {
+  fixtures.GivenAsyncJobHasFinished();
+  await fixtures.WhenSendingFailedApiEventForStuckAsyncJob();
+  fixtures.ThenNoApiEventHasBeenSent();
+});
+
+it(`does not send a failed api event for a non stuck async job`, async () => {
+  fixtures.GivenAsyncJobHasNotFinished({ isStuck: false });
+  await fixtures.WhenSendingFailedApiEventForStuckAsyncJob();
+  fixtures.ThenNoApiEventHasBeenSent();
+});
+
+it(`sends a failed api event for a stuck async job`, async () => {
+  fixtures.GivenAsyncJobHasNotFinished({ isStuck: true });
+  await fixtures.WhenSendingFailedApiEventForStuckAsyncJob();
+  fixtures.ThenApiEventHasBeenSent();
+});
+
+const getFixtures = async () => {
+  const getLatestEventForTopicMock = jest.fn();
+  const createIfNotExistsMock = jest.fn();
+  const sandbox = await Test.createTestingModule({
+    imports: [],
+    providers: [
+      AsyncJobFake,
+      {
+        provide: ApiEventsService,
+        useValue: {
+          getLatestEventForTopic: getLatestEventForTopicMock,
+          createIfNotExists: createIfNotExistsMock,
+        },
+      },
+    ],
+  }).compile();
+
+  await sandbox.init();
+
+  const projectId = v4();
+
+  const sut = sandbox.get(AsyncJobFake);
+
+  function subtract2HoursFromNow() {
+    const date = new Date();
+    date.setHours(date.getHours() - 2);
+    return date;
+  }
+
+  const finishedApiEvent = API_EVENT_KINDS.project__grid__finished__v1__alpha;
+  const workingApiEvent = API_EVENT_KINDS.project__grid__submitted__v1__alpha;
+  const failedApiEvent = API_EVENT_KINDS.project__grid__failed__v1__alpha;
+
+  return {
+    GivenAsyncJobHasNotStarted: () => {
+      getLatestEventForTopicMock.mockImplementation(async () => {
+        throw new NotFoundException();
+      });
+    },
+    GivenAsyncJobHasFinished: () => {
+      getLatestEventForTopicMock.mockImplementation(async () => {
+        return {
+          topic: projectId,
+          kind: finishedApiEvent,
+          timestamp: new Date(),
+        };
+      });
+    },
+    GivenAsyncJobHasNotFinished: (opts: { isStuck: boolean }) => {
+      const apiEventDate = opts.isStuck ? new Date(2022, 1, 1) : new Date();
+      sut.maxHoursForAsyncJob = 2;
+      getLatestEventForTopicMock.mockImplementation(async () => {
+        return {
+          topic: projectId,
+          kind: workingApiEvent,
+          timestamp: apiEventDate,
+        };
+      });
+    },
+    WhenSendingFailedApiEventForStuckAsyncJob: () =>
+      sut.sendFailedApiEventForStuckAsyncJob(projectId),
+    ThenApiEventHasBeenSent: () => {
+      expect(createIfNotExistsMock).toHaveBeenCalled();
+      expect(createIfNotExistsMock).toHaveBeenCalledWith({
+        topic: projectId,
+        kind: failedApiEvent,
+      });
+    },
+    ThenNoApiEventHasBeenSent: () => {
+      expect(createIfNotExistsMock).not.toHaveBeenCalled();
+    },
+  };
+};
+
+@Injectable()
+class AsyncJobFake extends AsyncJob {
+  public allAsyncJobStates: API_EVENT_KINDS[] = [];
+  public endAsyncJobStates: API_EVENT_KINDS[] = [
+    API_EVENT_KINDS.project__grid__finished__v1__alpha,
+  ];
+  public failedAsyncJob = API_EVENT_KINDS.project__grid__failed__v1__alpha;
+  public maxHoursForAsyncJob = 0;
+  protected getAllAsyncJobStates(): API_EVENT_KINDS[] {
+    return this.allAsyncJobStates;
+  }
+  protected getEndAsynJobStates(): API_EVENT_KINDS[] {
+    return this.endAsyncJobStates;
+  }
+  protected getFailedAsyncJobState(
+    stuckState: API_EVENT_KINDS,
+  ): API_EVENT_KINDS {
+    return this.failedAsyncJob;
+  }
+  protected getMaxHoursForAsyncJob(): number {
+    return this.maxHoursForAsyncJob;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.ts
@@ -11,7 +11,7 @@ export abstract class AsyncJob {
 
   protected abstract getAllAsyncJobStates(): API_EVENT_KINDS[];
 
-  protected abstract getEndAsynJobStates(): API_EVENT_KINDS[];
+  protected abstract getEndAsyncJobStates(): API_EVENT_KINDS[];
 
   protected abstract getFailedAsyncJobState(
     stuckState: API_EVENT_KINDS,
@@ -27,9 +27,9 @@ export abstract class AsyncJob {
 
     if (!latestApiEvent) return;
 
-    const hasAsyncJobFinsihed = this.hasAsyncJobFinsihed(latestApiEvent);
+    const hasAsyncJobFinished = this.hasAsyncJobFinished(latestApiEvent);
 
-    if (hasAsyncJobFinsihed) return;
+    if (hasAsyncJobFinished) return;
 
     const isAsyncJobStuck = this.isAsyncJobStuck(latestApiEvent);
 
@@ -55,8 +55,8 @@ export abstract class AsyncJob {
     }
   }
 
-  private hasAsyncJobFinsihed(latestApiEvent: ApiEventByTopicAndKind) {
-    return this.getEndAsynJobStates().includes(latestApiEvent.kind);
+  private hasAsyncJobFinished(latestApiEvent: ApiEventByTopicAndKind) {
+    return this.getEndAsyncJobStates().includes(latestApiEvent.kind);
   }
   private isAsyncJobStuck(latestApiEvent: ApiEventByTopicAndKind) {
     const maxTime = this.getMaxTimeForAsyncJob();

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-job.ts
@@ -1,0 +1,83 @@
+import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { ApiEventByTopicAndKind } from '@marxan-api/modules/api-events/api-event.topic+kind.api.entity';
+import { QualifiedEventTopicSearch } from '@marxan-api/modules/api-events/api-events.service';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { In } from 'typeorm';
+
+@Injectable()
+export abstract class AsyncJob {
+  constructor(protected readonly apiEvents: ApiEventsService) {}
+
+  protected abstract getAllAsyncJobStates(): API_EVENT_KINDS[];
+
+  protected abstract getEndAsynJobStates(): API_EVENT_KINDS[];
+
+  protected abstract getFailedAsyncJobState(
+    stuckState: API_EVENT_KINDS,
+  ): API_EVENT_KINDS;
+
+  protected abstract getMaxHoursForAsyncJob(): number;
+
+  public async sendFailedApiEventForStuckAsyncJob(resourceId: string) {
+    const latestApiEvent = await this.findLatestApiEvent({
+      topic: resourceId,
+      kind: In(this.getAllAsyncJobStates()),
+    });
+
+    if (!latestApiEvent) return;
+
+    const hasAsyncJobFinsihed = this.hasAsyncJobFinsihed(latestApiEvent);
+
+    if (hasAsyncJobFinsihed) return;
+
+    const isAsyncJobStuck = this.isAsyncJobStuck(latestApiEvent);
+
+    if (!isAsyncJobStuck) return;
+
+    return this.sendFailedApiEvent(resourceId, latestApiEvent);
+  }
+
+  private async findLatestApiEvent(
+    qualifiedTopic: QualifiedEventTopicSearch,
+  ): Promise<ApiEventByTopicAndKind | undefined> {
+    try {
+      const previousEvent = await this.apiEvents.getLatestEventForTopic(
+        qualifiedTopic,
+      );
+
+      return previousEvent;
+    } catch (err) {
+      if (err instanceof NotFoundException) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  private hasAsyncJobFinsihed(latestApiEvent: ApiEventByTopicAndKind) {
+    return this.getEndAsynJobStates().includes(latestApiEvent.kind);
+  }
+  private isAsyncJobStuck(latestApiEvent: ApiEventByTopicAndKind) {
+    const maxTime = this.getMaxTimeForAsyncJob();
+    return maxTime.getTime() >= latestApiEvent.timestamp.getTime();
+  }
+
+  private async sendFailedApiEvent(
+    resourceId: string,
+    latestApiEvent: ApiEventByTopicAndKind,
+  ) {
+    const failedKind = this.getFailedAsyncJobState(latestApiEvent.kind);
+
+    await this.apiEvents.createIfNotExists({
+      kind: failedKind,
+      topic: resourceId,
+    });
+  }
+
+  private getMaxTimeForAsyncJob() {
+    const now = new Date();
+    now.setHours(now.getHours() - this.getMaxHoursForAsyncJob());
+    return now;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-jobs.module.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/async-jobs.module.ts
@@ -1,0 +1,46 @@
+import { ApiEventsModule } from '@marxan-api/modules/api-events';
+import { Module } from '@nestjs/common';
+import { GridAsyncJob } from './project-async-jobs/grid-async-job';
+import { LegacyImportAsyncJob } from './project-async-jobs/legacy-import.async-job';
+import { PlanningUnitsAsyncJob } from './project-async-jobs/planning-units.async-job';
+import { ProjectCloneAsyncJob } from './project-async-jobs/project-clone.async-job';
+import { ProjectExportAsyncJob } from './project-async-jobs/project-export.async-job';
+import { ProjectImportAsyncJob } from './project-async-jobs/project-import.async-job';
+import { CalibrationAsyncJob } from './scenario-async-jobs/calibration.async-job';
+import { CostSurfaceAsyncJob } from './scenario-async-jobs/cost-surface.async-job';
+import { FeaturesWithPuIntersectionAsyncJob } from './scenario-async-jobs/features-with-pu-intersection.async-job';
+import { PlanningAreaProtectedCalculationAsyncJob } from './scenario-async-jobs/planning-area-protected-calculations.async-job';
+import { PlanningUnitsInclusionAsyncJob } from './scenario-async-jobs/planning-units-inclusion.async-job';
+import { ProtectedAreasAsyncJob } from './scenario-async-jobs/protected-areas.async-job';
+import { RunAsyncJob } from './scenario-async-jobs/run.async-job';
+import { ScenarioCloneAsyncJob } from './scenario-async-jobs/scenario-clone.async-job';
+import { ScenarioExportAsyncJob } from './scenario-async-jobs/scenario-export.async-job';
+import { ScenarioImportAsyncJob } from './scenario-async-jobs/scenario-import.async-job';
+import { SpecificationAsyncJob } from './scenario-async-jobs/specification.async-job';
+
+const asyncJobs = [
+  GridAsyncJob,
+  LegacyImportAsyncJob,
+  PlanningUnitsAsyncJob,
+  ProjectCloneAsyncJob,
+  ProjectExportAsyncJob,
+  ProjectImportAsyncJob,
+  CalibrationAsyncJob,
+  CostSurfaceAsyncJob,
+  FeaturesWithPuIntersectionAsyncJob,
+  PlanningAreaProtectedCalculationAsyncJob,
+  PlanningUnitsInclusionAsyncJob,
+  ProtectedAreasAsyncJob,
+  RunAsyncJob,
+  ScenarioCloneAsyncJob,
+  ScenarioExportAsyncJob,
+  ScenarioImportAsyncJob,
+  SpecificationAsyncJob,
+];
+
+@Module({
+  imports: [ApiEventsModule],
+  providers: asyncJobs,
+  exports: asyncJobs,
+})
+export class AsyncJobsModule {}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/index.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/index.ts
@@ -1,0 +1,17 @@
+export { GridAsyncJob } from './project-async-jobs/grid-async-job';
+export { LegacyImportAsyncJob } from './project-async-jobs/legacy-import.async-job';
+export { PlanningUnitsAsyncJob } from './project-async-jobs/planning-units.async-job';
+export { ProjectExportAsyncJob } from './project-async-jobs/project-export.async-job';
+export { ProjectImportAsyncJob } from './project-async-jobs/project-import.async-job';
+export { ProjectCloneAsyncJob } from './project-async-jobs/project-clone.async-job';
+export { CalibrationAsyncJob } from './scenario-async-jobs/calibration.async-job';
+export { CostSurfaceAsyncJob } from './scenario-async-jobs/cost-surface.async-job';
+export { FeaturesWithPuIntersectionAsyncJob } from './scenario-async-jobs/features-with-pu-intersection.async-job';
+export { PlanningAreaProtectedCalculationAsyncJob } from './scenario-async-jobs/planning-area-protected-calculations.async-job';
+export { PlanningUnitsInclusionAsyncJob } from './scenario-async-jobs/planning-units-inclusion.async-job';
+export { ProtectedAreasAsyncJob } from './scenario-async-jobs/protected-areas.async-job';
+export { RunAsyncJob } from './scenario-async-jobs/run.async-job';
+export { SpecificationAsyncJob } from './scenario-async-jobs/specification.async-job';
+export { ScenarioExportAsyncJob } from './scenario-async-jobs/scenario-export.async-job';
+export { ScenarioImportAsyncJob } from './scenario-async-jobs/scenario-import.async-job';
+export { ScenarioCloneAsyncJob } from './scenario-async-jobs/scenario-clone.async-job';

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/grid-async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/grid-async-job.ts
@@ -19,7 +19,7 @@ export class GridAsyncJob extends AsyncJob {
       API_EVENT_KINDS.project__grid__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): GridApiEvents[] {
+  getEndAsyncJobStates(): GridApiEvents[] {
     return [
       API_EVENT_KINDS.project__grid__finished__v1__alpha,
       API_EVENT_KINDS.project__grid__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/grid-async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/grid-async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type GridApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `project__grid__${string}`>
+  >
+>;
+
+@Injectable()
+export class GridAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): GridApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__grid__submitted__v1__alpha,
+      API_EVENT_KINDS.project__grid__finished__v1__alpha,
+      API_EVENT_KINDS.project__grid__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): GridApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__grid__finished__v1__alpha,
+      API_EVENT_KINDS.project__grid__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): GridApiEvents {
+    return API_EVENT_KINDS.project__grid__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/legacy-import.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/legacy-import.async-job.ts
@@ -20,7 +20,7 @@ export class LegacyImportAsyncJob extends AsyncJob {
       API_EVENT_KINDS.project__legacy__import__submitted__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): LegacyImportApiEvents[] {
+  getEndAsyncJobStates(): LegacyImportApiEvents[] {
     return [
       API_EVENT_KINDS.project__legacy__import__canceled__v1__alpha,
       API_EVENT_KINDS.project__legacy__import__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/legacy-import.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/legacy-import.async-job.ts
@@ -1,0 +1,36 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type LegacyImportApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `project__legacy__${string}`>
+  >
+>;
+
+@Injectable()
+export class LegacyImportAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): LegacyImportApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__legacy__import__canceled__v1__alpha,
+      API_EVENT_KINDS.project__legacy__import__failed__v1__alpha,
+      API_EVENT_KINDS.project__legacy__import__finished__v1__alpha,
+      API_EVENT_KINDS.project__legacy__import__submitted__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): LegacyImportApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__legacy__import__canceled__v1__alpha,
+      API_EVENT_KINDS.project__legacy__import__failed__v1__alpha,
+      API_EVENT_KINDS.project__legacy__import__finished__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): LegacyImportApiEvents {
+    return API_EVENT_KINDS.project__legacy__import__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/planning-units.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/planning-units.async-job.ts
@@ -19,7 +19,7 @@ export class PlanningUnitsAsyncJob extends AsyncJob {
       API_EVENT_KINDS.project__planningUnits__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): PlanningUnitsApiEvents[] {
+  getEndAsyncJobStates(): PlanningUnitsApiEvents[] {
     return [
       API_EVENT_KINDS.project__planningUnits__finished__v1__alpha,
       API_EVENT_KINDS.project__planningUnits__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/planning-units.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/planning-units.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type PlanningUnitsApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `project__planningUnits__${string}`>
+  >
+>;
+
+@Injectable()
+export class PlanningUnitsAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): PlanningUnitsApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__planningUnits__submitted__v1__alpha,
+      API_EVENT_KINDS.project__planningUnits__finished__v1__alpha,
+      API_EVENT_KINDS.project__planningUnits__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): PlanningUnitsApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__planningUnits__finished__v1__alpha,
+      API_EVENT_KINDS.project__planningUnits__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): PlanningUnitsApiEvents {
+    return API_EVENT_KINDS.project__planningUnits__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-clone.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-clone.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ProjectCloneApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `project__clone__${string}`>
+  >
+>;
+
+@Injectable()
+export class ProjectCloneAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ProjectCloneApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__clone__submitted__v1__alpha,
+      API_EVENT_KINDS.project__clone__finished__v1__alpha,
+      API_EVENT_KINDS.project__clone__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ProjectCloneApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__clone__finished__v1__alpha,
+      API_EVENT_KINDS.project__clone__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ProjectCloneApiEvents {
+    return API_EVENT_KINDS.project__clone__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-clone.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-clone.async-job.ts
@@ -19,7 +19,7 @@ export class ProjectCloneAsyncJob extends AsyncJob {
       API_EVENT_KINDS.project__clone__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ProjectCloneApiEvents[] {
+  getEndAsyncJobStates(): ProjectCloneApiEvents[] {
     return [
       API_EVENT_KINDS.project__clone__finished__v1__alpha,
       API_EVENT_KINDS.project__clone__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-export.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-export.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ProjectExportApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `project__export__${string}`>
+  >
+>;
+
+@Injectable()
+export class ProjectExportAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ProjectExportApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__export__submitted__v1__alpha,
+      API_EVENT_KINDS.project__export__finished__v1__alpha,
+      API_EVENT_KINDS.project__export__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ProjectExportApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__export__finished__v1__alpha,
+      API_EVENT_KINDS.project__export__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ProjectExportApiEvents {
+    return API_EVENT_KINDS.project__export__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-export.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-export.async-job.ts
@@ -19,7 +19,7 @@ export class ProjectExportAsyncJob extends AsyncJob {
       API_EVENT_KINDS.project__export__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ProjectExportApiEvents[] {
+  getEndAsyncJobStates(): ProjectExportApiEvents[] {
     return [
       API_EVENT_KINDS.project__export__finished__v1__alpha,
       API_EVENT_KINDS.project__export__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-import.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-import.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ProjectImportApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `project__import__${string}`>
+  >
+>;
+
+@Injectable()
+export class ProjectImportAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ProjectImportApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__import__submitted__v1__alpha,
+      API_EVENT_KINDS.project__import__finished__v1__alpha,
+      API_EVENT_KINDS.project__import__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ProjectImportApiEvents[] {
+    return [
+      API_EVENT_KINDS.project__import__finished__v1__alpha,
+      API_EVENT_KINDS.project__import__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ProjectImportApiEvents {
+    return API_EVENT_KINDS.project__import__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-import.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/project-async-jobs/project-import.async-job.ts
@@ -19,7 +19,7 @@ export class ProjectImportAsyncJob extends AsyncJob {
       API_EVENT_KINDS.project__import__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ProjectImportApiEvents[] {
+  getEndAsyncJobStates(): ProjectImportApiEvents[] {
     return [
       API_EVENT_KINDS.project__import__finished__v1__alpha,
       API_EVENT_KINDS.project__import__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/calibration.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/calibration.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type CalibrationApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__calibration__${string}`>
+  >
+>;
+
+@Injectable()
+export class CalibrationAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): CalibrationApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__calibration__submitted_v1_alpha1,
+      API_EVENT_KINDS.scenario__calibration__finished_v1_alpha1,
+      API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1,
+    ];
+  }
+  getEndAsynJobStates(): CalibrationApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__calibration__finished_v1_alpha1,
+      API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1,
+    ];
+  }
+  getFailedAsyncJobState(): CalibrationApiEvents {
+    return API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/calibration.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/calibration.async-job.ts
@@ -19,7 +19,7 @@ export class CalibrationAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1,
     ];
   }
-  getEndAsynJobStates(): CalibrationApiEvents[] {
+  getEndAsyncJobStates(): CalibrationApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__calibration__finished_v1_alpha1,
       API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/cost-surface.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/cost-surface.async-job.ts
@@ -1,0 +1,43 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type CostSurfaceApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__costSurface__${string}`>
+  >
+>;
+
+@Injectable()
+export class CostSurfaceAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): CostSurfaceApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__costSurface__submitted__v1_alpha1,
+      API_EVENT_KINDS.scenario__costSurface__shapeConverted__v1_alpha1,
+      API_EVENT_KINDS.scenario__costSurface__shapeConversionFailed__v1_alpha1,
+      API_EVENT_KINDS.scenario__costSurface__costUpdateFailed__v1_alpha1,
+      API_EVENT_KINDS.scenario__costSurface__finished__v1_alpha1,
+    ];
+  }
+  getEndAsynJobStates(): CostSurfaceApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__costSurface__costUpdateFailed__v1_alpha1,
+      API_EVENT_KINDS.scenario__costSurface__finished__v1_alpha1,
+    ];
+  }
+  getFailedAsyncJobState(): CostSurfaceApiEvents {
+    /*
+    At the moment in the codebase, we are not using this two api events:
+    API_EVENT_KINDS.scenario__costSurface__shapeConverted__v1_alpha1 
+    API_EVENT_KINDS.scenario__costSurface__shapeConversionFailed__v1_alpha1
+    In case we start using them, we migh have to do add new state to getEndAsynJobStates()
+    and check the latestApitEvent when executing getFailedAsyncJobState()
+    */
+    return API_EVENT_KINDS.scenario__costSurface__costUpdateFailed__v1_alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/cost-surface.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/cost-surface.async-job.ts
@@ -21,7 +21,7 @@ export class CostSurfaceAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__costSurface__finished__v1_alpha1,
     ];
   }
-  getEndAsynJobStates(): CostSurfaceApiEvents[] {
+  getEndAsyncJobStates(): CostSurfaceApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__costSurface__costUpdateFailed__v1_alpha1,
       API_EVENT_KINDS.scenario__costSurface__finished__v1_alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/features-with-pu-intersection.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/features-with-pu-intersection.async-job.ts
@@ -1,0 +1,37 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type FeaturesWithPuIntersectionApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<
+      keyof typeof API_EVENT_KINDS,
+      `scenario__featuresWithPuIntersection__${string}`
+    >
+  >
+>;
+
+@Injectable()
+export class FeaturesWithPuIntersectionAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): FeaturesWithPuIntersectionApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__featuresWithPuIntersection__submitted__v1__alpha1,
+      API_EVENT_KINDS.scenario__featuresWithPuIntersection__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__featuresWithPuIntersection__finished__v1__alpha1,
+    ];
+  }
+  getEndAsynJobStates(): FeaturesWithPuIntersectionApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__featuresWithPuIntersection__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__featuresWithPuIntersection__finished__v1__alpha1,
+    ];
+  }
+  getFailedAsyncJobState(): FeaturesWithPuIntersectionApiEvents {
+    return API_EVENT_KINDS.scenario__featuresWithPuIntersection__failed__v1__alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/features-with-pu-intersection.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/features-with-pu-intersection.async-job.ts
@@ -22,7 +22,7 @@ export class FeaturesWithPuIntersectionAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__featuresWithPuIntersection__finished__v1__alpha1,
     ];
   }
-  getEndAsynJobStates(): FeaturesWithPuIntersectionApiEvents[] {
+  getEndAsyncJobStates(): FeaturesWithPuIntersectionApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__featuresWithPuIntersection__failed__v1__alpha1,
       API_EVENT_KINDS.scenario__featuresWithPuIntersection__finished__v1__alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-area-protected-calculations.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-area-protected-calculations.async-job.ts
@@ -1,0 +1,37 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ProtectedAreasApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<
+      keyof typeof API_EVENT_KINDS,
+      `scenario__planningAreaProtectedCalculation__${string}`
+    >
+  >
+>;
+
+@Injectable()
+export class PlanningAreaProtectedCalculationAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ProtectedAreasApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__submitted__v1__alpha1,
+      API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__finished__v1__alpha1,
+      API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__failed__v1__alpha1,
+    ];
+  }
+  getEndAsynJobStates(): ProtectedAreasApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__finished__v1__alpha1,
+      API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__failed__v1__alpha1,
+    ];
+  }
+  getFailedAsyncJobState(): ProtectedAreasApiEvents {
+    return API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__failed__v1__alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-area-protected-calculations.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-area-protected-calculations.async-job.ts
@@ -22,7 +22,7 @@ export class PlanningAreaProtectedCalculationAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__failed__v1__alpha1,
     ];
   }
-  getEndAsynJobStates(): ProtectedAreasApiEvents[] {
+  getEndAsyncJobStates(): ProtectedAreasApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__finished__v1__alpha1,
       API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__failed__v1__alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-units-inclusion.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-units-inclusion.async-job.ts
@@ -1,0 +1,37 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type PlanningUnitsInclusionApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<
+      keyof typeof API_EVENT_KINDS,
+      `scenario__planningUnitsInclusion__${string}`
+    >
+  >
+>;
+
+@Injectable()
+export class PlanningUnitsInclusionAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): PlanningUnitsInclusionApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__planningUnitsInclusion__submitted__v1__alpha1,
+      API_EVENT_KINDS.scenario__planningUnitsInclusion__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__planningUnitsInclusion__finished__v1__alpha1,
+    ];
+  }
+  getEndAsynJobStates(): PlanningUnitsInclusionApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__planningUnitsInclusion__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__planningUnitsInclusion__finished__v1__alpha1,
+    ];
+  }
+  getFailedAsyncJobState(): PlanningUnitsInclusionApiEvents {
+    return API_EVENT_KINDS.scenario__planningUnitsInclusion__failed__v1__alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-units-inclusion.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/planning-units-inclusion.async-job.ts
@@ -22,7 +22,7 @@ export class PlanningUnitsInclusionAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__planningUnitsInclusion__finished__v1__alpha1,
     ];
   }
-  getEndAsynJobStates(): PlanningUnitsInclusionApiEvents[] {
+  getEndAsyncJobStates(): PlanningUnitsInclusionApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__planningUnitsInclusion__failed__v1__alpha1,
       API_EVENT_KINDS.scenario__planningUnitsInclusion__finished__v1__alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/protected-areas.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/protected-areas.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ProtectedAreasApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__protectedAreas__${string}`>
+  >
+>;
+
+@Injectable()
+export class ProtectedAreasAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ProtectedAreasApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__protectedAreas__submitted__v1__alpha,
+      API_EVENT_KINDS.scenario__protectedAreas__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__protectedAreas__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ProtectedAreasApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__protectedAreas__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__protectedAreas__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ProtectedAreasApiEvents {
+    return API_EVENT_KINDS.scenario__protectedAreas__finished__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/protected-areas.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/protected-areas.async-job.ts
@@ -26,7 +26,7 @@ export class ProtectedAreasAsyncJob extends AsyncJob {
     ];
   }
   getFailedAsyncJobState(): ProtectedAreasApiEvents {
-    return API_EVENT_KINDS.scenario__protectedAreas__finished__v1__alpha;
+    return API_EVENT_KINDS.scenario__protectedAreas__failed__v1__alpha;
   }
   getMaxHoursForAsyncJob(): number {
     return 8;

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/protected-areas.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/protected-areas.async-job.ts
@@ -19,7 +19,7 @@ export class ProtectedAreasAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__protectedAreas__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ProtectedAreasApiEvents[] {
+  getEndAsyncJobStates(): ProtectedAreasApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__protectedAreas__finished__v1__alpha,
       API_EVENT_KINDS.scenario__protectedAreas__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/run.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/run.async-job.ts
@@ -1,0 +1,45 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type RunApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__run__${string}`>
+  >
+>;
+
+@Injectable()
+export class RunAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): RunApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__run__submitted__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__progress__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__outputSaved__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__outputSaveFailed__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__finished__v1__alpha1,
+    ];
+  }
+  getEndAsynJobStates(): RunApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__run__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__outputSaved__v1__alpha1,
+      API_EVENT_KINDS.scenario__run__outputSaveFailed__v1__alpha1,
+    ];
+  }
+  getFailedAsyncJobState(stuckState: API_EVENT_KINDS): RunApiEvents {
+    /*
+     * In case it gets stuck before saving output (it has finished but has not saved),
+     * mark save output as failed
+     */
+    if (stuckState === API_EVENT_KINDS.scenario__run__finished__v1__alpha1)
+      return API_EVENT_KINDS.scenario__run__outputSaveFailed__v1__alpha1;
+
+    return API_EVENT_KINDS.scenario__run__failed__v1__alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/run.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/run.async-job.ts
@@ -22,7 +22,7 @@ export class RunAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__run__finished__v1__alpha1,
     ];
   }
-  getEndAsynJobStates(): RunApiEvents[] {
+  getEndAsyncJobStates(): RunApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__run__failed__v1__alpha1,
       API_EVENT_KINDS.scenario__run__outputSaved__v1__alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-clone.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-clone.async-job.ts
@@ -19,7 +19,7 @@ export class ScenarioCloneAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__clone__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ScenarioCloneApiEvents[] {
+  getEndAsyncJobStates(): ScenarioCloneApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__clone__finished__v1__alpha,
       API_EVENT_KINDS.scenario__clone__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-clone.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-clone.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ScenarioCloneApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__clone__${string}`>
+  >
+>;
+
+@Injectable()
+export class ScenarioCloneAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ScenarioCloneApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__clone__submitted__v1__alpha,
+      API_EVENT_KINDS.scenario__clone__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__clone__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ScenarioCloneApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__clone__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__clone__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ScenarioCloneApiEvents {
+    return API_EVENT_KINDS.scenario__clone__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-export.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-export.async-job.ts
@@ -19,7 +19,7 @@ export class ScenarioExportAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__export__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ScenarioExportApiEvents[] {
+  getEndAsyncJobStates(): ScenarioExportApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__export__finished__v1__alpha,
       API_EVENT_KINDS.scenario__export__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-export.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-export.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ScenarioExportApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__export__${string}`>
+  >
+>;
+
+@Injectable()
+export class ScenarioExportAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ScenarioExportApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__export__submitted__v1__alpha,
+      API_EVENT_KINDS.scenario__export__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__export__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ScenarioExportApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__export__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__export__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ScenarioExportApiEvents {
+    return API_EVENT_KINDS.scenario__export__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-import.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-import.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type ScenarioImportApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__import__${string}`>
+  >
+>;
+
+@Injectable()
+export class ScenarioImportAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): ScenarioImportApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__import__submitted__v1__alpha,
+      API_EVENT_KINDS.scenario__import__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__import__failed__v1__alpha,
+    ];
+  }
+  getEndAsynJobStates(): ScenarioImportApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__import__finished__v1__alpha,
+      API_EVENT_KINDS.scenario__import__failed__v1__alpha,
+    ];
+  }
+  getFailedAsyncJobState(): ScenarioImportApiEvents {
+    return API_EVENT_KINDS.scenario__import__failed__v1__alpha;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-import.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/scenario-import.async-job.ts
@@ -19,7 +19,7 @@ export class ScenarioImportAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__import__failed__v1__alpha,
     ];
   }
-  getEndAsynJobStates(): ScenarioImportApiEvents[] {
+  getEndAsyncJobStates(): ScenarioImportApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__import__finished__v1__alpha,
       API_EVENT_KINDS.scenario__import__failed__v1__alpha,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/specification.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/specification.async-job.ts
@@ -19,7 +19,7 @@ export class SpecificationAsyncJob extends AsyncJob {
       API_EVENT_KINDS.scenario__specification__finished__v1__alpha1,
     ];
   }
-  getEndAsynJobStates(): SpecificationApiEvents[] {
+  getEndAsyncJobStates(): SpecificationApiEvents[] {
     return [
       API_EVENT_KINDS.scenario__specification__failed__v1__alpha1,
       API_EVENT_KINDS.scenario__specification__finished__v1__alpha1,

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/specification.async-job.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/async-jobs/scenario-async-jobs/specification.async-job.ts
@@ -1,0 +1,34 @@
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { Injectable } from '@nestjs/common';
+import { ValuesType } from 'utility-types';
+import { AsyncJob } from '../async-job';
+
+type SpecificationApiEvents = ValuesType<
+  Pick<
+    typeof API_EVENT_KINDS,
+    Extract<keyof typeof API_EVENT_KINDS, `scenario__specification__${string}`>
+  >
+>;
+
+@Injectable()
+export class SpecificationAsyncJob extends AsyncJob {
+  getAllAsyncJobStates(): SpecificationApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__specification__submitted__v1__alpha1,
+      API_EVENT_KINDS.scenario__specification__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__specification__finished__v1__alpha1,
+    ];
+  }
+  getEndAsynJobStates(): SpecificationApiEvents[] {
+    return [
+      API_EVENT_KINDS.scenario__specification__failed__v1__alpha1,
+      API_EVENT_KINDS.scenario__specification__finished__v1__alpha1,
+    ];
+  }
+  getFailedAsyncJobState(): SpecificationApiEvents {
+    return API_EVENT_KINDS.scenario__specification__failed__v1__alpha1;
+  }
+  getMaxHoursForAsyncJob(): number {
+    return 8;
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/garbage-collect-async-jobs.command.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/garbage-collect-async-jobs.command.ts
@@ -1,0 +1,7 @@
+import { Command } from '@nestjs-architects/typed-cqrs';
+
+export class GarbageCollectAsyncJobs extends Command<void> {
+  constructor(public readonly userId: string) {
+    super();
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/garbage-collect-async-jobs.handler.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/garbage-collect-async-jobs.handler.ts
@@ -1,0 +1,51 @@
+import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UsersProjectsApiEntity } from '../access-control/projects-acl/entity/users-projects.api.entity';
+import { UsersScenariosApiEntity } from '../access-control/scenarios-acl/entity/users-scenarios.api.entity';
+import { GarbageCollectAsyncJobs } from './garbage-collect-async-jobs.command';
+import { ProjectAsyncJobsGarbageCollector } from './project-async-jobs.garbage-collector';
+import { ScenarioAsyncJobsGarbageCollector } from './scenario-async-jobs.garbage-collector';
+
+@CommandHandler(GarbageCollectAsyncJobs)
+export class GarbageCollectAsyncJobsHandler
+  implements IInferredCommandHandler<GarbageCollectAsyncJobs> {
+  constructor(
+    @InjectRepository(UsersProjectsApiEntity)
+    private readonly usersProjectsRepo: Repository<UsersProjectsApiEntity>,
+    @InjectRepository(UsersScenariosApiEntity)
+    private readonly usersScenariosRepo: Repository<UsersScenariosApiEntity>,
+    private readonly projectAsyncJobs: ProjectAsyncJobsGarbageCollector,
+    private readonly scenarioAsyncJobs: ScenarioAsyncJobsGarbageCollector,
+  ) {}
+
+  async execute({ userId }: GarbageCollectAsyncJobs) {
+    const projectsIds = await this.getProjectsIdsOf(userId);
+    await Promise.all(
+      projectsIds.map((projectId) =>
+        this.projectAsyncJobs.sendFailedApiEventsForStuckAsyncJobs(projectId),
+      ),
+    );
+
+    const scenariosIds = await this.getScenariosIdsOf(userId);
+    await Promise.all(
+      scenariosIds.map((scenarioId) =>
+        this.scenarioAsyncJobs.sendFailedApiEventsForStuckAsyncJobs(scenarioId),
+      ),
+    );
+  }
+
+  private async getProjectsIdsOf(userId: string) {
+    const userProjects = await this.usersProjectsRepo.find({
+      where: { userId },
+    });
+    return userProjects.map(({ projectId }) => projectId);
+  }
+
+  private async getScenariosIdsOf(userId: string) {
+    const userScenarios = await this.usersScenariosRepo.find({
+      where: { userId },
+    });
+    return userScenarios.map(({ scenarioId }) => scenarioId);
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/garbage-collect-async-jobs.handler.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/garbage-collect-async-jobs.handler.ts
@@ -27,18 +27,18 @@ export class GarbageCollectAsyncJobsHandler
 
   async execute({ userId }: GarbageCollectAsyncJobs) {
     const projectsIds = await this.getProjectsIdsOf(userId);
-    await Promise.all(
-      projectsIds.map((projectId) =>
-        this.projectAsyncJobs.sendFailedApiEventsForStuckAsyncJobs(projectId),
-      ),
-    );
+    for (const projectId of projectsIds) {
+      await this.projectAsyncJobs.sendFailedApiEventsForStuckAsyncJobs(
+        projectId,
+      );
+    }
 
     const scenariosIds = await this.getScenariosIdsOf(userId);
-    await Promise.all(
-      scenariosIds.map((scenarioId) =>
-        this.scenarioAsyncJobs.sendFailedApiEventsForStuckAsyncJobs(scenarioId),
-      ),
-    );
+    for (const scenarioId of scenariosIds) {
+      await this.scenarioAsyncJobs.sendFailedApiEventsForStuckAsyncJobs(
+        scenarioId,
+      );
+    }
 
     this.eventBus.publish(new AsyncJobsGarbageCollectorFinished(userId));
   }

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/index.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/index.ts
@@ -1,0 +1,1 @@
+export { AsyncJobsGarbageCollectorModule } from './async-jobs.garbage-collector.module';

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/index.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/index.ts
@@ -1,1 +1,5 @@
 export { AsyncJobsGarbageCollectorModule } from './async-jobs.garbage-collector.module';
+export { AsyncJobsGarbageCollectorFinished } from './async-jobs-garbage-collector-finished.event';
+export { UserLoggedInSaga } from './user-logged-in.saga';
+export { GarbageCollectAsyncJobsHandler } from './garbage-collect-async-jobs.handler';
+export { GarbageCollectAsyncJobs } from './garbage-collect-async-jobs.command';

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/project-async-jobs.garbage-collector.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/project-async-jobs.garbage-collector.ts
@@ -21,13 +21,13 @@ export class ProjectAsyncJobsGarbageCollector
     private readonly projectImportAsyncJob: ProjectImportAsyncJob,
   ) {}
   public async sendFailedApiEventsForStuckAsyncJobs(projectId: string) {
-    await Promise.all([
-      this.gridAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
-      this.legacyImportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
-      this.planningUnitsAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
-      this.projectCloneAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
-      this.projectExportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
-      this.projectImportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
-    ]);
+    await this.gridAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId);
+    await this.legacyImportAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      projectId,
+    );
+    this.planningUnitsAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId);
+    this.projectCloneAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId);
+    this.projectExportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId);
+    this.projectImportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId);
   }
 }

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/project-async-jobs.garbage-collector.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/project-async-jobs.garbage-collector.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import {
+  GridAsyncJob,
+  LegacyImportAsyncJob,
+  PlanningUnitsAsyncJob,
+  ProjectCloneAsyncJob,
+  ProjectExportAsyncJob,
+  ProjectImportAsyncJob,
+} from './async-jobs';
+import { AsyncJobsGarbageCollector } from './async-jobs.garbage-collector';
+
+@Injectable()
+export class ProjectAsyncJobsGarbageCollector
+  implements AsyncJobsGarbageCollector {
+  constructor(
+    private readonly gridAsyncJob: GridAsyncJob,
+    private readonly legacyImportAsyncJob: LegacyImportAsyncJob,
+    private readonly planningUnitsAsyncJob: PlanningUnitsAsyncJob,
+    private readonly projectCloneAsyncJob: ProjectCloneAsyncJob,
+    private readonly projectExportAsyncJob: ProjectExportAsyncJob,
+    private readonly projectImportAsyncJob: ProjectImportAsyncJob,
+  ) {}
+  public async sendFailedApiEventsForStuckAsyncJobs(projectId: string) {
+    await Promise.all([
+      this.gridAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
+      this.legacyImportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
+      this.planningUnitsAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
+      this.projectCloneAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
+      this.projectExportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
+      this.projectImportAsyncJob.sendFailedApiEventForStuckAsyncJob(projectId),
+    ]);
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/scenario-async-jobs.garbage-collector.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/scenario-async-jobs.garbage-collector.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import {
+  CalibrationAsyncJob,
+  CostSurfaceAsyncJob,
+  FeaturesWithPuIntersectionAsyncJob,
+  PlanningAreaProtectedCalculationAsyncJob,
+  PlanningUnitsInclusionAsyncJob,
+  ProtectedAreasAsyncJob,
+  RunAsyncJob,
+  ScenarioCloneAsyncJob,
+  ScenarioExportAsyncJob,
+  ScenarioImportAsyncJob,
+  SpecificationAsyncJob,
+} from './async-jobs';
+import { AsyncJobsGarbageCollector } from './async-jobs.garbage-collector';
+
+@Injectable()
+export class ScenarioAsyncJobsGarbageCollector
+  implements AsyncJobsGarbageCollector {
+  constructor(
+    private readonly calibrationAsyncJob: CalibrationAsyncJob,
+    private readonly costSurfaceAsyncJob: CostSurfaceAsyncJob,
+    private readonly featuresWithPuIntersectionAsyncJob: FeaturesWithPuIntersectionAsyncJob,
+    private readonly planningAreaProtectedCalculationAsyncJob: PlanningAreaProtectedCalculationAsyncJob,
+    private readonly planningUnitsInclusionAsyncJob: PlanningUnitsInclusionAsyncJob,
+    private readonly protectedAreasAsyncJob: ProtectedAreasAsyncJob,
+    private readonly runAsyncJob: RunAsyncJob,
+    private readonly scenarioCloneAsyncJob: ScenarioCloneAsyncJob,
+    private readonly scenarioExportAsyncJob: ScenarioExportAsyncJob,
+    private readonly scenarioImportAsyncJob: ScenarioImportAsyncJob,
+    private readonly specificationAsyncJob: SpecificationAsyncJob,
+  ) {}
+  public async sendFailedApiEventsForStuckAsyncJobs(scenarioId: string) {
+    await Promise.all([
+      this.calibrationAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
+      this.costSurfaceAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
+      this.featuresWithPuIntersectionAsyncJob.sendFailedApiEventForStuckAsyncJob(
+        scenarioId,
+      ),
+      this.planningAreaProtectedCalculationAsyncJob.sendFailedApiEventForStuckAsyncJob(
+        scenarioId,
+      ),
+      this.planningUnitsInclusionAsyncJob.sendFailedApiEventForStuckAsyncJob(
+        scenarioId,
+      ),
+      this.protectedAreasAsyncJob.sendFailedApiEventForStuckAsyncJob(
+        scenarioId,
+      ),
+      this.runAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
+      this.scenarioCloneAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
+      this.scenarioExportAsyncJob.sendFailedApiEventForStuckAsyncJob(
+        scenarioId,
+      ),
+      this.scenarioImportAsyncJob.sendFailedApiEventForStuckAsyncJob(
+        scenarioId,
+      ),
+      this.specificationAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
+    ]);
+  }
+}

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/scenario-async-jobs.garbage-collector.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/scenario-async-jobs.garbage-collector.ts
@@ -31,30 +31,36 @@ export class ScenarioAsyncJobsGarbageCollector
     private readonly specificationAsyncJob: SpecificationAsyncJob,
   ) {}
   public async sendFailedApiEventsForStuckAsyncJobs(scenarioId: string) {
-    await Promise.all([
-      this.calibrationAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
-      this.costSurfaceAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
-      this.featuresWithPuIntersectionAsyncJob.sendFailedApiEventForStuckAsyncJob(
-        scenarioId,
-      ),
-      this.planningAreaProtectedCalculationAsyncJob.sendFailedApiEventForStuckAsyncJob(
-        scenarioId,
-      ),
-      this.planningUnitsInclusionAsyncJob.sendFailedApiEventForStuckAsyncJob(
-        scenarioId,
-      ),
-      this.protectedAreasAsyncJob.sendFailedApiEventForStuckAsyncJob(
-        scenarioId,
-      ),
-      this.runAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
-      this.scenarioCloneAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
-      this.scenarioExportAsyncJob.sendFailedApiEventForStuckAsyncJob(
-        scenarioId,
-      ),
-      this.scenarioImportAsyncJob.sendFailedApiEventForStuckAsyncJob(
-        scenarioId,
-      ),
-      this.specificationAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId),
-    ]);
+    await this.calibrationAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.costSurfaceAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.featuresWithPuIntersectionAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.planningAreaProtectedCalculationAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.planningUnitsInclusionAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.protectedAreasAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.runAsyncJob.sendFailedApiEventForStuckAsyncJob(scenarioId);
+    await this.scenarioCloneAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.scenarioExportAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.scenarioImportAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
+    await this.specificationAsyncJob.sendFailedApiEventForStuckAsyncJob(
+      scenarioId,
+    );
   }
 }

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/user-logged-in.saga.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/user-logged-in.saga.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ICommand, ofType, Saga } from '@nestjs/cqrs';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { UserLoggedIn } from '../authentication/user-logged-in.event';
 import { GarbageCollectAsyncJobs } from './garbage-collect-async-jobs.command';

--- a/api/apps/api/src/modules/async-jobs-garbage-collector/user-logged-in.saga.ts
+++ b/api/apps/api/src/modules/async-jobs-garbage-collector/user-logged-in.saga.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, ofType, Saga } from '@nestjs/cqrs';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { UserLoggedIn } from '../authentication/user-logged-in.event';
+import { GarbageCollectAsyncJobs } from './garbage-collect-async-jobs.command';
+
+@Injectable()
+export class UserLoggedInSaga {
+  @Saga()
+  userLoggedInSaga = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(UserLoggedIn),
+      map((event) => new GarbageCollectAsyncJobs(event.userId)),
+    );
+}

--- a/api/apps/api/src/modules/authentication/authentication.module.ts
+++ b/api/apps/api/src/modules/authentication/authentication.module.ts
@@ -34,6 +34,7 @@ import {
 import { PasswordRecoveryService } from './password-recovery/password-recovery.service';
 import { PasswordRecoveryToken } from './password-recovery/password-recovery-token.api.entity';
 import { PasswordRecoveryController } from './password-recovery/password-recovery.controller';
+import { CqrsModule } from '@nestjs/cqrs';
 
 export const logger = new Logger('Authentication');
 
@@ -48,6 +49,7 @@ export const logger = new Logger('Authentication');
       signOptions: { expiresIn: AppConfig.get('auth.jwt.expiresIn', '2h') },
     }),
     TypeOrmModule.forFeature([User, IssuedAuthnToken, PasswordRecoveryToken]),
+    CqrsModule,
   ],
   providers: [
     AuthenticationService,

--- a/api/apps/api/src/modules/authentication/authentication.service.ts
+++ b/api/apps/api/src/modules/authentication/authentication.service.ts
@@ -23,6 +23,8 @@ import { v4 } from 'uuid';
 import * as ApiEventsUserData from '@marxan-api/modules/api-events/dto/apiEvents.user.data.dto';
 import { Mailer } from '@marxan-api/modules/authentication/password-recovery/mailer';
 import { API_EVENT_KINDS } from '@marxan/api-events';
+import { EventBus } from '@nestjs/cqrs';
+import { UserLoggedIn } from './user-logged-in.event';
 
 /**
  * Access token for the app: key user data and access token
@@ -79,6 +81,7 @@ export class AuthenticationService {
     private readonly issuedAuthnTokensRepository: Repository<IssuedAuthnToken>,
     @InjectRepository(User) private readonly usersRepository: Repository<User>,
     private readonly mailer: Mailer,
+    private readonly eventBus: EventBus,
   ) {}
 
   /**
@@ -273,6 +276,8 @@ export class AuthenticationService {
     };
 
     await this.purgeExpiredIssuedTokens();
+
+    this.eventBus.publish(new UserLoggedIn(user.id));
 
     return {
       user: UsersService.getSanitizedUserMetadata(user),

--- a/api/apps/api/src/modules/authentication/user-logged-in.event.ts
+++ b/api/apps/api/src/modules/authentication/user-logged-in.event.ts
@@ -1,0 +1,5 @@
+import { IEvent } from '@nestjs/cqrs';
+
+export class UserLoggedIn implements IEvent {
+  constructor(public readonly userId: string) {}
+}

--- a/api/apps/api/test/async-jobs-garbage-collector/garbage-collect-async-jobs.e2e-spec.ts
+++ b/api/apps/api/test/async-jobs-garbage-collector/garbage-collect-async-jobs.e2e-spec.ts
@@ -1,0 +1,230 @@
+import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
+import { UsersScenariosApiEntity } from '@marxan-api/modules/access-control/scenarios-acl/entity/users-scenarios.api.entity';
+import { ApiEvent } from '@marxan-api/modules/api-events/api-event.api.entity';
+import {
+  AsyncJobsGarbageCollectorFinished,
+  GarbageCollectAsyncJobs,
+  GarbageCollectAsyncJobsHandler,
+} from '@marxan-api/modules/async-jobs-garbage-collector';
+import { API_EVENT_KINDS } from '@marxan/api-events';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { CqrsModule, EventBus, IEvent } from '@nestjs/cqrs';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { GivenProjectExists } from '../steps/given-project';
+import { GivenScenarioExists } from '../steps/given-scenario-exists';
+import { GivenUserExists } from '../steps/given-user-exists';
+import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
+import { bootstrapApplication } from '../utils/api-application';
+import { EventBusTestUtils } from '../utils/event-bus.test.utils';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+}, 20000);
+
+afterEach(async () => {
+  await fixtures?.cleanup();
+});
+
+it('does not send failed api events for not started async jobs', async () => {
+  const projectId = await fixtures.GivenProjectExists();
+  const scenarioId = await fixtures.GivenScenarioExists(projectId);
+  await fixtures.GivenNoAsyncJobsFor(projectId, scenarioId);
+  await fixtures.WhenExecutionAsyncJobsGarbageCollector();
+  await fixtures.ThenAsyncJobsGarbageCollectorFinished();
+  await fixtures.ThenNoFailedApiEventsHasBeenSendForAsyncJobs(projectId);
+});
+
+it('does not send failed api events for not stucked async jobs', async () => {
+  const projectId = await fixtures.GivenProjectExists();
+  const scenarioId = await fixtures.GivenScenarioExists(projectId);
+  await fixtures.GivenAsyncJobsFor(projectId, scenarioId, { isStuck: false });
+  await fixtures.WhenExecutionAsyncJobsGarbageCollector();
+  await fixtures.ThenAsyncJobsGarbageCollectorFinished();
+  await fixtures.ThenNoFailedApiEventsHasBeenSendForAsyncJobs(projectId);
+});
+
+it('sends failed api events for stuck async jobs', async () => {
+  const projectId = await fixtures.GivenProjectExists();
+  const scenarioId = await fixtures.GivenScenarioExists(projectId);
+  await fixtures.GivenAsyncJobsFor(projectId, scenarioId, { isStuck: true });
+  await fixtures.WhenExecutionAsyncJobsGarbageCollector();
+  await fixtures.ThenAsyncJobsGarbageCollectorFinished();
+  await fixtures.ThenFailedApiEventsHasBeenSendForAsyncJobs(projectId);
+});
+
+const getFixtures = async () => {
+  const app = await bootstrapApplication([CqrsModule], [EventBusTestUtils]);
+  const eventBusTestUtils = app.get(EventBusTestUtils);
+  eventBusTestUtils.startInspectingEvents();
+
+  const usersProjectsRepo: Repository<UsersProjectsApiEntity> = app.get(
+    getRepositoryToken(UsersProjectsApiEntity),
+  );
+  const usersScenariosRepo: Repository<UsersScenariosApiEntity> = app.get(
+    getRepositoryToken(UsersScenariosApiEntity),
+  );
+  const apiEventsRepo: Repository<ApiEvent> = app.get(
+    getRepositoryToken(ApiEvent),
+  );
+  const sut = app.get(GarbageCollectAsyncJobsHandler);
+
+  const token = await GivenUserIsLoggedIn(app);
+  const userId = await GivenUserExists(app);
+
+  let projectCleanUp: () => Promise<void>;
+  let projectId: string;
+  let scenarioId: string;
+
+  const getApiEvents = async (resourceId: string) => {
+    return apiEventsRepo.find({ topic: resourceId });
+  };
+
+  const deleteApiEvents = async (resourceId: string) => {
+    await apiEventsRepo.delete({ topic: resourceId });
+    const projectApiEvents = await getApiEvents(resourceId);
+    expect(projectApiEvents).toHaveLength(0);
+  };
+
+  const projectSubmittedApiEvents = [
+    API_EVENT_KINDS.project__grid__submitted__v1__alpha,
+    API_EVENT_KINDS.project__legacy__import__submitted__v1__alpha,
+    API_EVENT_KINDS.project__planningUnits__submitted__v1__alpha,
+    API_EVENT_KINDS.project__clone__submitted__v1__alpha,
+    API_EVENT_KINDS.project__export__submitted__v1__alpha,
+    API_EVENT_KINDS.project__import__submitted__v1__alpha,
+  ];
+
+  const scenarioSubmittedApiEvents = [
+    API_EVENT_KINDS.scenario__calibration__submitted_v1_alpha1,
+    API_EVENT_KINDS.scenario__costSurface__submitted__v1_alpha1,
+    API_EVENT_KINDS.scenario__featuresWithPuIntersection__submitted__v1__alpha1,
+    API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__submitted__v1__alpha1,
+    API_EVENT_KINDS.scenario__planningUnitsInclusion__submitted__v1__alpha1,
+    API_EVENT_KINDS.scenario__protectedAreas__submitted__v1__alpha,
+    API_EVENT_KINDS.scenario__run__submitted__v1__alpha1,
+    API_EVENT_KINDS.scenario__clone__submitted__v1__alpha,
+    API_EVENT_KINDS.scenario__export__submitted__v1__alpha,
+    API_EVENT_KINDS.scenario__import__submitted__v1__alpha,
+    API_EVENT_KINDS.scenario__specification__submitted__v1__alpha1,
+  ];
+  const projectFailedApiEvents = [
+    API_EVENT_KINDS.project__grid__failed__v1__alpha,
+    API_EVENT_KINDS.project__legacy__import__failed__v1__alpha,
+    API_EVENT_KINDS.project__planningUnits__failed__v1__alpha,
+    API_EVENT_KINDS.project__clone__failed__v1__alpha,
+    API_EVENT_KINDS.project__export__failed__v1__alpha,
+    API_EVENT_KINDS.project__import__failed__v1__alpha,
+  ];
+
+  const scenarioFailedApiEvents = [
+    API_EVENT_KINDS.scenario__calibration__failed_v1_alpha1,
+    API_EVENT_KINDS.scenario__costSurface__costUpdateFailed__v1_alpha1,
+    API_EVENT_KINDS.scenario__featuresWithPuIntersection__failed__v1__alpha1,
+    API_EVENT_KINDS.scenario__planningAreaProtectedCalculation__failed__v1__alpha1,
+    API_EVENT_KINDS.scenario__planningUnitsInclusion__failed__v1__alpha1,
+    API_EVENT_KINDS.scenario__protectedAreas__failed__v1__alpha,
+    API_EVENT_KINDS.scenario__run__failed__v1__alpha1,
+    API_EVENT_KINDS.scenario__clone__failed__v1__alpha,
+    API_EVENT_KINDS.scenario__export__failed__v1__alpha,
+    API_EVENT_KINDS.scenario__import__failed__v1__alpha,
+    API_EVENT_KINDS.scenario__specification__failed__v1__alpha1,
+  ];
+
+  const getProjectFailedApiEvents = async (projectId: string) => {
+    return apiEventsRepo.find({
+      where: { topic: projectId, kind: In(projectFailedApiEvents) },
+    });
+  };
+
+  const getScenarioFailedApiEvents = async (scenarioId: string) => {
+    return apiEventsRepo.find({
+      where: { topic: scenarioId, kind: In(scenarioFailedApiEvents) },
+    });
+  };
+  return {
+    cleanup: async () => {
+      await projectCleanUp();
+      await usersProjectsRepo.delete({ projectId });
+      await usersScenariosRepo.delete({ scenarioId });
+      await apiEventsRepo.delete({ topic: projectId });
+      await apiEventsRepo.delete({ topic: scenarioId });
+      eventBusTestUtils.stopInspectingEvents();
+      await app.close();
+    },
+    GivenProjectExists: async () => {
+      const project = await GivenProjectExists(app, token);
+      projectId = project.projectId;
+      projectCleanUp = project.cleanup;
+      return projectId;
+    },
+    GivenScenarioExists: async (projectId: string) => {
+      const scenario = await GivenScenarioExists(app, projectId, token);
+      scenarioId = scenario.id;
+      return scenarioId;
+    },
+    GivenNoAsyncJobsFor: async (projectId: string, scenarioId: string) => {
+      await deleteApiEvents(projectId);
+      await deleteApiEvents(scenarioId);
+    },
+    GivenAsyncJobsFor: async (
+      projectId: string,
+      scenarioId: string,
+      opts: { isStuck: boolean },
+    ) => {
+      await deleteApiEvents(projectId);
+      await deleteApiEvents(scenarioId);
+      const apiEventDate = opts.isStuck ? new Date(2021, 1, 1) : new Date();
+      const projectApiEventAndKind = projectSubmittedApiEvents.map((kind) => ({
+        kind,
+        topic: projectId,
+        timestamp: apiEventDate,
+      }));
+      const scenarioApiEventAndKind = scenarioSubmittedApiEvents.map(
+        (kind) => ({
+          kind,
+          topic: scenarioId,
+          timestamp: apiEventDate,
+        }),
+      );
+      return apiEventsRepo.save([
+        ...projectApiEventAndKind,
+        ...scenarioApiEventAndKind,
+      ]);
+    },
+    WhenExecutionAsyncJobsGarbageCollector: () => {
+      return sut.execute(new GarbageCollectAsyncJobs(userId));
+    },
+    ThenAsyncJobsGarbageCollectorFinished: async () => {
+      await eventBusTestUtils.waitUntilEventIsPublished(
+        AsyncJobsGarbageCollectorFinished,
+      );
+    },
+    ThenFailedApiEventsHasBeenSendForAsyncJobs: async (projectId: string) => {
+      const projectFailedApiEventsFound = await getProjectFailedApiEvents(
+        projectId,
+      );
+      expect(projectFailedApiEventsFound).toHaveLength(
+        projectFailedApiEvents.length,
+      );
+      const scenarioFailedApiEventsFound = await getScenarioFailedApiEvents(
+        scenarioId,
+      );
+      expect(scenarioFailedApiEventsFound).toHaveLength(
+        scenarioFailedApiEvents.length,
+      );
+    },
+    ThenNoFailedApiEventsHasBeenSendForAsyncJobs: async (projectId: string) => {
+      const projectFailedApiEventsFound = await getProjectFailedApiEvents(
+        projectId,
+      );
+      expect(projectFailedApiEventsFound).toHaveLength(0);
+      const scenarioFailedApiEventsFound = await getScenarioFailedApiEvents(
+        scenarioId,
+      );
+      expect(scenarioFailedApiEventsFound).toHaveLength(0);
+    },
+  };
+};

--- a/api/apps/api/test/utils/api-application.ts
+++ b/api/apps/api/test/utils/api-application.ts
@@ -1,4 +1,5 @@
 import { AppModule } from '@marxan-api/app.module';
+import { UserLoggedInSaga } from '@marxan-api/modules/async-jobs-garbage-collector';
 import { ProjectChecker } from '@marxan-api/modules/projects/project-checker/project-checker.service';
 import { QueueBuilder } from '@marxan-api/modules/queue/queue.builder';
 import {
@@ -38,7 +39,7 @@ const defaultOverrides: Overrides = {
       implementation: FakeScenarioCalibrationRepo,
     },
   ],
-  values: [],
+  values: [{ provider: UserLoggedInSaga, implementation: {} }],
   factories: [],
 };
 

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-custom-features.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-custom-features.piece-exporter.e2e-spec.ts
@@ -171,10 +171,19 @@ const getFixtures = async () => {
             savedStrem,
           );
           expect(content.features).toHaveLength(amountOfCustomFeatures);
-          const { feature_class_name, data, is_legacy } = content.features[0];
-          expect(feature_class_name).toEqual(`custom-${projectId}-1`);
-          expect(is_legacy).toEqual(opts.isLegacy);
-          expect(data).toHaveLength(recordsOfDataForEachCustomFeature);
+          const featuresExported = content.features;
+          const expectedFeatureNames = Array(amountOfCustomFeatures)
+            .fill(0)
+            .map((_, index) => `custom-${projectId}-${index}`);
+
+          expect(
+            featuresExported.every(
+              ({ is_legacy, data, feature_class_name }) =>
+                is_legacy === opts.isLegacy &&
+                data.length === recordsOfDataForEachCustomFeature &&
+                expectedFeatureNames.includes(feature_class_name),
+            ),
+          );
         },
       };
     },


### PR DESCRIPTION
This PR adds async jobs garbage collector. So in case an async job gets stuck , a failed api events for the given async job will be send. We will check wether an async jobs is stuck or not when users logs in for every project and scenario where the user has any role.

For every kind of async job, a default 8 hours interval is set to define if the async job is stuck or not, this behavior can be easily updated for each individual async job kind changing the implementation of `getMaxHoursForAsyncJob` for the corresponding async job.

### Feature relevant tickets

[If an async job gets "stuck", it should be marked as failed automatically](https://vizzuality.atlassian.net/browse/MARXAN-1554)
