### PR TITLE
fix: bbox filter in getFeaturePropertySetsForFeatures function

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-feature-property-sets.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-feature-property-sets.service.ts
@@ -10,7 +10,7 @@ import { GeoFeature } from './geo-feature.api.entity';
 import { GeoFeaturePropertySet } from './geo-feature.geo.entity';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { BBox } from 'geojson';
-import { antimeridianBbox } from '@marxan/utils/geo';
+import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo';
 
 @Injectable()
 export class GeoFeaturePropertySetService {
@@ -33,20 +33,17 @@ export class GeoFeaturePropertySetService {
       .where(`propertySets.featureId IN (:...ids)`, { ids: geoFeatureIds });
 
     if (withinBBox) {
-      const { westBbox, eastBbox } = antimeridianBbox([
-        withinBBox[1],
-        withinBBox[3],
-        withinBBox[0],
-        withinBBox[2],
-      ]);
+      const { westBbox, eastBbox } = antimeridianBbox(
+        nominatim2bbox(withinBBox),
+      );
       query.andWhere(
         `(st_intersects(
-            st_intersection(st_makeenvelope(:...westBbox, 4326),
+            st_intersection(st_makeenvelope(:...eastBbox, 4326),
                                   ST_MakeEnvelope(0, -90, 180, 90, 4326)),
           "propertySets".bbox)
           or
           st_intersects(
-            st_intersection(st_makeenvelope(:...eastBbox, 4326),
+            st_intersection(st_makeenvelope(:...westBbox, 4326),
                                   ST_MakeEnvelope(-180, -90, 0, 90, 4326)),
             "propertySets".bbox))`,
         {


### PR DESCRIPTION
This PR changes the `bbox` filter being made in `getFeaturePropertySetsForFeatures` function as it seems to not be working properly. As an example, when selecting [Syncerus_caffer](https://github.com/marxan-cloud/tnc-training-bots/blob/main/2022-03_okavango/geo-data/features/species/Syncerus_caffer.zip) feature in a project with  the whole Angola 5000km2 hex as planning grid, no properties sets are returned, meanwhile, when using the same feature in a project with Angola -> Cuando Cubango region, 5000km² hex as planning grid,  properties sets are returned

Now we use the `nominatim2bbox` function and interchange the east and west `bbox`. These changes replicate what seems to be the same filter in other parts of the codebase, so it could be wrong.

### Feature relevant tickets

[Split icon  does not appear in features when using Angola as planning grid ](https://vizzuality.atlassian.net/browse/MARXAN-1715)

