### PR TITLE
fix: add update gap analysis views migration

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1658483942285-UpdateGapAnalysisViewsAddingApiFeatureId.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1658483942285-UpdateGapAnalysisViewsAddingApiFeatureId.ts
@@ -1,0 +1,142 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateGapAnalysisViewsAddingApiFeatureId1658483942285
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+drop view scenario_features_gap_data;
+
+create view scenario_features_gap_data as
+  with gap_data as (
+    select
+      sfd.api_feature_id as feature_id,
+      scenario_id,
+      sum(total_area) total_area,
+      case when sum(current_pa) is not null 
+	    then sum(current_pa)
+	    else 0 
+	    end as met_area,
+      min(prop) as coverage_target
+    from scenario_features_data sfd 
+    group by sfd.api_feature_id, feature_class_id, scenario_id)
+  select
+    scenario_id,
+    feature_id,
+    sum(total_area) as total_area,
+    sum(met_area) as met_area,
+    case 
+      when sum(total_area) > 0 
+      then round((sum(met_area)/sum(total_area))*100)
+      else 0
+    end as met,
+    sum(total_area) * min(coverage_target) as coverage_target_area,
+    round(min(coverage_target) * 100) as coverage_target,
+    sum(met_area) >= (sum(total_area) * min(coverage_target)) as on_target
+  from gap_data
+  group by feature_id, scenario_id;
+    `);
+
+    await queryRunner.query(`
+drop view scenario_features_output_gap_data;
+
+create view scenario_features_output_gap_data as
+  with gap_data as (
+    select
+      amount,
+      occurrences,
+      run_id,
+      sfd.api_feature_id as feature_id,
+      sfd.scenario_id,
+      osfd.total_area,
+      sfd.prop as coverage_target
+    from output_scenarios_features_data osfd
+    inner join scenario_features_data sfd on osfd.feature_scenario_id=sfd.id)
+  select
+    scenario_id,
+    feature_id,
+    sum(total_area) as total_area,
+    sum(amount) as met_area,
+    case
+      when sum(total_area) <> 0 and sum(total_area) is not null then
+        round((sum(amount)/sum(total_area))*100)
+      else
+        0
+    end as met,
+    sum(occurrences) as met_occurrences,
+    sum(total_area) * min(coverage_target) as coverage_target_area,
+    round(min(coverage_target) * 100) as coverage_target,
+    sum(amount) >= (sum(total_area) * min(coverage_target)) as on_target,
+    run_id
+  from gap_data
+  group by run_id, feature_id, scenario_id;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+drop view scenario_features_output_gap_data;
+
+create view scenario_features_output_gap_data as
+  with gap_data as (
+    select
+      amount,
+      occurrences,
+      run_id,
+      fd.feature_id,
+      sfd.scenario_id,
+      osfd.total_area,
+      sfd.prop as coverage_target
+    from output_scenarios_features_data osfd
+    inner join scenario_features_data sfd on osfd.feature_scenario_id=sfd.id
+    inner join features_data fd on sfd.feature_class_id=fd.id)
+  select
+    scenario_id,
+    feature_id,
+    sum(total_area) as total_area,
+    sum(amount) as met_area,
+    case
+      when sum(total_area) <> 0 and sum(total_area) is not null then
+        round((sum(amount)/sum(total_area))*100)
+      else
+        0
+    end as met,
+    sum(occurrences) as met_occurrences,
+    sum(total_area) * min(coverage_target) as coverage_target_area,
+    round(min(coverage_target) * 100) as coverage_target,
+    sum(amount) >= (sum(total_area) * min(coverage_target)) as on_target,
+    run_id
+  from gap_data
+  group by run_id, feature_id, scenario_id;
+    `);
+
+    await queryRunner.query(`
+drop view scenario_features_gap_data;
+
+create view scenario_features_gap_data as
+  with gap_data as (
+    select
+      fd.feature_id,
+      scenario_id,
+      sum(total_area) total_area,
+      sum(current_pa) met_area,
+      min(prop) as coverage_target
+    from scenario_features_data sfd 
+    inner join features_data fd on sfd.feature_class_id=fd.id 
+    group by fd.feature_id, feature_class_id, scenario_id)
+  select
+    scenario_id,
+    feature_id,
+    sum(total_area) as total_area,
+    sum(met_area) as met_area,
+    case 
+      when sum(total_area) > 0 then round((sum(met_area)/sum(total_area))*100)
+      else 0
+    end as met,
+    sum(total_area) * min(coverage_target) as coverage_target_area,
+    round(min(coverage_target) * 100) as coverage_target,
+    sum(met_area) >= (sum(total_area) * min(coverage_target)) as on_target
+  from gap_data
+  group by feature_id, scenario_id;
+    `);
+  }
+}

--- a/api/libs/features/src/scenario-features-gap-data.geo.entity.ts
+++ b/api/libs/features/src/scenario-features-gap-data.geo.entity.ts
@@ -1,32 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Column, ViewEntity } from 'typeorm';
 
-@ViewEntity('scenario_features_gap_data', {
-  expression: `
-  with gap_data as (
-    select
-      sfd.api_feature_id as feature_id,
-      scenario_id,
-      sum(total_area) total_area,
-      sum(current_pa) met_area,
-      min(prop) as coverage_target
-    from scenario_features_data sfd 
-    inner join features_data fd on sfd.feature_class_id=fd.id 
-    group by sfd.api_feature_id, feature_class_id, scenario_id)
-  select
-    scenario_id,
-    feature_id,
-    total_area,
-    met_area,
-    case 
-      when total_area > 0 then round((met_area/total_area)*100)
-      else 0
-    end as met,
-    total_area * coverage_target as coverage_target_area,
-    coverage_target,
-    met_area >= (total_area * coverage_target) as on_target
-  from gap_data;`,
-})
+@ViewEntity('scenario_features_gap_data')
 export class ScenarioFeaturesGapData {
   @ApiProperty()
   @Column({ name: 'scenario_id' })

--- a/api/libs/features/src/scenario-features-output-gap-data.geo.entity.ts
+++ b/api/libs/features/src/scenario-features-output-gap-data.geo.entity.ts
@@ -2,38 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Column, ViewEntity } from 'typeorm';
 import { ScenarioFeaturesGapData } from './scenario-features-gap-data.geo.entity';
 
-@ViewEntity('scenario_features_output_gap_data', {
-  expression: `
-  with gap_data as (
-    select
-      amount,
-      occurrences,
-      run_id,
-      sfd.api_feature_id as feature_id,
-      sfd.scenario_id,
-      osfd.total_area,
-      sfd.prop as coverage_target
-    from output_scenarios_features_data osfd
-    inner join scenario_features_data sfd on osfd.feature_scenario_id=sfd.id
-    inner join features_data fd on sfd.feature_class_id=fd.id)
-  select
-    scenario_id,
-    feature_id,
-    sum(amount) as met_area,
-    case
-      when sum(total_area) <> 0 and sum(total_area) is not null then
-        round((sum(amount)/sum(total_area))*100)
-      else
-        0
-    end as met,
-    sum(occurrences) as met_occurrences,
-    sum(total_area) * min(coverage_target) as coverage_target_area,
-    min(coverage_target) as coverage_target,
-    sum(amount) >= (sum(total_area) * min(coverage_target)) as on_target,
-    run_id
-  from gap_data
-  group by run_id, feature_id, scenario_id;`,
-})
+@ViewEntity('scenario_features_output_gap_data')
 export class ScenarioFeaturesOutputGapData extends ScenarioFeaturesGapData {
   @ApiProperty()
   @Column({ name: 'met_occurrences' })


### PR DESCRIPTION
This PR adds new migration for updating gap analysis views, now they take into account api_feature_id.

Also, delete on both views, extra join with `features_data` and added case clause to `met_area` in `scenario_features_gap_data` view

### Feature relevant tickets

[Update gap analysis view using a migration](https://vizzuality.atlassian.net/browse/MARXAN-1714)

