### PR TITLE
feat: remove stratification option from SpecFromGeoFeatureWithGeoproc…

### DIFF
--- a/api/apps/api/src/modules/geo-features/dto/geo-feature-set-specification.dto.ts
+++ b/api/apps/api/src/modules/geo-features/dto/geo-feature-set-specification.dto.ts
@@ -33,6 +33,13 @@ export class SpecForPlainGeoFeatureWithFeatureMetadata extends SpecForPlainGeoFe
   metadata!: GeoFeature;
 }
 
+/**
+ * Stratification operations are not accepted right now, in case an stratification operation
+ * is submitted in geoprocessingOperations array, the validation will fail. Despite that,
+ * the signature for geoprocessingOperations array still contains Stratification operations,
+ * this is due to the fact that we don't want to remove the work already done for stratification
+ * operations
+ */
 export class SpecForGeoFeatureWithGeoprocessing extends SpecForGeofeature {
   @Equals('withGeoprocessing')
   kind!: 'withGeoprocessing';
@@ -46,10 +53,7 @@ export class SpecForGeoFeatureWithGeoprocessing extends SpecForGeofeature {
     keepDiscriminatorProperty: true,
     discriminator: {
       property: 'kind',
-      subTypes: [
-        { value: GeoprocessingOpSplitV1, name: 'split/v1' },
-        { value: GeoprocessingOpStratificationV1, name: 'stratification/v1' },
-      ],
+      subTypes: [{ value: GeoprocessingOpSplitV1, name: 'split/v1' }],
     },
   })
   @ApiPropertyOptional()


### PR DESCRIPTION
This PR removes from `SpecForGeoFeatureWithGeoprocessing` the option to pass stratification operations in `geoprocessingOperations` array, son in case a stratification operation is passed the validation will fail ( the signature of `geoprocessingOperations` array still accepts stratification operations so we don't have to delete the code already done for stratification operations, as there are dependencies between the `DTO` and other parts of the application)

### Feature relevant tickets
[backend: remove stratification option from GeoFeatureSetSpecification](https://vizzuality.atlassian.net/browse/MARXAN-1677)
