### PR TITLE
feat: identify expired resources in exports table [MARXAN-1649]

### DIFF
--- a/api/apps/api/config/default.json
+++ b/api/apps/api/config/default.json
@@ -63,7 +63,8 @@
       "localPath": "/tmp/storage"
     },
     "cloningFileStorage": {
-      "localPath": "/opt/marxan-project-cloning"
+      "localPath": "/opt/marxan-project-cloning",
+      "artifactValidityInHours": 168
     }
   },
   "marxan": {

--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -39,6 +39,7 @@ import { CloneModule } from './modules/clone';
 import { ApiCloningFilesRepositoryModule } from './modules/cloning-file-repository/api-cloning-file-repository.module';
 import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-collector';
 import { ExportCleanupModule } from './modules/export-cleanup/export-cleanup.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { ExportCleanupModule } from './modules/export-cleanup/export-cleanup.mod
     AsyncJobsGarbageCollectorModule,
     ThrottlerModule.forRoot(),
     ExportCleanupModule,
+    ScheduleModule.forRoot(),
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -38,6 +38,7 @@ import { AccessControlModule } from '@marxan-api/modules/access-control';
 import { CloneModule } from './modules/clone';
 import { ApiCloningFilesRepositoryModule } from './modules/cloning-file-repository/api-cloning-file-repository.module';
 import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-collector';
+import { ExportCleanupModule } from './modules/export-cleanup/export-cleanup.module';
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-co
     CloneModule,
     AsyncJobsGarbageCollectorModule,
     ThrottlerModule.forRoot(),
+    ExportCleanupModule,
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/apps/api/src/modules/export-cleanup/export-cleanup.module.ts
+++ b/api/apps/api/src/modules/export-cleanup/export-cleanup.module.ts
@@ -1,0 +1,11 @@
+import { apiConnections } from '@marxan-api/ormconfig';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ExportCleanupService } from './export-cleanup.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([], apiConnections.default)],
+  providers: [ExportCleanupService],
+  exports: [ExportCleanupService],
+})
+export class ExportCleanupModule {}

--- a/api/apps/api/src/modules/export-cleanup/export-cleanup.service.ts
+++ b/api/apps/api/src/modules/export-cleanup/export-cleanup.service.ts
@@ -5,7 +5,6 @@ import { EntityManager } from 'typeorm';
 import { ExportCleanup } from './export-cleanup';
 import { apiConnections } from '@marxan-api/ormconfig';
 import { AppConfig } from '@marxan-api/utils/config.utils';
-import { execSync } from 'child_process';
 
 const validityIntervalInHours = AppConfig.get<string>(
   'storage.cloningFileStorage.artifactValidityInHours',
@@ -23,8 +22,8 @@ export class ExportCleanupService implements ExportCleanup {
     const expiredProjectExportsIds = await this.apiEntityManager.query(`
       SELECT e.id FROM exports e
         WHERE e.resource_kind = 'project' AND 
-        WHERE e.created_at > NOW() - INTERVAL ${validityIntervalInHours} HOUR) AND
-        WHERE e.resource_id NOT IN (SELECT id FROM published_projects);
+        (AGE(NOW(), e.created_at) <  INTERVAL ${validityIntervalInHours} HOUR OR
+        e.resource_id NOT IN (SELECT id FROM published_projects));
     `);
 
     const expiredScenarioExportsIds = await this.apiEntityManager.query(`
@@ -49,7 +48,5 @@ export class ExportCleanupService implements ExportCleanup {
     );
 
     const expiredResourcesIds = await this.identifyExpiredResources();
-
-    // await this.deleteExpiredResources(expiredResourcesIds);
   }
 }

--- a/api/apps/api/src/modules/export-cleanup/export-cleanup.service.ts
+++ b/api/apps/api/src/modules/export-cleanup/export-cleanup.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { EntityManager } from 'typeorm';
 import { ExportCleanup } from './export-cleanup';
@@ -7,9 +7,6 @@ import { apiConnections } from '@marxan-api/ormconfig';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { execSync } from 'child_process';
 
-const cronJobInterval: string = AppConfig.get(
-  'cleanupCronJobSettings.interval',
-);
 const validityIntervalInHours = AppConfig.get<string>(
   'storage.cloningFileStorage.artifactValidityInHours',
 );
@@ -45,7 +42,7 @@ export class ExportCleanupService implements ExportCleanup {
     return uniqueExpiredExportIds;
   }
 
-  @Cron(cronJobInterval)
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async handleCron() {
     this.logger.debug(
       'Preparing to clean dangling import/export data for projects/scenarios',

--- a/api/apps/api/src/modules/export-cleanup/export-cleanup.service.ts
+++ b/api/apps/api/src/modules/export-cleanup/export-cleanup.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+import { ExportCleanup } from './export-cleanup';
+import { apiConnections } from '@marxan-api/ormconfig';
+import { AppConfig } from '@marxan-api/utils/config.utils';
+import { execSync } from 'child_process';
+
+const cronJobInterval: string = AppConfig.get(
+  'cleanupCronJobSettings.interval',
+);
+const validityIntervalInHours = AppConfig.get<string>(
+  'storage.cloningFileStorage.artifactValidityInHours',
+);
+
+@Injectable()
+export class ExportCleanupService implements ExportCleanup {
+  private readonly logger = new Logger(ExportCleanupService.name);
+  constructor(
+    @InjectEntityManager(apiConnections.default)
+    private readonly apiEntityManager: EntityManager,
+  ) {}
+
+  async identifyExpiredResources() {
+    const expiredProjectExportsIds = await this.apiEntityManager.query(`
+      SELECT e.id FROM exports e
+        WHERE e.resource_kind = 'project' AND 
+        WHERE e.created_at > NOW() - INTERVAL ${validityIntervalInHours} HOUR) AND
+        WHERE e.resource_id NOT IN (SELECT id FROM published_projects);
+    `);
+
+    const expiredScenarioExportsIds = await this.apiEntityManager.query(`
+      SELECT e.id FROM exports e
+        WHERE e.resource_kind = 'scenario';
+    `);
+
+    const uniqueExpiredExportIds: string[] = [
+      ...expiredProjectExportsIds,
+      expiredScenarioExportsIds,
+    ]
+      .filter((item, pos, self) => self.indexOf(item) == pos)
+      .sort();
+
+    return uniqueExpiredExportIds;
+  }
+
+  @Cron(cronJobInterval)
+  async handleCron() {
+    this.logger.debug(
+      'Preparing to clean dangling import/export data for projects/scenarios',
+    );
+
+    const expiredResourcesIds = await this.identifyExpiredResources();
+
+    // await this.deleteExpiredResources(expiredResourcesIds);
+  }
+}

--- a/api/apps/api/src/modules/export-cleanup/export-cleanup.ts
+++ b/api/apps/api/src/modules/export-cleanup/export-cleanup.ts
@@ -1,0 +1,3 @@
+export abstract class ExportCleanup {
+  abstract handleCron(): Promise<void>;
+}


### PR DESCRIPTION
- Adds ExportCleanup module and service to API.
- Adds config interval to check for validity of creation of exports.
- Adds job that identifies expired exports based on time, its presence on the `published_projects` table and the scenario exports.