### PR TITLE
feat(front): Features Split 2

### DIFF
--- a/app/components/features/selected-item/component.tsx
+++ b/app/components/features/selected-item/component.tsx
@@ -216,7 +216,7 @@ export const Item: React.FC<ItemProps> = ({
           </div>
         </div>
 
-        {split && (splitSelected || splitOpen) && (
+        {split && splitOpen && (
           <div>
             <div className="flex items-center mt-3 space-x-2 tracking-wide font-heading">
               <h4 className="text-white uppercase text-xxs">
@@ -330,7 +330,7 @@ export const Item: React.FC<ItemProps> = ({
         )}
       </header>
 
-      {splitSelected && split && (
+      {splitSelected && split && splitOpen && (
         <ul className="pl-3">
           {splitFeaturesOptions.map((f) => {
             const checked = !splitFeaturesSelected.length

--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import chroma from 'chroma-js';
+
 import Icon from 'components/icon';
 
 import HEXAGON_SVG from 'svgs/map/hexagon.svg?sprite';
@@ -10,56 +12,6 @@ export const COLORS = {
   'features-preview': {
     default: '#FFCC00',
     hover: '#FF9900',
-    items: {
-      '#e0e681': ['00'],
-      '#e1e479': ['01', '10', '11'],
-      '#e3e271': [
-        '02', '03', '04', '05',
-        '12', '13', '14', '15',
-      ],
-      '#e4df69': [
-        '06', '07', '08', '09', '010',
-        '16', '17', '18', '19', '110',
-      ],
-      '#e6dd61': [
-        '20', '30', '40', '50',
-        '21', '31', '41', '51',
-      ],
-      '#e8da58': [
-        '60', '70', '80', '90', '100',
-        '61', '71', '81', '91', '101',
-      ],
-      '#ebd84f': [
-        '22', '23', '24', '25',
-        '32', '33', '34', '35',
-        '42', '43', '44', '45',
-        '52', '53', '54', '55',
-      ],
-      '#edd546': [
-        '26', '27', '28', '29', '210',
-        '36', '37', '38', '39', '310',
-        '46', '47', '48', '49', '410',
-        '56', '57', '58', '59', '510',
-      ],
-      '#efd23d': [
-        '62', '63', '64', '65',
-        '72', '73', '74', '75',
-        '82', '83', '84', '85',
-        '92', '93', '94', '95',
-        '102', '103', '104', '105',
-      ],
-      '#f5cc27': [
-        '66', '67', '68', '69', '610',
-        '76', '77', '78', '79', '710',
-        '86', '87', '88', '89', '810',
-        '96', '97', '98',
-        '106', '107', '108',
-      ],
-      '#FFF': [
-        '99', '910',
-        '109', '1010',
-      ],
-    },
   },
   wdpa: '#00F',
   features: '#6F53F7',
@@ -128,27 +80,6 @@ export const COLORS = {
   },
 };
 
-export const FEATURES_PREVIEW_RAMP = (features) => {
-  const COLOR_NUMBER = features.length;
-  const colors = [...Array((COLOR_NUMBER + 1) * (COLOR_NUMBER + 1)).keys()];
-
-  return colors
-    .map((c, i) => {
-      const position = `${Math.floor((i / (COLOR_NUMBER + 1)) % (COLOR_NUMBER + 1))}${i % (COLOR_NUMBER + 1)}`;
-      const color = Object.keys(COLORS['features-preview'].items)
-        .reduce((acc, k) => {
-          if (COLORS['features-preview'].items[k].includes(position) && !acc) {
-            return k;
-          }
-
-          return acc;
-        }, '');
-
-      return color;
-    })
-    .flat();
-};
-
 export const LEGEND_LAYERS = {
   pugrid: () => ({
     id: 'pugrid',
@@ -194,7 +125,7 @@ export const LEGEND_LAYERS = {
       items: items.map((item, i) => {
         return {
           value: item.name,
-          color: FEATURES_PREVIEW_RAMP(items)[i],
+          color: chroma.scale(['#e0e681', '#FFF']).mode('lch').colors(items.length)[i],
         };
       }),
     };

--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -12,6 +12,7 @@ export const COLORS = {
   'features-preview': {
     default: '#FFCC00',
     hover: '#FF9900',
+    ramp: ['#e0e681', '3DF7B3', '#FFF'],
   },
   wdpa: '#00F',
   features: '#6F53F7',
@@ -125,7 +126,7 @@ export const LEGEND_LAYERS = {
       items: items.map((item, i) => {
         return {
           value: item.name,
-          color: chroma.scale(['#e0e681', '#FFF']).mode('lch').colors(items.length)[i],
+          color: chroma.scale(COLORS['features-preview'].ramp).mode('lch').colors(items.length)[i],
         };
       }),
     };

--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -109,15 +109,26 @@ export const LEGEND_LAYERS = {
     },
   }),
 
-  'features-preview': () => ({
-    id: 'features-preview',
-    name: 'Features preview',
-    icon: <Icon icon={SQUARE_SVG} className="w-3.5 h-3.5 mt-0.5 stroke-current stroke-2" style={{ color: COLORS['features-preview'].default }} />,
-    settingsManager: {
-      opacity: true,
-      visibility: true,
-    },
-  }),
+  'features-preview': (options) => {
+    const { items } = options;
+
+    return {
+      id: 'features-preview',
+      name: 'Features preview',
+      icon: <Icon icon={SQUARE_SVG} className="w-3.5 h-3.5 mt-0.5 stroke-current stroke-2" style={{ color: COLORS['features-preview'].default }} />,
+      type: 'basic',
+      settingsManager: {
+        opacity: true,
+        visibility: true,
+      },
+      items: items.map((i) => {
+        return {
+          value: i.name,
+          color: '#FFCC00',
+        };
+      }),
+    };
+  },
   features: () => ({
     id: 'features',
     name: 'Features',

--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -12,7 +12,7 @@ export const COLORS = {
   'features-preview': {
     default: '#FFCC00',
     hover: '#FF9900',
-    ramp: ['#e0e681', '3DF7B3', '#FFF'],
+    ramp: ['#C21701', '#3278B3', '3DF7B3', '#FFF'],
   },
   wdpa: '#00F',
   features: '#6F53F7',
@@ -117,7 +117,6 @@ export const LEGEND_LAYERS = {
     return {
       id: 'features-preview',
       name: 'Features preview',
-      icon: <Icon icon={SQUARE_SVG} className="w-3.5 h-3.5 mt-0.5 stroke-current stroke-2" style={{ color: COLORS['features-preview'].default }} />,
       type: 'basic',
       settingsManager: {
         opacity: true,

--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -10,6 +10,56 @@ export const COLORS = {
   'features-preview': {
     default: '#FFCC00',
     hover: '#FF9900',
+    items: {
+      '#e0e681': ['00'],
+      '#e1e479': ['01', '10', '11'],
+      '#e3e271': [
+        '02', '03', '04', '05',
+        '12', '13', '14', '15',
+      ],
+      '#e4df69': [
+        '06', '07', '08', '09', '010',
+        '16', '17', '18', '19', '110',
+      ],
+      '#e6dd61': [
+        '20', '30', '40', '50',
+        '21', '31', '41', '51',
+      ],
+      '#e8da58': [
+        '60', '70', '80', '90', '100',
+        '61', '71', '81', '91', '101',
+      ],
+      '#ebd84f': [
+        '22', '23', '24', '25',
+        '32', '33', '34', '35',
+        '42', '43', '44', '45',
+        '52', '53', '54', '55',
+      ],
+      '#edd546': [
+        '26', '27', '28', '29', '210',
+        '36', '37', '38', '39', '310',
+        '46', '47', '48', '49', '410',
+        '56', '57', '58', '59', '510',
+      ],
+      '#efd23d': [
+        '62', '63', '64', '65',
+        '72', '73', '74', '75',
+        '82', '83', '84', '85',
+        '92', '93', '94', '95',
+        '102', '103', '104', '105',
+      ],
+      '#f5cc27': [
+        '66', '67', '68', '69', '610',
+        '76', '77', '78', '79', '710',
+        '86', '87', '88', '89', '810',
+        '96', '97', '98',
+        '106', '107', '108',
+      ],
+      '#FFF': [
+        '99', '910',
+        '109', '1010',
+      ],
+    },
   },
   wdpa: '#00F',
   features: '#6F53F7',
@@ -78,6 +128,27 @@ export const COLORS = {
   },
 };
 
+export const FEATURES_PREVIEW_RAMP = (features) => {
+  const COLOR_NUMBER = features.length;
+  const colors = [...Array((COLOR_NUMBER + 1) * (COLOR_NUMBER + 1)).keys()];
+
+  return colors
+    .map((c, i) => {
+      const position = `${Math.floor((i / (COLOR_NUMBER + 1)) % (COLOR_NUMBER + 1))}${i % (COLOR_NUMBER + 1)}`;
+      const color = Object.keys(COLORS['features-preview'].items)
+        .reduce((acc, k) => {
+          if (COLORS['features-preview'].items[k].includes(position) && !acc) {
+            return k;
+          }
+
+          return acc;
+        }, '');
+
+      return color;
+    })
+    .flat();
+};
+
 export const LEGEND_LAYERS = {
   pugrid: () => ({
     id: 'pugrid',
@@ -111,7 +182,6 @@ export const LEGEND_LAYERS = {
 
   'features-preview': (options) => {
     const { items } = options;
-
     return {
       id: 'features-preview',
       name: 'Features preview',
@@ -121,10 +191,10 @@ export const LEGEND_LAYERS = {
         opacity: true,
         visibility: true,
       },
-      items: items.map((i) => {
+      items: items.map((item, i) => {
         return {
-          value: i.name,
-          color: '#FFCC00',
+          value: item.name,
+          color: FEATURES_PREVIEW_RAMP(items)[i],
         };
       }),
     };

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { COLORS, LEGEND_LAYERS } from './constants';
+import { COLORS, LEGEND_LAYERS, FEATURES_PREVIEW_RAMP } from './constants';
 import {
   UseGeoJSONLayer,
 
@@ -279,7 +279,7 @@ export function useFeaturePreviewLayers({
     };
 
     return FEATURES
-      .map((f) => {
+      .map((f, index) => {
         const { id } = f;
 
         const F = featuresRecipe.find((fr) => fr.id === id) || f;
@@ -306,7 +306,7 @@ export function useFeaturePreviewLayers({
                   visibility: getLayerVisibility(),
                 },
                 paint: {
-                  'fill-color': COLORS['features-preview'].default,
+                  'fill-color': FEATURES_PREVIEW_RAMP(selectedFeatures)[index],
                   'fill-opacity': opacity,
                 },
               },

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -998,6 +998,7 @@ export function useLegend({
 }: UseLegend) {
   return useMemo(() => {
     const { layerSettings = {} } = options;
+    // TODO: Add legend with feature preview name
 
     return layers
       .map((l) => {

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
-import { COLORS, LEGEND_LAYERS, FEATURES_PREVIEW_RAMP } from './constants';
+import chroma from 'chroma-js';
+
+import { COLORS, LEGEND_LAYERS } from './constants';
 import {
   UseGeoJSONLayer,
 
@@ -306,7 +308,7 @@ export function useFeaturePreviewLayers({
                   visibility: getLayerVisibility(),
                 },
                 paint: {
-                  'fill-color': FEATURES_PREVIEW_RAMP(selectedFeatures)[index],
+                  'fill-color': chroma.scale(['#e0e681', '#FFF']).mode('lch').colors(selectedFeatures.length)[index],
                   'fill-opacity': opacity,
                 },
               },

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -308,7 +308,7 @@ export function useFeaturePreviewLayers({
                   visibility: getLayerVisibility(),
                 },
                 paint: {
-                  'fill-color': chroma.scale(['#e0e681', '#FFF']).mode('lch').colors(selectedFeatures.length)[index],
+                  'fill-color': chroma.scale(COLORS['features-preview'].ramp).mode('lch').colors(selectedFeatures.length)[index],
                   'fill-opacity': opacity,
                 },
               },

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -997,8 +997,7 @@ export function useLegend({
   layers, options = {},
 }: UseLegend) {
   return useMemo(() => {
-    const { layerSettings = {} } = options;
-    // TODO: Add legend with feature preview name
+    const { layerSettings = {}, items = [] } = options;
 
     return layers
       .map((l) => {
@@ -1009,6 +1008,7 @@ export function useLegend({
             ...L({
               ...options,
               ...layerSettings[l],
+              ...items,
             }),
             settings: layerSettings[l],
           };

--- a/app/hooks/map/types.ts
+++ b/app/hooks/map/types.ts
@@ -171,6 +171,7 @@ export interface UseLegend {
       min: number;
       max: number,
     };
+    items?:string[];
     puAction?: string;
     puIncludedValue?: string[];
     puExcludedValue?: string[];

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -119,6 +119,11 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
   }) => selectedFeatures.includes(id)).length > 0,
   [selectedFeaturesData, selectedFeatures]);
 
+  const selectedPreviewFeatures = useMemo(() => selectedFeaturesData.filter(({
+    id,
+  }) => selectedFeatures.includes(id)).map(({ name, id }) => ({ name, id })),
+  [selectedFeaturesData, selectedFeatures]);
+
   const {
     data: costSurfaceRangeData,
   } = useCostSurfaceRange(sid);
@@ -323,6 +328,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
         && subtab === ScenarioSidebarSubTabs.PROTECTED_AREAS_THRESHOLD
         ? wdpaThreshold : scenarioData?.wdpaThreshold,
       cost: costSurfaceRangeData,
+      items: selectedPreviewFeatures,
       puAction,
       puIncludedValue: puTmpIncludedValue,
       puExcludedValue: puTmpExcludedValue,
@@ -493,6 +499,7 @@ export const ScenariosEditMap: React.FC<ScenariosEditMapProps> = () => {
       </Controls>
 
       {/* Legend */}
+
       <div className="absolute w-full max-w-xs bottom-16 right-5">
         <Legend
           open={open}

--- a/app/package.json
+++ b/app/package.json
@@ -51,7 +51,7 @@
     "@vizzuality/layer-manager-provider-carto": "^1.0.0-alpha.3",
     "@vizzuality/layer-manager-react": "^1.0.0-alpha.3",
     "axios": "^0.21.1",
-    "chroma-js": "^2.1.2",
+    "chroma-js": "^2.4.2",
     "classnames": "^2.2.6",
     "cookie": "^0.4.1",
     "d3": "^6.5.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -6238,12 +6238,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chroma-js@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.1.2.tgz#1075cb9ae25bcb2017c109394168b5cf3aa500ec"
-  integrity sha512-ri/ouYDWuxfus3UcaMxC1Tfp3IE9K5iQzxc2hSxbBRVNQFut1UuGAsZmiAf2mOUubzGJwgMSv9lHg+XqLaz1QQ==
-  dependencies:
-    cross-env "^6.0.3"
+chroma-js@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.4.2.tgz#dffc214ed0c11fa8eefca2c36651d8e57cbfb2b0"
+  integrity sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -6776,13 +6774,6 @@ create-react-context@0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
-
-cross-env@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
-  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
-  dependencies:
-    cross-spawn "^7.0.0"
 
 cross-fetch@3.0.5:
   version "3.0.5"


### PR DESCRIPTION
## Split

### Overview

Continuation of `feature/split` since that branch was merged into develop and vercel-demo so the backend could work.

- Collapse the split button when there are split features as well.
- Add basic legend to the features preview, displaying the name of each legend.
- Assign a color within a ramp to each feature preview

### Testing instructions



### Feature relevant tickets

[MARXAN-1706](https://vizzuality.atlassian.net/browse/MARXAN-1706)
[MARXAN-1713](https://vizzuality.atlassian.net/browse/MARXAN-1713)

---
