### PR TITLE
feat: set planning unit grid shape on legacy projects

### DIFF
--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/planning-grid.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/planning-grid.legacy-piece-importer.ts
@@ -179,6 +179,7 @@ export class PlanningGridLegacyProjectPieceImporter
       .createQueryBuilder()
       .update('projects')
       .set({
+        planning_unit_grid_shape: PlanningUnitGridShape.FromShapefile,
         planning_area_geometry_id: planningAreaId,
         bbox: JSON.stringify(bbox),
       })

--- a/api/apps/geoprocessing/test/integration/legacy-project-import/planning-grid.legacy-piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/legacy-project-import/planning-grid.legacy-piece-importer.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
   LegacyProjectImportPiece,
 } from '@marxan/legacy-project-import';
 import { PlanningArea } from '@marxan/planning-area-repository/planning-area.geo.entity';
+import { PlanningUnitGridShape } from '@marxan/scenarios-planning-unit';
 import { ShapefileService } from '@marxan/shapefile-converter';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
 import { Logger } from '@nestjs/common';
@@ -31,6 +32,7 @@ import {
 type ProjectSelectResult = {
   planning_area_geometry_id: string;
   bbox: string;
+  planning_unit_grid_shape: PlanningUnitGridShape;
 };
 
 let fixtures: FixtureType<typeof getFixtures>;
@@ -306,6 +308,9 @@ const getFixtures = async () => {
 
           expect(project.bbox).toBeDefined();
           expect(project.planning_area_geometry_id).toBeDefined();
+          expect(project.planning_unit_grid_shape).toBe(
+            PlanningUnitGridShape.FromShapefile,
+          );
 
           const expectedLength = validGeojson.features.length;
 


### PR DESCRIPTION
This PR sets on legacy project projects planning unit grid shape to `PlanningUnitGridShape.FromShapefile` 

### Feature relevant tickets

[Legacy projects does not have planning_unit_grid_shape](https://vizzuality.atlassian.net/browse/MARXAN-1705)
