### PR TITLE
create features for split [MARXAN-1681]

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/scenario-features.module.ts
+++ b/api/apps/api/src/modules/scenarios-features/scenario-features.module.ts
@@ -31,6 +31,7 @@ import { LegacyProjectImportRepositoryModule } from '../legacy-project-import/in
 import { PuvsprCalculationsModule } from '@marxan/puvspr-calculations';
 import { SplitFeatureConfigMapper } from '../scenarios/specification/split-feature-config.mapper';
 import { FeatureHashModule } from '../features-hash/features-hash.module';
+import { SplitCreateFeatures } from './split/split-create-features.service';
 
 @Module({
   imports: [
@@ -62,6 +63,7 @@ import { FeatureHashModule } from '../features-hash/features-hash.module';
     CopyDataProvider,
     CopyOperation,
     ComputeArea,
+    SplitCreateFeatures,
     SplitQuery,
     SplitDataProvider,
     SplitOperation,

--- a/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
@@ -182,7 +182,11 @@ export class SplitCreateFeatures {
       },
     );
 
-    await this.featuresRepo.save(features);
+    await Promise.all(
+      features.map((feature) => {
+        return this.featuresRepo.save(feature);
+      }),
+    );
 
     return res;
   }

--- a/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
@@ -1,0 +1,189 @@
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import { JobStatus } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { SplitFeatureConfigMapper } from '@marxan-api/modules/scenarios/specification/split-feature-config.mapper';
+import { FeatureConfigSplit } from '@marxan-api/modules/specification';
+import { FeatureTag } from '@marxan/features';
+import { isDefined } from '@marxan/utils';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { v4 } from 'uuid';
+import { SingleConfigFeatureValueHasher } from '@marxan-api/modules/features-hash/single-config-feature-value.hasher';
+import {
+  SingleSplitConfigFeatureValue,
+  SingleSplitConfigFeatureValueStripped,
+} from '@marxan/features-hash';
+import { isLeft, left, right } from 'fp-ts/lib/Either';
+
+type HashCanonicalAndSingleSplitConfigFeature = {
+  hash: string;
+  canonical: SingleSplitConfigFeatureValueStripped;
+  singleSplitFeature: SingleSplitConfigFeatureValue;
+};
+
+export type SingleSplitConfigFeatureValueWithId = {
+  id: string;
+  singleSplitFeature: SingleSplitConfigFeatureValue;
+};
+
+export const baseFeatureIsDerived = Symbol('base feature is derived');
+
+@Injectable()
+export class SplitCreateFeatures {
+  constructor(
+    @InjectRepository(GeoFeature)
+    private readonly featuresRepo: Repository<GeoFeature>,
+    private readonly splitFeatureConfigMapper: SplitFeatureConfigMapper,
+    private readonly splitConfigHasher: SingleConfigFeatureValueHasher,
+  ) {}
+  public async createSplitFeatures(
+    input: FeatureConfigSplit,
+    projectId: string,
+  ) {
+    const baseFeatureOrError = await this.isBaseFeatureADerivedFeature(input);
+
+    if (isLeft(baseFeatureOrError))
+      throw new Error('trying to split an already derived feature');
+
+    const baseFeature = baseFeatureOrError.right;
+
+    const singleSplitFeatures = this.splitFeatureConfigMapper.toSingleSplitFeatureConfig(
+      input,
+    );
+
+    const singleSplitFeaturesWithHashes = await this.getSplitConfigFeaturesWithHashes(
+      singleSplitFeatures,
+    );
+
+    const {
+      createdFeatures,
+      notCreatedFeatues,
+    } = await this.getCreatedAndNotCreatedFeatures(
+      singleSplitFeaturesWithHashes,
+    );
+
+    const newFeaturesCreated = await this.createFeatures(
+      notCreatedFeatues,
+      baseFeature,
+      projectId,
+    );
+
+    return createdFeatures.concat(newFeaturesCreated);
+  }
+
+  private async isBaseFeatureADerivedFeature(input: FeatureConfigSplit) {
+    const baseFeature = await this.getBaseFeature(input.baseFeatureId);
+
+    return isDefined(baseFeature.geoprocessingOpsHash)
+      ? left(baseFeatureIsDerived)
+      : right(baseFeature);
+  }
+
+  private async getBaseFeature(baseFeatureId: string) {
+    const [feature] = await this.featuresRepo.find({ id: baseFeatureId });
+
+    if (!feature) throw new Error('did not find base feature');
+
+    return feature;
+  }
+
+  private async getSplitConfigFeaturesWithHashes(
+    singleSplitFeatures: SingleSplitConfigFeatureValue[],
+  ): Promise<HashCanonicalAndSingleSplitConfigFeature[]> {
+    return Promise.all(
+      singleSplitFeatures.map((singleSplitFeature) =>
+        this.getHashAndStripped(singleSplitFeature),
+      ),
+    );
+  }
+
+  private async getHashAndStripped(
+    singleSplitFeature: SingleSplitConfigFeatureValue,
+  ) {
+    const hashAndStrippedFeature = await this.splitConfigHasher.getHashAndStrippedConfigFeature(
+      singleSplitFeature,
+    );
+
+    return { singleSplitFeature, ...hashAndStrippedFeature };
+  }
+
+  private async getCreatedAndNotCreatedFeatures(
+    singleSplitFeaturesWithHashes: HashCanonicalAndSingleSplitConfigFeature[],
+  ) {
+    if (!singleSplitFeaturesWithHashes.length)
+      return { notCreatedFeatues: [], createdFeatures: [] };
+
+    const hashes = singleSplitFeaturesWithHashes.map(({ hash }) => hash);
+
+    const featuresWithHashesFound = await this.featuresRepo.find({
+      where: { geoprocessingOpsHash: In(hashes) },
+    });
+
+    if (!featuresWithHashesFound.length)
+      return {
+        notCreatedFeatues: singleSplitFeaturesWithHashes,
+        createdFeatures: [],
+      };
+
+    const featureIdByHash: Record<string, string> = this.getFeatureIdByHash(
+      featuresWithHashesFound,
+    );
+
+    const notCreatedFeatues = singleSplitFeaturesWithHashes.filter(
+      ({ hash }) => !featureIdByHash[hash],
+    );
+
+    const createdFeatures = singleSplitFeaturesWithHashes
+      .filter(({ hash }) => isDefined(featureIdByHash[hash]))
+      .map(({ singleSplitFeature, hash }) => {
+        return { id: featureIdByHash[hash], singleSplitFeature };
+      });
+
+    return { notCreatedFeatues, createdFeatures };
+  }
+
+  private getFeatureIdByHash(featuresWithHashesFound: GeoFeature[]) {
+    const featureIdByHash: Record<string, string> = {};
+
+    featuresWithHashesFound.reduce((prev, { geoprocessingOpsHash, id }) => {
+      if (!geoprocessingOpsHash) return prev;
+
+      prev[geoprocessingOpsHash] = id;
+      return prev;
+    }, featureIdByHash);
+
+    return featureIdByHash;
+  }
+
+  private async createFeatures(
+    nonExistingFeatures: HashCanonicalAndSingleSplitConfigFeature[],
+    baseFeature: GeoFeature,
+    projectId: string,
+  ) {
+    const res: SingleSplitConfigFeatureValueWithId[] = [];
+    const features = nonExistingFeatures.map(
+      ({ canonical, singleSplitFeature }) => {
+        const valueChain = canonical.value ? `: ${canonical.value}` : '';
+        const featureName =
+          `${baseFeature.featureClassName} / ${canonical.splitByProperty}` +
+          valueChain;
+
+        const featureId = v4();
+        res.push({ id: featureId, singleSplitFeature });
+
+        return {
+          id: featureId,
+          projectId,
+          featureClassName: featureName,
+          tag: FeatureTag.Species,
+          creationStatus: JobStatus.created,
+          fromGeoprocessingOps: canonical,
+        };
+      },
+    );
+
+    await this.featuresRepo.save(features);
+
+    return res;
+  }
+}

--- a/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
@@ -60,6 +60,7 @@ export class SplitCreateFeatures {
       notCreatedFeatues,
     } = await this.getCreatedAndNotCreatedFeatures(
       singleSplitFeaturesWithHashes,
+      projectId,
     );
 
     const newFeaturesCreated = await this.createFeatures(
@@ -109,24 +110,25 @@ export class SplitCreateFeatures {
 
   private async getCreatedAndNotCreatedFeatures(
     singleSplitFeaturesWithHashes: HashCanonicalAndSingleSplitConfigFeature[],
+    projectId: string,
   ) {
     if (!singleSplitFeaturesWithHashes.length)
       return { notCreatedFeatues: [], createdFeatures: [] };
 
     const hashes = singleSplitFeaturesWithHashes.map(({ hash }) => hash);
 
-    const featuresWithHashesFound = await this.featuresRepo.find({
-      where: { geoprocessingOpsHash: In(hashes) },
+    const featuresWithHashesFoundInProject = await this.featuresRepo.find({
+      where: { geoprocessingOpsHash: In(hashes), projectId },
     });
 
-    if (!featuresWithHashesFound.length)
+    if (!featuresWithHashesFoundInProject.length)
       return {
         notCreatedFeatues: singleSplitFeaturesWithHashes,
         createdFeatures: [],
       };
 
     const featureIdByHash: Record<string, string> = this.getFeatureIdByHash(
-      featuresWithHashesFound,
+      featuresWithHashesFoundInProject,
     );
 
     const notCreatedFeatues = singleSplitFeaturesWithHashes.filter(

--- a/api/apps/api/src/modules/scenarios-features/split/split-operation.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-operation.service.ts
@@ -84,7 +84,7 @@ export class SplitOperation {
   ) {
     return Promise.all(
       featuresIds.map((featureId) =>
-        this.computeArea.computeAreaPerPanningUnitOfFeature(
+        this.computeArea.computeAreaPerPlanningUnitOfFeature(
           projectId,
           scenarioId,
           featureId,

--- a/api/apps/api/src/modules/scenarios/specification/split-feature-config.mapper.ts
+++ b/api/apps/api/src/modules/scenarios/specification/split-feature-config.mapper.ts
@@ -8,7 +8,7 @@ export class SplitFeatureConfigMapper {
     input: FeatureConfigSplit,
   ): SingleSplitConfigFeatureValue[] {
     const subsets = input.selectSubSets;
-    return subsets
+    return subsets && subsets.length
       ? subsets.map((subset) => ({
           baseFeatureId: input.baseFeatureId,
           operation: input.operation,

--- a/api/apps/api/test/integration/split-create-features.service.e2e-spec.ts
+++ b/api/apps/api/test/integration/split-create-features.service.e2e-spec.ts
@@ -9,7 +9,6 @@ import { FeatureSubSet, SpecificationOperation } from '@marxan/specification';
 import { GivenProjectExists } from '../steps/given-project';
 import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
 import { IsNull, Not, Repository } from 'typeorm';
-import { FeatureTag } from '@marxan/features';
 import { JobStatus } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import { SingleSplitConfigFeatureValue } from '@marxan/features-hash';
 
@@ -23,20 +22,20 @@ afterEach(async () => {
   await fixtures.cleanup();
 });
 
-it('fails to create split features when basefeature does not exists', async () => {
+it('fails to create split features when basefeature does not exist', async () => {
   const splitByProperty = 'random property';
   const projectId = await fixtures.GivenProjectExist();
-  const featureId = await fixtures.GivenBaseFeatureDoesNotExists();
+  const featureId = await fixtures.GivenBaseFeatureDoesNotExist();
   const splitFeatureConfig = fixtures.GivenSplitFeatureConfig(
     featureId,
     splitByProperty,
   );
   await fixtures
     .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
-    .ThenBaseFeatureDoesNotExistsErrorIsThrow();
+    .ThenBaseFeatureDoesNotExistErrorIsThrow();
 });
 
-it('fails to create split features when basefeature is a derived feture', async () => {
+it('fails to create split features when basefeature is a derived feature', async () => {
   const splitByProperty = 'random property';
   const projectId = await fixtures.GivenProjectExist();
   const feature = await fixtures.GivenBaseFeatureIsADerivedFeature();
@@ -46,7 +45,7 @@ it('fails to create split features when basefeature is a derived feture', async 
   );
   await fixtures
     .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
-    .ThenBaseFeatureIsADerivedFeatureErrorIsThrow();
+    .ThenBaseFeatureIsADerivedFeatureErrorIsThrown();
 });
 
 it('creates split features', async () => {
@@ -138,7 +137,6 @@ async function getFixtures() {
       const feature = await featuresRepo.save({
         id: v4(),
         featureClassName: 'base feature',
-        tag: FeatureTag.Species,
         creationStatus: JobStatus.created,
       });
       baseFeatureId = feature.id;
@@ -148,7 +146,6 @@ async function getFixtures() {
       const feature = await featuresRepo.save({
         id: v4(),
         featureClassName: 'base feature',
-        tag: FeatureTag.Species,
         creationStatus: JobStatus.created,
         fromGeoprocessingOps: {
           baseFeatureId: v4(),
@@ -159,7 +156,7 @@ async function getFixtures() {
       baseFeatureId = feature.id;
       return feature;
     },
-    GivenBaseFeatureDoesNotExists: async () => {
+    GivenBaseFeatureDoesNotExist: async () => {
       return v4();
     },
 
@@ -183,12 +180,12 @@ async function getFixtures() {
         projectId,
       );
       return {
-        ThenBaseFeatureDoesNotExistsErrorIsThrow: async () => {
+        ThenBaseFeatureDoesNotExistErrorIsThrow: async () => {
           await expect(createSplitFeatures).rejects.toThrow(
             /did not find base feature/,
           );
         },
-        ThenBaseFeatureIsADerivedFeatureErrorIsThrow: async () => {
+        ThenBaseFeatureIsADerivedFeatureErrorIsThrown: async () => {
           await expect(createSplitFeatures).rejects.toThrow(
             /trying to split an already derived feature/,
           );

--- a/api/apps/api/test/integration/split-create-features.service.e2e-spec.ts
+++ b/api/apps/api/test/integration/split-create-features.service.e2e-spec.ts
@@ -1,0 +1,278 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import { SplitCreateFeatures } from '@marxan-api/modules/scenarios-features/split/split-create-features.service';
+import { bootstrapApplication } from '../utils/api-application';
+import { FeatureConfigSplit } from '@marxan-api/modules/specification';
+import { v4 } from 'uuid';
+import { FeatureSubSet, SpecificationOperation } from '@marxan/specification';
+import { GivenProjectExists } from '../steps/given-project';
+import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
+import { IsNull, Not, Repository } from 'typeorm';
+import { FeatureTag } from '@marxan/features';
+import { JobStatus } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { SingleSplitConfigFeatureValue } from '@marxan/features-hash';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+it('fails to create split features when basefeature does not exists', async () => {
+  const splitByProperty = 'random property';
+  const projectId = await fixtures.GivenProjectExist();
+  const featureId = await fixtures.GivenBaseFeatureDoesNotExists();
+  const splitFeatureConfig = fixtures.GivenSplitFeatureConfig(
+    featureId,
+    splitByProperty,
+  );
+  await fixtures
+    .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
+    .ThenBaseFeatureDoesNotExistsErrorIsThrow();
+});
+
+it('fails to create split features when basefeature is a derived feture', async () => {
+  const splitByProperty = 'random property';
+  const projectId = await fixtures.GivenProjectExist();
+  const feature = await fixtures.GivenBaseFeatureIsADerivedFeature();
+  const splitFeatureConfig = fixtures.GivenSplitFeatureConfig(
+    feature.id,
+    splitByProperty,
+  );
+  await fixtures
+    .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
+    .ThenBaseFeatureIsADerivedFeatureErrorIsThrow();
+});
+
+it('creates split features', async () => {
+  const splitByProperty = 'random property';
+  const selectSubSets: FeatureSubSet[] = [
+    { value: 'random value 1' },
+    { value: 'random value 2' },
+  ];
+  const projectId = await fixtures.GivenProjectExist();
+  const feature = await fixtures.GivenBaseFeature();
+  const splitFeatureConfig = fixtures.GivenSplitFeatureConfig(
+    feature.id,
+    splitByProperty,
+    selectSubSets,
+  );
+  await fixtures
+    .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
+    .ThenSplitFeaturesAreCreated(feature);
+});
+
+it('creates one split feature when there are no subsets', async () => {
+  const splitByProperty = 'random property';
+  const selectSubSets: FeatureSubSet[] = [];
+  const projectId = await fixtures.GivenProjectExist();
+  const feature = await fixtures.GivenBaseFeature();
+  const splitFeatureConfig = fixtures.GivenSplitFeatureConfig(
+    feature.id,
+    splitByProperty,
+    selectSubSets,
+  );
+  await fixtures
+    .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
+    .ThenOneSplitFeatureIsCreated(feature);
+});
+
+it('does not creat new split features when they are already created', async () => {
+  const splitByProperty = 'random property';
+  const selectSubSets: FeatureSubSet[] = [];
+  const projectId = await fixtures.GivenProjectExist();
+  const feature = await fixtures.GivenBaseFeature();
+  const splitFeatureConfig = fixtures.GivenSplitFeatureConfig(
+    feature.id,
+    splitByProperty,
+    selectSubSets,
+  );
+  const fitstResult = await fixtures
+    .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
+    .ThenOneSplitFeatureIsCreated(feature);
+
+  await fixtures
+    .WhenCreatingSplitFeatures(splitFeatureConfig, projectId)
+    .ThenOnlyExistsOneSplitFeature(fitstResult);
+});
+
+async function getFixtures() {
+  const app = await bootstrapApplication();
+
+  const sut = app.get(SplitCreateFeatures);
+  const featuresRepo: Repository<GeoFeature> = app.get(
+    getRepositoryToken(GeoFeature),
+  );
+
+  const token = await GivenUserIsLoggedIn(app);
+  let projectId: string;
+  let cleanupProject: () => Promise<void>;
+  let baseFeatureId: string;
+
+  const getFeatureName = (
+    baseFeatureName: string,
+    splitByProperty: string,
+    value?: string,
+  ) => {
+    const valueChain = value ? `: ${value}` : '';
+    return `${baseFeatureName} / ${splitByProperty}` + valueChain;
+  };
+  return {
+    cleanup: async () => {
+      await cleanupProject();
+      await featuresRepo.delete({ id: baseFeatureId });
+      await featuresRepo.delete({ projectId });
+    },
+    GivenProjectExist: async () => {
+      const project = await GivenProjectExists(app, token);
+      cleanupProject = project.cleanup;
+      projectId = project.projectId;
+      return projectId;
+    },
+    GivenBaseFeature: async () => {
+      const feature = await featuresRepo.save({
+        id: v4(),
+        featureClassName: 'base feature',
+        tag: FeatureTag.Species,
+        creationStatus: JobStatus.created,
+      });
+      baseFeatureId = feature.id;
+      return feature;
+    },
+    GivenBaseFeatureIsADerivedFeature: async () => {
+      const feature = await featuresRepo.save({
+        id: v4(),
+        featureClassName: 'base feature',
+        tag: FeatureTag.Species,
+        creationStatus: JobStatus.created,
+        fromGeoprocessingOps: {
+          baseFeatureId: v4(),
+          operation: SpecificationOperation.Split,
+          splitByProperty: 'basefeature prop',
+        },
+      });
+      baseFeatureId = feature.id;
+      return feature;
+    },
+    GivenBaseFeatureDoesNotExists: async () => {
+      return v4();
+    },
+
+    GivenSplitFeatureConfig: (
+      baseFeatureId: string,
+      splitByProperty: string,
+      selectSubSets?: FeatureSubSet[],
+    ): FeatureConfigSplit => ({
+      id: v4(),
+      operation: SpecificationOperation.Split,
+      baseFeatureId,
+      splitByProperty,
+      selectSubSets,
+    }),
+    WhenCreatingSplitFeatures: (
+      splitFeatureConfig: FeatureConfigSplit,
+      projectId: string,
+    ) => {
+      const createSplitFeatures = sut.createSplitFeatures(
+        splitFeatureConfig,
+        projectId,
+      );
+      return {
+        ThenBaseFeatureDoesNotExistsErrorIsThrow: async () => {
+          await expect(createSplitFeatures).rejects.toThrow(
+            /did not find base feature/,
+          );
+        },
+        ThenBaseFeatureIsADerivedFeatureErrorIsThrow: async () => {
+          await expect(createSplitFeatures).rejects.toThrow(
+            /trying to split an already derived feature/,
+          );
+        },
+        ThenOneSplitFeatureIsCreated: async (baseFeature: GeoFeature) => {
+          const results = await createSplitFeatures;
+
+          const splitFeaturesFound = await featuresRepo.find({
+            where: { projectId, geoprocessingOpsHash: Not(IsNull()) },
+          });
+          expect(results).toHaveLength(splitFeaturesFound.length);
+          expect(results).toHaveLength(1);
+
+          const splitFeatureFound = splitFeaturesFound[0];
+          const splitFeatureResult = results[0];
+          const {
+            splitByProperty,
+            subset,
+          } = splitFeatureResult.singleSplitFeature;
+          const value = subset?.value;
+
+          expect(
+            splitFeatureFound.featureClassName ===
+              getFeatureName(
+                baseFeature.featureClassName!,
+                splitByProperty,
+                value,
+              ),
+          );
+
+          return results;
+        },
+        ThenSplitFeaturesAreCreated: async (baseFeature: GeoFeature) => {
+          const results = await createSplitFeatures;
+
+          const splitFeaturesFound = await featuresRepo.find({
+            where: { projectId, geoprocessingOpsHash: Not(IsNull()) },
+          });
+          expect(results).toHaveLength(splitFeaturesFound.length);
+
+          expect(
+            results.every((splitFeature) => {
+              const foundFeature = splitFeaturesFound.find(
+                ({ id }) => splitFeature.id === id,
+              );
+              const {
+                splitByProperty,
+                subset,
+              } = splitFeature.singleSplitFeature;
+              const value = subset?.value;
+
+              return (
+                foundFeature &&
+                foundFeature.featureClassName ===
+                  getFeatureName(
+                    baseFeature.featureClassName!,
+                    splitByProperty,
+                    value,
+                  )
+              );
+            }),
+          );
+        },
+        ThenOnlyExistsOneSplitFeature: async (
+          prevResult: {
+            id: string;
+            singleSplitFeature: SingleSplitConfigFeatureValue;
+          }[],
+        ) => {
+          const results = await createSplitFeatures;
+
+          const splitFeaturesFound = await featuresRepo.find({
+            where: { projectId, geoprocessingOpsHash: Not(IsNull()) },
+          });
+          expect(results).toHaveLength(splitFeaturesFound.length);
+          expect(results).toHaveLength(1);
+
+          expect(results[0].id).toEqual(splitFeaturesFound[0].id);
+
+          expect(prevResult).toHaveLength(1);
+
+          expect(prevResult[0].id).toEqual(results[0].id);
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
This PR adds creation of features when a split specification is submitted.

In case the base feature is already a derived feature, the service will fail, also, when cretaing the new features, in case no value has been specified in the subsets, the name of the only created feature will be set to:  "<base-feature-name> / <split-by-property>" 

### Feature relevant tickets

[api: when users request to split features, (apidb)features records should always be created](https://vizzuality.atlassian.net/browse/MARXAN-1681)


