### PR TITLE
fix: filter values in split query service

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/split/split-query.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-query.service.ts
@@ -90,7 +90,7 @@ export class SplitQuery {
           and fpkv.key = ${fields.splitByProperty}
           ${
             fields.filterByValue
-              ? `and fpkv.value = (select to_jsonb(${fields.filterByValue}::text))`
+              ? `and trim('"' FROM fpkv.value::text) = trim('"' FROM ${fields.filterByValue}::text)`
               : ``
           }
       )


### PR DESCRIPTION
This PRs fixes the way we are filtering values in split query service. When uploading [feature](https://github.com/marxan-cloud/tnc-training-bots/blob/main/2022-03_okavango/geo-data/features/species/Syncerus_caffer.zip), values are of type numerical so the filtering was not working.

### Feature relevant tickets

