### PR TITLE
MARXAN-1484-minimum-password-strength

### DIFF
--- a/api/apps/api/src/utils/passwordValidation.utils.ts
+++ b/api/apps/api/src/utils/passwordValidation.utils.ts
@@ -1,0 +1,15 @@
+import { Either, left, right } from 'fp-ts/lib/Either';
+
+export const passwordEntropyValidation = (
+  password: string,
+): Either<string, void> => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const entropyChecker = require('fast-password-entropy');
+  const result = entropyChecker(password);
+  const entropyThreshold = 80;
+  if (result < entropyThreshold) {
+    return left('Weak Password. Please use a stronger password.');
+  }
+
+  return right(void 0);
+};

--- a/api/apps/api/src/utils/passwordValidation.utils.ts
+++ b/api/apps/api/src/utils/passwordValidation.utils.ts
@@ -1,12 +1,12 @@
 import { Either, left, right } from 'fp-ts/lib/Either';
 
-export const passwordEntropyValidation = (
+export const isStringEntropyHigherThan = (
+  entropyThreshold: number,
   password: string,
 ): Either<string, void> => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const entropyChecker = require('fast-password-entropy');
   const result = entropyChecker(password);
-  const entropyThreshold = 80;
   if (result < entropyThreshold) {
     return left('Weak Password. Please use a stronger password.');
   }

--- a/api/apps/api/src/utils/passwordValidation.utils.ts
+++ b/api/apps/api/src/utils/passwordValidation.utils.ts
@@ -1,11 +1,11 @@
 import { Either, left, right } from 'fp-ts/lib/Either';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const entropyChecker = require('fast-password-entropy');
 
 export const isStringEntropyHigherThan = (
   entropyThreshold: number,
   password: string,
 ): Either<string, void> => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const entropyChecker = require('fast-password-entropy');
   const result = entropyChecker(password);
   if (result < entropyThreshold) {
     return left('Weak Password. Please use a stronger password.');

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -105,6 +105,16 @@ describe('UsersModule (e2e)', () => {
         .expect(HttpStatus.CREATED);
     });
 
+    test('A user should not be able to create an account using a weak password', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/sign-up')
+        .send({
+          ...signUpDto,
+          password: 'abcdef',
+        })
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
     test('A user should not be able to create an account using an email address already in use', async () => {
       /**
        * We should handle this explicitly in the API - until then, this should

--- a/api/package.json
+++ b/api/package.json
@@ -71,6 +71,7 @@
     "express": "^4.17.1",
     "faker": "^5.1.0",
     "fast-csv": "^4.3.6",
+    "fast-password-entropy": "^1.1.1",
     "fp-ts": "2.10.5",
     "geojson": "0.5.0",
     "helmet": "^4.3.1",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -5085,6 +5085,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-password-entropy@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-password-entropy/-/fast-password-entropy-1.1.1.tgz#47ba9933095fd5a32fb184915fc8e76ee19cf429"
+  integrity sha512-dxm29/BPFrNgyEDygg/lf9c2xQR0vnQhG7+hZjAI39M/3um9fD4xiqG6F0ZjW6bya5m9CI0u6YryHGRtxCGCiw==
+
 fast-safe-stringify@2.0.7, fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"


### PR DESCRIPTION
-Adds small utility to check that passwords used are over 80 in entropy levels.
-Adds small test to check lower than 80 password can't be used.