### PR TITLE
feat(front): legacy project validations + solutions locked[MARXAN-1693]

### DIFF
--- a/app/layout/projects/all/toolbar/upload-btn/legacy-upload-modal/upload-files/component.tsx
+++ b/app/layout/projects/all/toolbar/upload-btn/legacy-upload-modal/upload-files/component.tsx
@@ -60,6 +60,7 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
   useEffect(() => {
     if (legacyDone) {
       queryClient.invalidateQueries('projects');
+      queryClient.invalidateQueries(['scenarios', legacyProjectId]);
       onDismiss(true);
       setLoading(false);
       addToast('success-import-legacy-project', (
@@ -72,6 +73,7 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
       });
     }
   }, [
+    legacyProjectId,
     legacyDone,
     queryClient,
     addToast,

--- a/app/layout/projects/all/toolbar/upload-btn/legacy-upload-modal/upload-files/component.tsx
+++ b/app/layout/projects/all/toolbar/upload-btn/legacy-upload-modal/upload-files/component.tsx
@@ -1,8 +1,9 @@
 import React, {
-  useCallback, useRef, useState,
+  useCallback, useEffect, useRef, useState,
 } from 'react';
 
 import { Field as FieldRFF, Form as FormRFF } from 'react-final-form';
+import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { setLegacyProjectId } from 'store/slices/projects/new';
@@ -39,6 +40,8 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
   const dispatch = useDispatch();
   const { legacyProjectId } = useSelector((state) => state['/projects/new']);
 
+  const queryClient = useQueryClient();
+
   const cancelLegacyProjectMutation = useCancelImportLegacyProject({});
   const legacyProjectValidationResultsMutation = useLegacyProjectValidationResults({});
 
@@ -46,12 +49,58 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
 
   const ref = useRef(null);
 
-  const { data: scenarioStatusData } = useScenariosStatus(legacyProjectId);
+  const {
+    data: scenarioStatusData,
+    isError: scenarioStatusDataIsError,
+  } = useScenariosStatus(legacyProjectId);
   const { jobs = [] } = scenarioStatusData || {};
-
-  const legacyRunning = jobs.find((j) => j.kind === 'legacy')?.status === 'running';
+  const legacyFailure = jobs.find((j) => j.kind === 'legacy')?.status === 'failure';
   const legacyDone = jobs.find((j) => j.kind === 'legacy')?.status === 'done';
-  console.info('legacyRunning', legacyRunning, 'legacyDone', legacyDone);
+
+  useEffect(() => {
+    if (legacyDone) {
+      queryClient.invalidateQueries('projects');
+      onDismiss(true);
+      setLoading(false);
+      addToast('success-import-legacy-project', (
+        <>
+          <h2 className="font-medium">Success!</h2>
+          <p className="text-sm">Legacy project import has been done</p>
+        </>
+      ), {
+        level: 'success',
+      });
+    }
+  }, [
+    legacyDone,
+    queryClient,
+    addToast,
+    onDismiss,
+  ]);
+
+  useEffect(() => {
+    if (legacyFailure || scenarioStatusDataIsError) {
+      legacyProjectValidationResultsMutation.mutate({ projectId: legacyProjectId }, {
+        onSuccess: ({ errorsAndWarnings }) => {
+          if (errorsAndWarnings && errorsAndWarnings.length) {
+            const errors = errorsAndWarnings.filter((vr) => vr.status === 'failed').map((vr) => vr.errors);
+            setLoading(false);
+            setImportLegacyErrors(errors);
+            ref?.current?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+          }
+        },
+        onError: ({ response }) => {
+          const { errors } = response.data;
+          console.info(errors);
+          setLoading(false);
+        },
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    legacyFailure,
+    scenarioStatusDataIsError,
+  ]);
 
   const onCancelImportLegacyProject = useCallback(() => {
     cancelLegacyProjectMutation.mutate({ projectId: legacyProjectId }, {
@@ -73,36 +122,6 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
 
     importLegacyMutation.mutate({ projectId: legacyProjectId, data }, {
       onSuccess: () => {
-        legacyProjectValidationResultsMutation.mutate({ projectId: legacyProjectId }, {
-          onSuccess: ({ errorsAndWarnings }) => {
-            if (errorsAndWarnings && errorsAndWarnings.length) {
-              const errors = errorsAndWarnings.filter((vr) => vr.status === 'failed').map((vr) => vr.errors);
-              setLoading(false);
-              setImportLegacyErrors(errors);
-              ref?.current?.scrollIntoView({ block: 'start', behavior: 'smooth' });
-            } else {
-              addToast('success-import-legacy-project', (
-                <>
-                  <h2 className="font-medium">Success!</h2>
-                  <p className="text-sm">Legacy project import has been done</p>
-                </>
-              ), {
-                level: 'success',
-              });
-
-              if (legacyDone) {
-                onDismiss(true);
-                console.info('Legacy project uploaded');
-                setLoading(false);
-              }
-            }
-          },
-          onError: ({ response }) => {
-            const { errors } = response.data;
-            console.info(errors);
-            setLoading(false);
-          },
-        });
       },
       onError: ({ response }) => {
         const { errors } = response.data;
@@ -125,10 +144,7 @@ export const UploadFiles: React.FC<UploadFilesProps> = ({
   }, [
     legacyProjectId,
     addToast,
-    onDismiss,
     importLegacyMutation,
-    legacyProjectValidationResultsMutation,
-    legacyDone,
   ]);
 
   return (

--- a/app/layout/projects/show/status/actions/done.tsx
+++ b/app/layout/projects/show/status/actions/done.tsx
@@ -6,11 +6,11 @@ import { useQueryClient } from 'react-query';
 
 import { useRouter } from 'next/router';
 
-import { ScenarioSidebarTabs } from 'utils/tabs';
-import { mergeScenarioStatusMetaData } from 'utils/utils-scenarios';
+// import { ScenarioSidebarTabs } from 'utils/tabs';
+// import { mergeScenarioStatusMetaData } from 'utils/utils-scenarios';
 
 import { useSaveProject } from 'hooks/projects';
-import { useScenarios, useSaveScenario } from 'hooks/scenarios';
+// import { useScenarios, useSaveScenario } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 
 export const useProjectActionsDone = () => {
@@ -21,17 +21,17 @@ export const useProjectActionsDone = () => {
 
   const { addToast } = useToasts();
 
-  const { data: scenariosData } = useScenarios(pid, {
-    filters: {
-      projectId: pid,
-    },
-  });
+  // const { data: scenariosData } = useScenarios(pid, {
+  //   filters: {
+  //     projectId: pid,
+  //   },
+  // });
 
-  const scenarioMutation = useSaveScenario({
-    requestConfig: {
-      method: 'PATCH',
-    },
-  });
+  // const scenarioMutation = useSaveScenario({
+  //   requestConfig: {
+  //     method: 'PATCH',
+  //   },
+  // });
 
   const projectMutation = useSaveProject({
     requestConfig: {
@@ -102,45 +102,6 @@ export const useProjectActionsDone = () => {
         JOB_REF.current = null;
         queryClient.invalidateQueries('projects');
         queryClient.invalidateQueries(['scenarios', pid]);
-
-        // Save metadata from scenario to prevent changing the tab whe you first load the scenario
-        const [scenario] = scenariosData;
-        const { id: sid } = scenario;
-
-        // Let's talk with backend because this is something that should do the BE in the async jobs
-        scenarioMutation.mutate({
-          id: `${sid}`,
-          data: {
-            metadata: mergeScenarioStatusMetaData({
-              scenarioEditingMetadata: {
-                status: {
-                  'planning-unit': 'draft',
-                  features: 'draft',
-                  parameters: 'draft',
-                  solutions: 'draft',
-                },
-                tab: ScenarioSidebarTabs.SOLUTIONS,
-                subtab: null,
-              },
-            }, {
-              tab: ScenarioSidebarTabs.SOLUTIONS,
-              subtab: null,
-            }),
-          },
-        }, {
-          onSuccess: () => {
-
-          },
-          onError: () => {
-            addToast('onRunError', (
-              <>
-                <h2 className="font-medium">Error!</h2>
-              </>
-            ), {
-              level: 'error',
-            });
-          },
-        });
       },
       onError: () => {
         addToast('onDone', (
@@ -152,7 +113,13 @@ export const useProjectActionsDone = () => {
         });
       },
     });
-  }, [pid, projectMutation, scenarioMutation, addToast, queryClient, scenariosData]);
+  }, [
+    pid,
+    projectMutation,
+    addToast,
+    queryClient,
+    // scenariosData,
+  ]);
 
   return {
     default: onDone,

--- a/app/layout/scenarios/edit/parameters/component.tsx
+++ b/app/layout/scenarios/edit/parameters/component.tsx
@@ -60,7 +60,7 @@ export const ScenariosSidebarEditAnalysis: React.FC<ScenariosSidebarEditAnalysis
   const { data: projectData } = useProject(pid);
 
   const { data: scenarioData } = useScenario(sid);
-  const { metadata } = scenarioData || {};
+  const { metadata, solutionsAreLocked } = scenarioData || {};
   const { marxanInputParameterFile: runSettings, scenarioEditingMetadata } = metadata || {};
 
   const saveScenarioMutation = useSaveScenario({
@@ -230,6 +230,7 @@ export const ScenariosSidebarEditAnalysis: React.FC<ScenariosSidebarEditAnalysis
                 <Button
                   theme="spacial"
                   size="lg"
+                  disabled={solutionsAreLocked}
                   onClick={onRunScenario}
                 >
                   Run scenario


### PR DESCRIPTION
## Legacy project validations and solutions locked

### Overview

This PR adds the functionality so that it is possible to close the modal that is used to upload legacy projects in the event that the import is going to be executed correctly, or that validation errors are displayed in the event that the files are incorrect.

It also disables the Run Scenario button in case the option has been checked when uploading the legacy project.

**IMPORTANT:** The `useScenariosStatus` polling is not fast enough for the "_legacy_" job to return a "_failure_" status before the project has been deleted, so the solution adopted has been to add a `useEffect` to read the validations in case `useScenarioStatus` returns an error or the status of the job is failure. This is not optimal, since `useScenarioStatus` could fail for another reason.

### Testing instructions

1. Please create a legacy project with the attached files in JIRA. Check "_Do you want to lock these results calculated outside of the Marxan MaPP platform?_"

Once created check:
- The modal closes when the import is finished.
- The main project list is updated with the new project.
- If I navigate to parameters, the Run Scenario button is disabled.

2. Please create a legacy project with the files in the wrong place.

Once created check:
- When the loader ends, the modal scrolls up and one or more errors are shown in red. 

### Feature relevant tickets

[MARXAN-1696](https://vizzuality.atlassian.net/browse/MARXAN-1696)
