### PR TITLE
feat: add api_feature_id to split query

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-create-features.service.ts
@@ -38,7 +38,7 @@ export class SplitCreateFeatures {
   public async createSplitFeatures(
     input: FeatureConfigSplit,
     projectId: string,
-  ) {
+  ): Promise<SingleSplitConfigFeatureValueWithId[]> {
     const baseFeatureOrError = await this.isBaseFeatureADerivedFeature(input);
 
     if (isLeft(baseFeatureOrError))

--- a/api/apps/api/src/modules/scenarios-features/split/split-query.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-query.service.ts
@@ -1,24 +1,35 @@
 import { Injectable } from '@nestjs/common';
-import { isDefined } from '@marxan/utils';
-import { FeatureConfigSplit } from '@marxan-api/modules/specification';
+import { antimeridianBbox, isDefined, nominatim2bbox } from '@marxan/utils';
 import { Project } from '@marxan-api/modules/projects/project.api.entity';
+import { SingleSplitConfigFeatureValueWithId } from './split-create-features.service';
 
 @Injectable()
 export class SplitQuery {
   prepareQuery(
-    input: FeatureConfigSplit,
+    {
+      id: apiFeatureId,
+      singleSplitFeature,
+    }: SingleSplitConfigFeatureValueWithId,
     scenarioId: string,
     specificationId: string,
     planningAreaLocation: { id: string; tableName: string } | undefined,
     protectedAreaFilterByIds: string[],
     project: Pick<Project, 'bbox'>,
   ) {
+    const subset = singleSplitFeature.subset;
+    const { westBbox, eastBbox } = antimeridianBbox(
+      nominatim2bbox(project.bbox),
+    );
     const parameters: (string | number)[] = [];
     const fields = {
-      filterByValues: (input.selectSubSets ?? []).map(
-        (s) => `$${parameters.push(s.value)}`,
-      ),
-      splitByProperty: `$${parameters.push(input.splitByProperty)}`,
+      filterByValue: subset ? `$${parameters.push(subset.value)}` : undefined,
+      fpf: subset && subset.fpf ? `$${parameters.push(subset.fpf)}` : 'NULL',
+      prop: subset && subset.prop ? `$${parameters.push(subset.prop)}` : 'NULL',
+      target:
+        subset && subset.target ? `$${parameters.push(subset.target)}` : 'NULL',
+      splitByProperty: `$${parameters.push(
+        singleSplitFeature.splitByProperty,
+      )}`,
       scenarioId: `$${parameters.push(scenarioId)}`,
       specificationId: `$${parameters.push(specificationId)}`,
       planningAreaId: isDefined(planningAreaLocation)
@@ -32,12 +43,19 @@ export class SplitQuery {
           : undefined,
       protectedArea:
         protectedAreaFilterByIds.length > 0 ? 'protected.area' : 'NULL',
-      featureId: `$${parameters.push(input.baseFeatureId)}`,
-      bbox: [
-        `$${parameters.push(project.bbox[0])}`,
-        `$${parameters.push(project.bbox[2])}`,
-        `$${parameters.push(project.bbox[1])}`,
-        `$${parameters.push(project.bbox[3])}`,
+      baseFeatureId: `$${parameters.push(singleSplitFeature.baseFeatureId)}`,
+      apiFeatureId: `$${parameters.push(apiFeatureId)}`,
+      westBbox: [
+        `$${parameters.push(westBbox[0])}`,
+        `$${parameters.push(westBbox[1])}`,
+        `$${parameters.push(westBbox[2])}`,
+        `$${parameters.push(westBbox[3])}`,
+      ],
+      eastBbox: [
+        `$${parameters.push(eastBbox[0])}`,
+        `$${parameters.push(eastBbox[1])}`,
+        `$${parameters.push(eastBbox[2])}`,
+        `$${parameters.push(eastBbox[3])}`,
       ],
       totalArea: isDefined(planningAreaLocation)
         ? `st_area(st_intersection(pa.the_geom, fd.the_geom))`
@@ -53,9 +71,9 @@ export class SplitQuery {
       ? `left join ${planningAreaLocation.tableName} as pa on pa.id = ${fields.planningAreaId}`
       : ``;
 
-    const hasSubSetFilter = (input.selectSubSets ?? []).length > 0;
     const query = `
       insert into scenario_features_preparation as sfp (feature_class_id,
+                                                        api_feature_id,
                                                         scenario_id,
                                                         specification_id,
                                                         fpf,
@@ -64,51 +82,37 @@ export class SplitQuery {
                                                         total_area,
                                                         current_pa)
       WITH split as (
-        WITH subsets as (
-          select value as sub_value, target, fpf, prop
-          from json_to_recordset('${JSON.stringify(
-            input.selectSubSets ?? [],
-          )}') as x(value varchar, target float8, fpf float8,
-                    prop float8)
-        )
         SELECT distinct fpkv.feature_data_id,
                         fpkv.key,
-                        fpkv.value,
-                        subsets.fpf,
-                        subsets.prop,
-                        subsets.target
+                        fpkv.value
         from feature_properties_kv fpkv
-               left join subsets
-                         on trim('"' FROM fpkv.value::TEXT) = trim('"' FROM subsets
-                           .sub_value::text)
-        where fpkv.feature_id = ${fields.featureId}
-          and fpkv.key = ${fields.splitByProperty} ${
-      hasSubSetFilter
-        ? `and fpkv.value IN(${fields.filterByValues
-            .map((e) => `(select to_jsonb(${e}::text))`)
-            .join(',')})`
-        : ``
-    }
+          where fpkv.feature_id = ${fields.baseFeatureId}
+          and fpkv.key = ${fields.splitByProperty}
+          ${
+            fields.filterByValue
+              ? `and fpkv.value = (select to_jsonb(${fields.filterByValue}::text))`
+              : ``
+          }
       )
       select fd.id,
+            ${fields.apiFeatureId},
              ${fields.scenarioId},
              ${fields.specificationId},
-             split.fpf,
-             split.target,
-             split.prop,
+             ${fields.fpf},
+             ${fields.target},
+             ${fields.prop},
              ${fields.totalArea},
              ${fields.protectedArea}
       from split
              join features_data as fd
                   on (split.feature_data_id = fd.id)
         ${planningAreaJoin} ${protectedAreaJoin}
-      where st_intersects(st_makeenvelope( ${fields.bbox[0]}
-          , ${fields.bbox[1]}
-          , ${fields.bbox[2]}
-          , ${fields.bbox[3]}
-          , 4326
-        )
-          , fd.the_geom)
+        where st_intersects(ST_MakeEnvelope(${fields.westBbox
+          .map((coordinate) => coordinate)
+          .join(',')}, 4326), fd.the_geom)
+        or st_intersects(ST_MakeEnvelope(${fields.eastBbox
+          .map((coordinate) => coordinate)
+          .join(',')}, 4326), fd.the_geom)
         returning sfp.id as id;
     `;
     return { parameters, query };

--- a/api/apps/api/test/integration/split-query.service.e2e-spec.ts
+++ b/api/apps/api/test/integration/split-query.service.e2e-spec.ts
@@ -1,0 +1,277 @@
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getEntityManagerToken, getRepositoryToken } from '@nestjs/typeorm';
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import { bootstrapApplication } from '../utils/api-application';
+import { v4 } from 'uuid';
+import { GivenProjectExists } from '../steps/given-project';
+import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
+import { EntityManager, In, Repository } from 'typeorm';
+import { JobStatus } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { SplitQuery } from '@marxan-api/modules/scenarios-features/split';
+import { SingleSplitConfigFeatureValueWithId } from '@marxan-api/modules/scenarios-features/split/split-create-features.service';
+import { FeatureSubSet, SpecificationOperation } from '@marxan/specification';
+import { Project } from '@marxan-api/modules/projects/project.api.entity';
+import { GivenScenarioExists } from '../steps/given-scenario-exists';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { GeoFeatureGeometry, GeometrySource } from '@marxan/geofeatures';
+import { Polygon } from 'geojson';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+}, 30_000);
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+it('does not link split feature when value in subset does not match any possible values', async () => {
+  const subset = fixtures.GivenSubSetWithWrongSubsetValue();
+  const { projectId, scenarioId } = await fixtures.GivenScenarioExist();
+  const baseFeatureId = await fixtures.GivenBaseFeature();
+  const splitFeature = await fixtures.GivenASplitFeature(
+    baseFeatureId,
+    projectId,
+    subset,
+  );
+  const linkingQueryAndParams = await fixtures.WhenLinkingASplitingAFeature(
+    projectId,
+    scenarioId,
+    splitFeature,
+  );
+
+  await fixtures.ThenNoSplitFeatureIsLinked(linkingQueryAndParams);
+});
+
+it('links a feature when subset is specified', async () => {
+  const subset = fixtures.GivenSubSetWithCorrectValue();
+  const { projectId, scenarioId } = await fixtures.GivenScenarioExist();
+  const baseFeatureId = await fixtures.GivenBaseFeature();
+  const splitFeature = await fixtures.GivenASplitFeature(
+    baseFeatureId,
+    projectId,
+    subset,
+  );
+  const linkingQueryAndParams = await fixtures.WhenLinkingASplitingAFeature(
+    projectId,
+    scenarioId,
+    splitFeature,
+  );
+
+  await fixtures.ThenSplitFeatureIsLinked(linkingQueryAndParams, splitFeature);
+});
+
+it('links a feature when no subset is specified', async () => {
+  const subset = fixtures.GivenNoSubSet();
+  const { projectId, scenarioId } = await fixtures.GivenScenarioExist();
+  const baseFeatureId = await fixtures.GivenBaseFeature();
+  const splitFeature = await fixtures.GivenASplitFeature(
+    baseFeatureId,
+    projectId,
+    subset,
+  );
+  const linkingQueryAndParams = await fixtures.WhenLinkingASplitingAFeature(
+    projectId,
+    scenarioId,
+    splitFeature,
+  );
+
+  await fixtures.ThenSplitFeatureIsLinked(linkingQueryAndParams, splitFeature);
+});
+
+async function getFixtures() {
+  const app = await bootstrapApplication();
+
+  const sut = app.get(SplitQuery);
+  const featuresRepo: Repository<GeoFeature> = app.get(
+    getRepositoryToken(GeoFeature),
+  );
+  const projectsRepo: Repository<Project> = app.get(
+    getRepositoryToken(Project),
+  );
+  const featuresDataRepo: Repository<GeoFeatureGeometry> = app.get(
+    getRepositoryToken(GeoFeatureGeometry, DbConnections.geoprocessingDB),
+  );
+  const geoEntityManager: EntityManager = app.get(
+    getEntityManagerToken(DbConnections.geoprocessingDB),
+  );
+
+  const token = await GivenUserIsLoggedIn(app);
+  let projectId: string;
+  let cleanupProject: () => Promise<void>;
+  let baseFeatureId: string;
+  let scenarioFeaturesPreparationIds: { id: string }[];
+
+  const splitByProperty = 'key 1';
+  const splitValue = 'value 1';
+  const polygon: Polygon = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 1],
+        [1, 1],
+        [1, 0],
+        [0, 0],
+        [0, 1],
+      ],
+    ],
+  };
+
+  return {
+    cleanup: async () => {
+      await cleanupProject();
+      await featuresRepo.delete({ id: baseFeatureId });
+      await featuresRepo.delete({ projectId });
+      await featuresDataRepo.delete({ featureId: baseFeatureId });
+      if (scenarioFeaturesPreparationIds.length)
+        await geoEntityManager
+          .createQueryBuilder()
+          .delete()
+          .from('scenario_features_preparation')
+          .where('id IN (:...ids)', {
+            ids: scenarioFeaturesPreparationIds.map(({ id }) => id),
+          })
+          .execute();
+    },
+    GivenSubSetWithCorrectValue: () => {
+      return { value: splitValue, fpf: 0.3, prop: 0.7, target: 20 };
+    },
+    GivenSubSetWithWrongSubsetValue: () => {
+      return { value: 'random value', fpf: 0.3, prop: 0.7, target: 20 };
+    },
+    GivenNoSubSet: () => {
+      return undefined;
+    },
+    GivenScenarioExist: async () => {
+      const project = await GivenProjectExists(app, token);
+      cleanupProject = project.cleanup;
+      projectId = project.projectId;
+      await projectsRepo.save({
+        id: projectId,
+        bbox: [200.0, -200.0, 200.0, -200.0],
+      });
+      const scenario = await GivenScenarioExists(app, projectId, token);
+      return { projectId, scenarioId: scenario.id };
+    },
+    GivenBaseFeature: async () => {
+      const baseFeature = await featuresRepo.save({
+        id: v4(),
+        featureClassName: 'base feature',
+        creationStatus: JobStatus.created,
+      });
+      baseFeatureId = baseFeature.id;
+      const featureDataId = v4();
+
+      await geoEntityManager
+        .createQueryBuilder()
+        .insert()
+        .into('features_data')
+        .values({
+          id: featureDataId,
+          featureId: baseFeatureId,
+          properties: {
+            [splitByProperty]: splitValue,
+            'other-key': splitValue,
+          },
+          source: GeometrySource.user_imported,
+          theGeom: () =>
+            `st_multi(ST_GeomFromGeoJSON('${JSON.stringify(polygon)}'))`,
+        })
+        .execute();
+
+      return baseFeatureId;
+    },
+    GivenASplitFeature: async (
+      baseFeatureId: string,
+      projectId: string,
+      subset?: FeatureSubSet,
+    ): Promise<SingleSplitConfigFeatureValueWithId> => {
+      const splitFeature = {
+        id: v4(),
+        singleSplitFeature: {
+          baseFeatureId,
+          operation: SpecificationOperation.Split as SpecificationOperation.Split,
+          splitByProperty,
+          subset,
+        },
+      };
+      await featuresRepo.save({
+        id: splitFeature.id,
+        featureClassName: `base feature / ${splitByProperty} ${
+          subset ? `:${subset.value}` : ``
+        }`,
+        creationStatus: JobStatus.created,
+        fromGeoprocessingOps: splitFeature.singleSplitFeature,
+        projectId,
+      });
+
+      return splitFeature;
+    },
+    WhenLinkingASplitingAFeature: async (
+      projectId: string,
+      scenarioId: string,
+      splitFeature: SingleSplitConfigFeatureValueWithId,
+    ) => {
+      const [project] = await projectsRepo.find({ id: projectId });
+      if (!project) throw new Error('project should be defined');
+      return sut.prepareQuery(
+        splitFeature,
+        scenarioId,
+        v4(),
+        undefined,
+        [],
+        project,
+      );
+    },
+    ThenSplitFeatureIsLinked: async (
+      linkingQueryAndParams: {
+        parameters: (string | number)[];
+        query: string;
+      },
+      splitFeature: SingleSplitConfigFeatureValueWithId,
+    ) => {
+      scenarioFeaturesPreparationIds = await geoEntityManager.query(
+        linkingQueryAndParams.query,
+        linkingQueryAndParams.parameters,
+      );
+
+      expect(scenarioFeaturesPreparationIds).toHaveLength(1);
+
+      const scenarioFeaturesPreparationInserted: {
+        id: string;
+        api_feature_id: string;
+        fpf: number;
+        target: number;
+        prop: number;
+      }[] = await geoEntityManager
+        .createQueryBuilder()
+        .select(['api_feature_id', 'fpf', 'target', 'prop'])
+        .from('scenario_features_preparation', 'sfp')
+        .where('id IN (:...ids)', {
+          ids: scenarioFeaturesPreparationIds.map(({ id }) => id),
+        })
+        .execute();
+
+      expect(scenarioFeaturesPreparationInserted).toHaveLength(1);
+
+      const scenarioFeaturePreparation = scenarioFeaturesPreparationInserted[0];
+
+      expect(scenarioFeaturePreparation).toEqual({
+        api_feature_id: splitFeature.id,
+        ...splitFeature.singleSplitFeature.subset,
+      });
+    },
+    ThenNoSplitFeatureIsLinked: async (linkingQueryAndParams: {
+      parameters: (string | number)[];
+      query: string;
+    }) => {
+      scenarioFeaturesPreparationIds = await geoEntityManager.query(
+        linkingQueryAndParams.query,
+        linkingQueryAndParams.parameters,
+      );
+
+      expect(scenarioFeaturesPreparationIds).toHaveLength(0);
+    },
+  };
+}

--- a/api/apps/api/test/integration/split-query.service.e2e-spec.ts
+++ b/api/apps/api/test/integration/split-query.service.e2e-spec.ts
@@ -257,9 +257,12 @@ async function getFixtures() {
 
       const scenarioFeaturePreparation = scenarioFeaturesPreparationInserted[0];
 
+      const subset = splitFeature.singleSplitFeature.subset;
       expect(scenarioFeaturePreparation).toEqual({
         api_feature_id: splitFeature.id,
-        ...splitFeature.singleSplitFeature.subset,
+        fpf: subset ? subset.fpf : null,
+        prop: subset ? subset.prop : null,
+        target: subset ? subset.target : null,
       });
     },
     ThenNoSplitFeatureIsLinked: async (linkingQueryAndParams: {


### PR DESCRIPTION
This PR adds api feature id to split query. Also, now, split query is performed once per each split feature.

### Feature relevant tickets

[api: set apiFeatureId in `SplitQuery.prepareQuery`](https://vizzuality.atlassian.net/browse/MARXAN-1682)

