### PR TITLE
MARXAN-1308-1690-1691-1692-scenarios-lockin-lockout

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1658479002103-AddColumnMarkSelectionsUsersScenariosPuData.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1658479002103-AddColumnMarkSelectionsUsersScenariosPuData.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddColumnMarkSelectionsUsersScenariosPuData1658499008203
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE scenarios_pu_data ADD COLUMN lock_status_set_by_user boolean not null default false;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE scenarios
+            DROP COLUMN lock_status_set_by_user;
+    `);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
@@ -130,6 +130,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.Unstated,
+        setByUser: false,
       },
     );
 
@@ -140,6 +141,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.LockedIn,
+        setByUser: false,
       },
     );
 
@@ -150,6 +152,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.LockedIn,
+        setByUser: true,
       },
     );
 
@@ -160,6 +163,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.LockedOut,
+        setByUser: true,
       },
     );
     return true;

--- a/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
+++ b/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
@@ -64,6 +64,14 @@ export class ScenariosPlanningUnitGeoEntity {
   lockStatus?: LockStatus | null;
 
   @Column({
+    type: `boolean`,
+    nullable: false,
+    default: false,
+    name: `lock_status_set_by_user`,
+  })
+  setByUser?: boolean;
+
+  @Column({
     type: 'float8',
     nullable: true,
   })


### PR DESCRIPTION
- Adds new column `lock_status_set_by_user` to `scenarios_pu_data` table.
- Applies lock by user when it is effectively locked by user in ScenarioPlanningUnitsInclusionProcessor.
- Checks for locks by users when ScenarioPlanningUnitsProtectedStatusCalculatorService calculation is executed.