### PR TITLE
feat: calculate project and scenario blm values before running legacy…

### DIFF
--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -139,6 +139,7 @@ import {
 } from './dto/legacy-project-import.dto';
 import { deleteProjectFailed } from './delete-project/delete-project.command';
 import { updateSolutionsAreLockFailed } from '../legacy-project-import/application/update-solutions-are-locked-to-legacy-project-import.command';
+import { blmCreationFailure } from '../scenarios/blm-calibration/create-initial-scenario-blm.command';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -291,6 +292,7 @@ export class ProjectsController {
           );
         case legacyProjectImportSaveError:
         case updateSolutionsAreLockFailed:
+        case blmCreationFailure:
         default:
           throw new InternalServerErrorException();
       }

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -42,6 +42,7 @@ import { ExportRepository } from '../clone/export/application/export-repository.
 import { TypeormExportRepository } from '../clone/export/adapters/typeorm-export.repository';
 import { LegacyProjectImportModule } from '../legacy-project-import/legacy-project-import.module';
 import { DeleteProjectModule } from './delete-project/delete-project.module';
+import { LegacyProjectImportRepositoryModule } from '../legacy-project-import/infra/legacy-project-import.repository.module';
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { DeleteProjectModule } from './delete-project/delete-project.module';
     BlockGuardModule,
     ProjectCheckerModule,
     DeleteProjectModule,
+    LegacyProjectImportRepositoryModule,
   ],
   providers: [
     ProjectsCrudService,


### PR DESCRIPTION
This PR adds two new steps before running a legacy import:

- Before running, first we will send `SetProjectBlm` command.
- After sending `SetProjectBlm` command, we will send `CreateInitialScenarioBlm` command.


### Feature relevant tickets

[Legacy project does not have project blm values](https://vizzuality.atlassian.net/browse/MARXAN-1703)
[Legacy projects does not have scenario blm values](https://vizzuality.atlassian.net/browse/MARXAN-1704)

