### PR TITLE
fix: add fk between puvspr_calculations and projects_pu table

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/compute-area.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios-features/compute-area.service.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '@marxan/puvspr-calculations';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Test } from '@nestjs/testing';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { v4 } from 'uuid';
 import { LegacyProjectImport } from '../legacy-project-import/domain/legacy-project-import/legacy-project-import';
 import { LegacyProjectImportRepository } from '../legacy-project-import/domain/legacy-project-import/legacy-project-import.repository';
@@ -69,7 +68,7 @@ const getFixtures = async () => {
     PuvsprCalculationsRepository,
   );
 
-  const expectedPuid = 1;
+  const expectedPuid = v4();
   const expectedAmount = 20;
   return {
     GivenProject: () => {
@@ -91,7 +90,14 @@ const getFixtures = async () => {
     GivenNoComputationHasBeenSaved: () => {
       const featureId = v4();
       computeMarxanAmountPerPlanningUnitMock.mockImplementation(async () => {
-        return [{ featureId, puid: expectedPuid, amount: expectedAmount }];
+        return [
+          {
+            featureId,
+            projectPuId: expectedPuid,
+            amount: expectedAmount,
+            puId: 1,
+          },
+        ];
       });
 
       return featureId;
@@ -110,7 +116,7 @@ const getFixtures = async () => {
       expect(savedCalculations).toBeDefined();
       expect(savedCalculations[0]).toEqual({
         amount: expectedAmount,
-        puid: expectedPuid,
+        projectPuId: expectedPuid,
         featureId,
       });
     },

--- a/api/apps/api/src/modules/scenarios-features/compute-area.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/compute-area.service.ts
@@ -37,7 +37,13 @@ export class ComputeArea {
 
     return this.puvsprCalculationsRepo.saveAmountPerPlanningUnitAndFeature(
       projectId,
-      amountPerPlanningUnitOfFeature,
+      amountPerPlanningUnitOfFeature.map(
+        ({ featureId, projectPuId, amount }) => ({
+          featureId,
+          projectPuId,
+          amount,
+        }),
+      ),
     );
   }
 

--- a/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvspr.dat.marxan-project.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvspr.dat.marxan-project.ts
@@ -1,20 +1,56 @@
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
 import { PuvsprCalculationsRepository } from '@marxan/puvspr-calculations';
 import { Injectable } from '@nestjs/common';
-import { PuvsprDat } from './puvsrpr.dat';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FeatureAmountPerPlanningUnitId, PuvsprDat } from './puvsrpr.dat';
 
 @Injectable()
 export class PuvsprDatMarxanProject implements PuvsprDat {
   constructor(
     private readonly puvsprCalculationsRepo: PuvsprCalculationsRepository,
+    @InjectRepository(ProjectsPuEntity, DbConnections.geoprocessingDB)
+    private readonly projectsPusRepo: Repository<ProjectsPuEntity>,
   ) {}
   public async getAmountPerPlanningUnitAndFeature(
     projectId: string,
     scenarioId: string,
     featureIds: string[],
-  ) {
-    return this.puvsprCalculationsRepo.getAmountPerPlanningUnitAndFeature(
+  ): Promise<FeatureAmountPerPlanningUnitId[]> {
+    const amountPerPlanningUnitOfFeature = await this.puvsprCalculationsRepo.getAmountPerPlanningUnitAndFeature(
       projectId,
       featureIds,
     );
+
+    const projectPusById = await this.getProjectPlanningUnitsById(projectId);
+
+    return amountPerPlanningUnitOfFeature.map(
+      ({ amount, featureId, projectPuId }) => ({
+        amount,
+        featureId,
+        puId: projectPusById[projectPuId],
+      }),
+    );
+  }
+
+  private async getProjectPlanningUnitsById(projectId: string) {
+    const projectPus: {
+      id: string;
+      puId: number;
+    }[] = await this.projectsPusRepo
+      .createQueryBuilder()
+      .select('id')
+      .addSelect('puid', 'puId')
+      .where('project_id = :projectId', { projectId })
+      .execute();
+
+    const projectPusById: Record<string, number> = {};
+    projectPus.reduce((prev, { id, puId }) => {
+      prev[id] = puId;
+      return prev;
+    }, projectPusById);
+
+    return projectPusById;
   }
 }

--- a/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvspr.dat.processor.module.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvspr.dat.processor.module.ts
@@ -15,6 +15,7 @@ import { PuvsprDatLegacyProject } from './puvspr.dat.legacy-project';
 import { PuvsprDatMarxanProject } from './puvspr.dat.marxan-project';
 import { PuvsprDatProcessor } from './puvspr.dat.processor';
 import { FeatureHashModule } from '@marxan-api/modules/features-hash/features-hash.module';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
 
 @Module({
   imports: [
@@ -22,7 +23,7 @@ import { FeatureHashModule } from '@marxan-api/modules/features-hash/features-ha
     FeatureHashModule,
     TypeOrmModule.forFeature([Scenario, GeoFeature]),
     TypeOrmModule.forFeature(
-      [ScenarioFeaturesData, GeoFeatureGeometry],
+      [ScenarioFeaturesData, GeoFeatureGeometry, ProjectsPuEntity],
       DbConnections.geoprocessingDB,
     ),
     ScenarioSpecificationAdaptersModule,

--- a/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvspr.dat.processor.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvspr.dat.processor.ts
@@ -27,7 +27,7 @@ import { PuvrsprDatFactory } from './puvspr.dat.factory';
 export type PuvrsprDatRow = {
   speciesId: number;
   amount: number;
-  puid: number;
+  puId: number;
 };
 
 @Injectable()
@@ -74,10 +74,10 @@ export class PuvsprDatProcessor {
         (row) => row.featureId === featureId,
       );
 
-      return amountPerPlanningUnitOfFeature.map(({ amount, puid }) => ({
+      return amountPerPlanningUnitOfFeature.map(({ amount, puId }) => ({
         speciesId,
         amount,
-        puid,
+        puId,
       }));
     });
   }

--- a/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvsrpr.dat.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.processor/puvsrpr.dat.ts
@@ -1,9 +1,13 @@
-import { FeatureAmountPerPlanningUnit } from '@marxan/puvspr-calculations';
+export type FeatureAmountPerPlanningUnitId = {
+  featureId: string;
+  amount: number;
+  puId: number;
+};
 
 export abstract class PuvsprDat {
   abstract getAmountPerPlanningUnitAndFeature(
     projectId: string,
     scenarioId: string,
     featureIds: string[],
-  ): Promise<FeatureAmountPerPlanningUnit[]>;
+  ): Promise<FeatureAmountPerPlanningUnitId[]>;
 }

--- a/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.service.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/puvspr.dat.service.ts
@@ -50,8 +50,8 @@ export class PuvsprDatService {
       'species\tpu\tamount\n' +
       rows
         .map(
-          ({ speciesId, puid, amount }) =>
-            `${speciesId}\t${puid}\t${amount.toFixed(6)}`,
+          ({ speciesId, puId, amount }) =>
+            `${speciesId}\t${puId}\t${amount.toFixed(6)}`,
         )
         .join('\n')
     );

--- a/api/apps/api/src/modules/scenarios/input-files/puvspr.data.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/puvspr.data.service.spec.ts
@@ -58,17 +58,17 @@ describe(`when there is data available`, () => {
       {
         amount: 1000.0,
         speciesId: 'feature-1',
-        puid: 'pu-1,',
+        puId: 'pu-1,',
       },
       {
         amount: 0.001,
         speciesId: 'feature-1',
-        puid: 'pu-2,',
+        puId: 'pu-2,',
       },
       {
         amount: 99.995,
         speciesId: 'feature-1',
-        puid: 'pu-3,',
+        puId: 'pu-3,',
       },
     ]);
   });

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1657780657222-AddFKBetweenPuvsprCalculationsAndProjectsPu.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1657780657222-AddFKBetweenPuvsprCalculationsAndProjectsPu.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFKBetweenPuvsprCalculationsAndProjectsPu1657780657222
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM puvspr_calculations;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE puvspr_calculations
+        DROP COLUMN pu_id;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE puvspr_calculations
+        ADD COLUMN project_pu_id uuid NOT NULL;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE puvspr_calculations
+        ADD FOREIGN KEY (project_pu_id) REFERENCES projects_pu(id) 
+        ON DELETE cascade;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE puvspr_calculations
+        DROP COLUMN project_pu_id;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE puvspr_calculations
+        ADD COLUMN pu_id integer NOT NULL;
+    `);
+  }
+}

--- a/api/libs/puvspr-calculations/src/index.ts
+++ b/api/libs/puvspr-calculations/src/index.ts
@@ -2,7 +2,7 @@ export { TypeOrmPuvsprCalculationsRepository } from './repository/typeorm-puvspr
 export { MemoryPuvsprCalculationsRepository } from './repository/memory-puvspr-calculations.repository';
 export {
   PuvsprCalculationsRepository,
-  FeatureAmountPerPlanningUnit,
+  FeatureAmountPerProjectPlanningUnit,
 } from './repository/puvspr-calculations.repository';
 export { PuvsprCalculationsEntity } from './puvspr-calculations.geo.entity';
 export { PuvsprCalculationsService } from './puvspr-calculations.service';

--- a/api/libs/puvspr-calculations/src/puvspr-calculations.geo.entity.ts
+++ b/api/libs/puvspr-calculations/src/puvspr-calculations.geo.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Entity('puvspr_calculations')
 export class PuvsprCalculationsEntity {
@@ -11,9 +18,18 @@ export class PuvsprCalculationsEntity {
   @Column('uuid', { name: 'feature_id' })
   featureId!: string;
 
-  @Column('integer', { name: 'pu_id' })
-  puid!: number;
-
   @Column('double precision')
   amount!: number;
+
+  @Column('uuid', { name: 'project_pu_id' })
+  projectPuId!: string;
+
+  @ManyToOne(() => ProjectsPuEntity, (projectPu) => projectPu.id, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    referencedColumnName: 'id',
+    name: 'project_pu_id',
+  })
+  projectPu!: ProjectsPuEntity;
 }

--- a/api/libs/puvspr-calculations/src/repository/memory-puvspr-calculations.repository.ts
+++ b/api/libs/puvspr-calculations/src/repository/memory-puvspr-calculations.repository.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import {
-  FeatureAmountPerPlanningUnit,
+  FeatureAmountPerProjectPlanningUnit,
   PuvsprCalculationsRepository,
 } from './puvspr-calculations.repository';
 
 @Injectable()
 export class MemoryPuvsprCalculationsRepository
   implements PuvsprCalculationsRepository {
-  public memory: Record<string, FeatureAmountPerPlanningUnit[]> = {};
+  public memory: Record<string, FeatureAmountPerProjectPlanningUnit[]> = {};
   async areAmountPerPlanningUnitAndFeatureSaved(
     projectId: string,
     featureId: string,
@@ -22,7 +22,7 @@ export class MemoryPuvsprCalculationsRepository
   async getAmountPerPlanningUnitAndFeature(
     projectId: string,
     featureIds: string[],
-  ): Promise<FeatureAmountPerPlanningUnit[]> {
+  ): Promise<FeatureAmountPerProjectPlanningUnit[]> {
     const featureAmountsPerPlanningUnit = this.memory[projectId];
 
     if (!featureAmountsPerPlanningUnit) return [];
@@ -33,13 +33,13 @@ export class MemoryPuvsprCalculationsRepository
   }
   async saveAmountPerPlanningUnitAndFeature(
     projectId: string,
-    results: FeatureAmountPerPlanningUnit[],
+    results: FeatureAmountPerProjectPlanningUnit[],
   ): Promise<void> {
     this.memory[projectId] = results;
   }
   async getAmountPerPlanningUnitAndFeatureInProject(
     projectId: string,
-  ): Promise<FeatureAmountPerPlanningUnit[]> {
+  ): Promise<FeatureAmountPerProjectPlanningUnit[]> {
     return this.memory[projectId];
   }
 }

--- a/api/libs/puvspr-calculations/src/repository/puvspr-calculations.repository.ts
+++ b/api/libs/puvspr-calculations/src/repository/puvspr-calculations.repository.ts
@@ -1,7 +1,7 @@
-export type FeatureAmountPerPlanningUnit = {
+export type FeatureAmountPerProjectPlanningUnit = {
   featureId: string;
   amount: number;
-  puid: number;
+  projectPuId: string;
 };
 
 export abstract class PuvsprCalculationsRepository {
@@ -13,14 +13,14 @@ export abstract class PuvsprCalculationsRepository {
   abstract getAmountPerPlanningUnitAndFeature(
     projectId: string,
     featureIds: string[],
-  ): Promise<FeatureAmountPerPlanningUnit[]>;
+  ): Promise<FeatureAmountPerProjectPlanningUnit[]>;
 
   abstract saveAmountPerPlanningUnitAndFeature(
     projectId: string,
-    results: FeatureAmountPerPlanningUnit[],
+    results: FeatureAmountPerProjectPlanningUnit[],
   ): Promise<void>;
 
   abstract getAmountPerPlanningUnitAndFeatureInProject(
     projectId: string,
-  ): Promise<FeatureAmountPerPlanningUnit[]>;
+  ): Promise<FeatureAmountPerProjectPlanningUnit[]>;
 }

--- a/api/libs/puvspr-calculations/src/repository/typeorm-puvspr-calculations.repository.ts
+++ b/api/libs/puvspr-calculations/src/repository/typeorm-puvspr-calculations.repository.ts
@@ -3,7 +3,7 @@ import { EntityManager } from 'typeorm';
 import { PuvsprCalculationsEntity } from '../puvspr-calculations.geo.entity';
 import { geoEntityManagerToken } from '../puvspr-calculations.service';
 import {
-  FeatureAmountPerPlanningUnit,
+  FeatureAmountPerProjectPlanningUnit,
   PuvsprCalculationsRepository,
 } from './puvspr-calculations.repository';
 
@@ -16,11 +16,11 @@ export class TypeOrmPuvsprCalculationsRepository
   ) {}
   async getAmountPerPlanningUnitAndFeatureInProject(
     projectId: string,
-  ): Promise<FeatureAmountPerPlanningUnit[]> {
+  ): Promise<FeatureAmountPerProjectPlanningUnit[]> {
     return this.geoEntityManager
       .createQueryBuilder()
       .select('amount')
-      .addSelect('pu_id', 'puid')
+      .addSelect('project_pu_id', 'projectPuId')
       .addSelect('feature_id', 'featureId')
       .from(PuvsprCalculationsEntity, 'puvspr')
       .where('project_id = :projectId', { projectId })
@@ -30,11 +30,11 @@ export class TypeOrmPuvsprCalculationsRepository
   public async getAmountPerPlanningUnitAndFeature(
     projectId: string,
     featureIds: string[],
-  ): Promise<FeatureAmountPerPlanningUnit[]> {
+  ): Promise<FeatureAmountPerProjectPlanningUnit[]> {
     return this.geoEntityManager
       .createQueryBuilder()
       .select('amount')
-      .addSelect('pu_id', 'puid')
+      .addSelect('project_pu_id', 'projectPuId')
       .addSelect('feature_id', 'featureId')
       .from(PuvsprCalculationsEntity, 'puvspr')
       .where('project_id = :projectId', { projectId })
@@ -44,15 +44,15 @@ export class TypeOrmPuvsprCalculationsRepository
 
   public async saveAmountPerPlanningUnitAndFeature(
     projectId: string,
-    results: FeatureAmountPerPlanningUnit[],
+    results: FeatureAmountPerProjectPlanningUnit[],
   ) {
     const repo = this.geoEntityManager.getRepository(PuvsprCalculationsEntity);
     await repo.save(
-      results.map(({ amount, puid, featureId }) => ({
+      results.map(({ amount, projectPuId, featureId }) => ({
         projectId,
         featureId,
         amount,
-        puid,
+        projectPuId,
       })),
     );
   }


### PR DESCRIPTION
This PR adds FK between `puvspr_calculations` and `projects_pu` table. Now `PuvsprCalculationsService` methods returns also the `project_pu.id`.

### Feature relevant tickets

[fix: add FK between puvspr_calculations and projects_pu](https://vizzuality.atlassian.net/browse/MARXAN-1689)