### PR TITLE
feat: update scenario metadata for legacy project imports

### DIFF
--- a/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-finished.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/mark-legacy-project-import-as-finished.handler.ts
@@ -1,6 +1,7 @@
 import { ProjectRoles } from '@marxan-api/modules/access-control/projects-acl/dto/user-role-project.dto';
 import { UsersProjectsApiEntity } from '@marxan-api/modules/access-control/projects-acl/entity/users-projects.api.entity';
 import { ApiEventsService } from '@marxan-api/modules/api-events';
+import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import { API_EVENT_KINDS } from '@marxan/api-events';
 import { ResourceId } from '@marxan/cloning/domain';
 import { Logger } from '@nestjs/common';
@@ -25,6 +26,8 @@ export class MarkLegacyProjectImportAsFinishedHandler
     private readonly commandBus: CommandBus,
     @InjectRepository(UsersProjectsApiEntity)
     private readonly usersRepo: Repository<UsersProjectsApiEntity>,
+    @InjectRepository(Scenario)
+    private readonly scenariosRepo: Repository<Scenario>,
     private readonly logger: Logger,
   ) {
     this.logger.setContext(MarkLegacyProjectImportAsFinishedHandler.name);
@@ -38,6 +41,37 @@ export class MarkLegacyProjectImportAsFinishedHandler
     await this.commandBus.execute(
       new MarkLegacyProjectImportAsFailed(projectId, reason),
     );
+  }
+
+  private async updateScenarioMetadataOfLegacyProjectImport(
+    projectId: ResourceId,
+    scenarioId: string,
+  ) {
+    const [scenario] = await this.scenariosRepo.find({ id: scenarioId });
+
+    if (!scenario) {
+      const reason = 'could not find scenario';
+      return this.markLegacyProjectImportAsFailed(projectId, reason);
+    }
+
+    const scenarioMetadata = scenario.metadata;
+
+    if (!scenarioMetadata || !scenarioMetadata.scenarioEditingMetadata) {
+      const reason = 'input.dat file should have updated scenario metadata';
+      return this.markLegacyProjectImportAsFailed(projectId, reason);
+    }
+    const updatedScenarioMetadata = {
+      ...scenarioMetadata,
+      scenarioEditingMetadata: {
+        ...scenarioMetadata.scenarioEditingMetadata,
+        lastJobCheck: new Date().getTime(),
+      },
+    };
+
+    await this.scenariosRepo.save({
+      id: scenarioId,
+      metadata: updatedScenarioMetadata,
+    });
   }
 
   async execute({
@@ -57,6 +91,11 @@ export class MarkLegacyProjectImportAsFinishedHandler
     const { ownerId, scenarioId } = legacyProjectImport.right.toSnapshot();
     const kind = API_EVENT_KINDS.project__legacy__import__finished__v1__alpha;
     const topic = projectId.value;
+
+    await this.updateScenarioMetadataOfLegacyProjectImport(
+      projectId,
+      scenarioId,
+    );
 
     await this.apiEvents.createIfNotExists({
       kind,

--- a/api/apps/api/src/modules/legacy-project-import/application/start-legacy-project-import.handler.ts
+++ b/api/apps/api/src/modules/legacy-project-import/application/start-legacy-project-import.handler.ts
@@ -52,8 +52,9 @@ export class StartLegacyProjectImportHandler
         description,
       });
 
+      const scenarioName = name + ' - scenario';
       const scenario = await this.scenarioRepo.save({
-        name,
+        name: scenarioName,
         projectId: project.id,
       });
 

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/input.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/input.legacy-piece-importer.ts
@@ -78,7 +78,7 @@ export class InputLegacyProjectPieceImporter
 
     const scenarioMetadata = {
       scenarioEditingMetadata: {
-        tab: 'planning-unit',
+        tab: legacyProjectImportIncludesSolutions ? 'solutions' : 'parameters',
         subtab: null,
         status: {
           'planning-unit': 'draft',

--- a/api/apps/geoprocessing/test/integration/legacy-project-import/input.legacy-piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/legacy-project-import/input.legacy-piece-importer.e2e-spec.ts
@@ -236,7 +236,7 @@ const getFixtures = async () => {
           expect(scenario.metadata).toEqual({
             marxanInputParameterFile: expectedInputParameterFile,
             scenarioEditingMetadata: {
-              tab: 'planning-unit',
+              tab: withSolutions ? 'solutions' : 'parameters',
               subtab: null,
               status: {
                 'planning-unit': 'draft',


### PR DESCRIPTION
This PR fixes scenario metadata for legacy project. Now when the legacy project import is finished the scenario metadata is updated so the lastCheckJob is made after the features are imported 

### Feature relevant tickets

