### PR TITLE
MARXAN-1486-auth-endpoint-limit

### DIFF
--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -4,7 +4,7 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthenticationModule } from '@marxan-api/modules/authentication/authentication.module';
@@ -20,7 +20,7 @@ import { GeoFeaturesModule } from '@marxan-api/modules/geo-features/geo-features
 import { apiConnections } from './ormconfig';
 import { OrganizationsModule } from '@marxan-api/modules/organizations/organizations.module';
 import { FetchSpecificationMiddleware } from 'nestjs-base-service';
-import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { APP_FILTER } from '@nestjs/core';
 import { AllExceptionsFilter } from '@marxan-api/filters/all-exceptions.exception.filter';
 import { AdminAreasModule } from '@marxan-api/modules/admin-areas/admin-areas.module';
 import { ApiEventsModule } from '@marxan-api/modules/api-events/api-events.module';
@@ -76,7 +76,7 @@ import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-co
     AsyncJobsGarbageCollectorModule,
     ThrottlerModule.forRoot({
       ttl: 60,
-      limit: 10,
+      limit: 25,
     }),
   ],
   controllers: [AppController, PingController],
@@ -85,10 +85,6 @@ import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-co
     {
       provide: APP_FILTER,
       useClass: AllExceptionsFilter,
-    },
-    {
-      provide: APP_GUARD,
-      useClass: ThrottlerGuard,
     },
   ],
 })

--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthenticationModule } from '@marxan-api/modules/authentication/authentication.module';
@@ -19,7 +20,7 @@ import { GeoFeaturesModule } from '@marxan-api/modules/geo-features/geo-features
 import { apiConnections } from './ormconfig';
 import { OrganizationsModule } from '@marxan-api/modules/organizations/organizations.module';
 import { FetchSpecificationMiddleware } from 'nestjs-base-service';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { AllExceptionsFilter } from '@marxan-api/filters/all-exceptions.exception.filter';
 import { AdminAreasModule } from '@marxan-api/modules/admin-areas/admin-areas.module';
 import { ApiEventsModule } from '@marxan-api/modules/api-events/api-events.module';
@@ -73,6 +74,10 @@ import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-co
     ApiCloningFilesRepositoryModule,
     CloneModule,
     AsyncJobsGarbageCollectorModule,
+    ThrottlerModule.forRoot({
+      ttl: 60,
+      limit: 10,
+    }),
   ],
   controllers: [AppController, PingController],
   providers: [
@@ -80,6 +85,10 @@ import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-co
     {
       provide: APP_FILTER,
       useClass: AllExceptionsFilter,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
     },
   ],
 })

--- a/api/apps/api/src/modules/authentication/authentication.controller.ts
+++ b/api/apps/api/src/modules/authentication/authentication.controller.ts
@@ -15,7 +15,6 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
 import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 
@@ -34,7 +33,6 @@ import { IsMissingAclImplementation } from '@marxan-api/decorators/acl.decorator
 export class AuthenticationController {
   constructor(private readonly authenticationService: AuthenticationService) {}
 
-  @Throttle(5, 60)
   @UseGuards(LocalAuthGuard)
   @ApiOperation({
     description: 'Sign user in, issuing a JWT token.',

--- a/api/apps/api/src/modules/authentication/authentication.controller.ts
+++ b/api/apps/api/src/modules/authentication/authentication.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
 import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 
@@ -33,6 +34,7 @@ import { IsMissingAclImplementation } from '@marxan-api/decorators/acl.decorator
 export class AuthenticationController {
   constructor(private readonly authenticationService: AuthenticationService) {}
 
+  @Throttle(10, 60)
   @UseGuards(LocalAuthGuard)
   @ApiOperation({
     description: 'Sign user in, issuing a JWT token.',

--- a/api/apps/api/src/modules/authentication/authentication.controller.ts
+++ b/api/apps/api/src/modules/authentication/authentication.controller.ts
@@ -34,7 +34,7 @@ import { IsMissingAclImplementation } from '@marxan-api/decorators/acl.decorator
 export class AuthenticationController {
   constructor(private readonly authenticationService: AuthenticationService) {}
 
-  @Throttle(10, 60)
+  @Throttle(5, 60)
   @UseGuards(LocalAuthGuard)
   @ApiOperation({
     description: 'Sign user in, issuing a JWT token.',

--- a/api/apps/api/src/modules/authentication/authentication.module.ts
+++ b/api/apps/api/src/modules/authentication/authentication.module.ts
@@ -2,6 +2,8 @@ import { forwardRef, Logger, Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { User } from '@marxan-api/modules/users/user.api.entity';
 
 import { UsersModule } from '@marxan-api/modules/users/users.module';
@@ -75,6 +77,10 @@ export const logger = new Logger('Authentication');
       useClass: TypeORMRecoveryTokenRepository,
     },
     PasswordRecoveryService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
   controllers: [AuthenticationController, PasswordRecoveryController],
   exports: [AuthenticationService],

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -171,28 +171,6 @@ describe('UsersModule (e2e)', () => {
         .send(loginDto)
         .expect(HttpStatus.CREATED);
     });
-
-    test('The API should show a 429: Too many request error if multiple attempts at login are done in a short space of time', async () => {
-      const requestsArray = await Promise.all([
-        await request(app.getHttpServer())
-          .post('/auth/sign-in')
-          .send({ ...loginDto, password: 'abcde1' }),
-        await request(app.getHttpServer())
-          .post('/auth/sign-in')
-          .send({ ...loginDto, password: 'abcde2' }),
-        await request(app.getHttpServer())
-          .post('/auth/sign-in')
-          .send({ ...loginDto, password: 'abcde3' }),
-        await request(app.getHttpServer())
-          .post('/auth/sign-in')
-          .send({ ...loginDto, password: 'abcde4' }),
-        await request(app.getHttpServer())
-          .post('/auth/sign-in')
-          .send({ ...loginDto, password: 'abcde5' }),
-      ]);
-      const tooManyRequest = requestsArray.find((r) => r.status === 429);
-      expect(tooManyRequest).toBeDefined();
-    });
   });
 
   describe('Users - metadata', () => {
@@ -649,6 +627,32 @@ describe('UsersModule (e2e)', () => {
         .get('/api/v1/users/by-email/aa@example')
         .set('Authorization', `Bearer ${adminToken}`);
       expect(WhenSearchingUserByFullMail.status).toEqual(400);
+    });
+  });
+
+  describe('', () => {
+    test('The API should show a 429: Too many request error if multiple attempts at login are done in a short space of time', async () => {
+      const requestsArray = await Promise.all([
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ username: 'aa@example.com', password: 'abcde1' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ username: 'aa@example.com', password: 'abcde2' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ username: 'aa@example.com', password: 'abcde3' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ username: 'aa@example.com', password: 'abcde4' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ username: 'aa@example.com', password: 'abcde5' }),
+      ]);
+      const tooManyRequest = requestsArray.find(
+        (r) => r.status === HttpStatus.TOO_MANY_REQUESTS,
+      );
+      expect(tooManyRequest).toBeDefined();
     });
   });
 });

--- a/api/apps/api/test/users.e2e-spec.ts
+++ b/api/apps/api/test/users.e2e-spec.ts
@@ -171,6 +171,28 @@ describe('UsersModule (e2e)', () => {
         .send(loginDto)
         .expect(HttpStatus.CREATED);
     });
+
+    test('The API should show a 429: Too many request error if multiple attempts at login are done in a short space of time', async () => {
+      const requestsArray = await Promise.all([
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ ...loginDto, password: 'abcde1' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ ...loginDto, password: 'abcde2' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ ...loginDto, password: 'abcde3' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ ...loginDto, password: 'abcde4' }),
+        await request(app.getHttpServer())
+          .post('/auth/sign-in')
+          .send({ ...loginDto, password: 'abcde5' }),
+      ]);
+      const tooManyRequest = requestsArray.find((r) => r.status === 429);
+      expect(tooManyRequest).toBeDefined();
+    });
   });
 
   describe('Users - metadata', () => {

--- a/api/package.json
+++ b/api/package.json
@@ -53,6 +53,7 @@
     "@nestjs/platform-express": "7.6.18",
     "@nestjs/schedule": "^2.0.1",
     "@nestjs/swagger": "^4.8.0",
+    "@nestjs/throttler": "^3.0.0",
     "@nestjs/typeorm": "^7.1.5",
     "@pgtyped/cli": "0.11.0",
     "@pgtyped/query": "0.11.0",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -750,6 +750,13 @@
     optional "0.1.4"
     tslib "2.0.3"
 
+"@nestjs/throttler@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/throttler/-/throttler-3.0.0.tgz#08a9c53d1246069292504f5d4d9db2257b51e36f"
+  integrity sha512-E5aLstJ1a3yZE6AgcN+BgHLiRd8lonR5E4E4I3wzVHRGfgglHQS1sa2zEUuD/pdzLPlbI8pvVDJom8Z2D1oDug==
+  dependencies:
+    md5 "^2.2.1"
+
 "@nestjs/typeorm@^7.1.5":
   version "7.1.5"
   resolved "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-7.1.5.tgz"
@@ -3666,6 +3673,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
 chokidar@3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
@@ -4200,6 +4212,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -6010,7 +6027,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -7327,6 +7344,15 @@ mapshaper@0.5.91:
     rw "~1.3.3"
     sync-request "5.0.0"
     tinyqueue "^2.0.3"
+
+md5@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
-Adds an endpoint request limit for Auth endpoints.
-The limit is 25 requests per minute mainly due to the amount of sign-in endpoint calls inside tests for the Auth module.