### PR TITLE
move amount from legacy project column [MARXAN-1728 ]

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/compute-area.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/compute-area.service.ts
@@ -1,18 +1,20 @@
-import { LegacyProjectImportRepository } from '@marxan-api/modules/legacy-project-import/domain/legacy-project-import/legacy-project-import.repository';
-import { ResourceId } from '@marxan/cloning/domain';
+import { ProjectSourcesEnum } from '@marxan/projects';
 import {
   PuvsprCalculationsRepository,
   PuvsprCalculationsService,
 } from '@marxan/puvspr-calculations';
 import { Injectable } from '@nestjs/common';
-import { isRight } from 'fp-ts/lib/Either';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Project } from '../projects/project.api.entity';
 
 @Injectable()
 export class ComputeArea {
   constructor(
     private readonly puvsprCalculationsRepo: PuvsprCalculationsRepository,
     private readonly puvsprCalculations: PuvsprCalculationsService,
-    private readonly legacyProjectImportRepo: LegacyProjectImportRepository,
+    @InjectRepository(Project)
+    private readonly projectsRepo: Repository<Project>,
   ) {}
   public async computeAreaPerPlanningUnitOfFeature(
     projectId: string,
@@ -48,10 +50,10 @@ export class ComputeArea {
   }
 
   private async isLegacyProject(projectId: string) {
-    const legacyProjectImportOrError = await this.legacyProjectImportRepo.find(
-      new ResourceId(projectId),
-    );
+    const [project] = await this.projectsRepo.find({
+      id: projectId,
+    });
 
-    return isRight(legacyProjectImportOrError);
+    return project.sources === ProjectSourcesEnum.legacyImport;
   }
 }

--- a/api/apps/api/src/modules/scenarios-features/scenario-features.module.ts
+++ b/api/apps/api/src/modules/scenarios-features/scenario-features.module.ts
@@ -32,11 +32,12 @@ import { PuvsprCalculationsModule } from '@marxan/puvspr-calculations';
 import { SplitFeatureConfigMapper } from '../scenarios/specification/split-feature-config.mapper';
 import { FeatureHashModule } from '../features-hash/features-hash.module';
 import { SplitCreateFeatures } from './split/split-create-features.service';
+import { Project } from '../projects/project.api.entity';
 
 @Module({
   imports: [
     CqrsModule,
-    TypeOrmModule.forFeature([GeoFeature]),
+    TypeOrmModule.forFeature([Project, GeoFeature]),
     TypeOrmModule.forFeature(
       [
         ScenarioFeaturesData,
@@ -51,7 +52,6 @@ import { SplitCreateFeatures } from './split/split-create-features.service';
     ApiEventsModule,
     IntersectWithPuModule,
     AccessControlModule,
-    LegacyProjectImportRepositoryModule,
   ],
   providers: [
     ScenarioFeaturesService,

--- a/api/apps/api/src/modules/scenarios/input-files/input-files.module.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/input-files.module.ts
@@ -19,11 +19,11 @@ import { ioSettingsProvider } from './input-params/io-settings';
 import { InputParameterFileProvider } from './input-params/input-parameter-file.provider';
 import { InputFilesArchiverService } from './input-files-archiver.service';
 import { PuvsprDatProcessorModule } from './puvspr.dat.processor/puvspr.dat.processor.module';
-import { LegacyProjectImportRepositoryModule } from '@marxan-api/modules/legacy-project-import/infra/legacy-project-import.repository.module';
+import { Project } from '@marxan-api/modules/projects/project.api.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Scenario]),
+    TypeOrmModule.forFeature([Project, Scenario]),
     TypeOrmModule.forFeature(
       [
         PlanningUnitsGeom,
@@ -33,7 +33,6 @@ import { LegacyProjectImportRepositoryModule } from '@marxan-api/modules/legacy-
       ],
       DbConnections.geoprocessingDB,
     ),
-    LegacyProjectImportRepositoryModule,
     PuvsprDatProcessorModule,
   ],
   providers: [

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-data.piece-exporter.ts
@@ -83,7 +83,6 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
         target2: sfd.target2,
         target: sfd.target,
         targetocc: sfd.targetocc,
-        amountFromLegacyProject: sfd.amountFromLegacyProject,
         outputFeaturesData: [],
       }));
   }

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features-specification.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features-specification.legacy-piece-importer.ts
@@ -337,7 +337,6 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
 
   private async updateScenarioFeaturesData(
     specRows: PropSpecDatRow[],
-    puvsprRows: PuvrsprDatRow[],
     scenarioId: string,
   ): Promise<void> {
     const scenarioFeaturesData: ScenarioFeaturesData[] = await this.scenarioFeaturesDataRepo.find(
@@ -347,12 +346,8 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
         relations: ['featureData'],
       },
     );
-    const amountsByIntegerIdAndPuid: Record<string, number> = {};
     const propertiesByIntegerId: Record<number, PropSpecDatRow> = {};
 
-    puvsprRows.forEach((row) => {
-      amountsByIntegerIdAndPuid[`${row.species}-${row.pu}`] = row.amount;
-    });
     specRows.forEach((row) => {
       propertiesByIntegerId[row.id] = row;
     });
@@ -370,8 +365,6 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
         this.logAndThrow(
           'Scenario features data properties does not contain required properties',
         );
-
-      const amount = amountsByIntegerIdAndPuid[`${integerId}-${puid}`];
       const { target2, targetocc, sepnum } = propertiesByIntegerId[integerId];
 
       return {
@@ -379,7 +372,6 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
         target2,
         targetocc,
         sepnum,
-        amountFromLegacyProject: amount,
       };
     });
 
@@ -415,11 +407,7 @@ export class FeaturesSpecificationLegacyProjectPieceImporter
 
     const specRows = this.getPropSpecRows(specRowsOrError, puvsprRowsOrError);
     await this.runSpecification(specRows, projectId, scenarioId);
-    await this.updateScenarioFeaturesData(
-      specRows,
-      puvsprRowsOrError,
-      scenarioId,
-    );
+    await this.updateScenarioFeaturesData(specRows, scenarioId);
 
     return input;
   }

--- a/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features.legacy-piece-importer.ts
+++ b/api/apps/geoprocessing/src/legacy-project-import/legacy-piece-importers/features.legacy-piece-importer.ts
@@ -194,13 +194,15 @@ export class FeaturesLegacyProjectPieceImporter
       );
 
       filteredPuvspr.forEach((filteredRow) => {
-        const { theGeom, projectPuId } = projectPusGeomsMap[filteredRow.pu];
+        const geomAndPuId = projectPusGeomsMap[filteredRow.pu];
         const amountFromLegacyProject = filteredRow.amount;
 
-        if (!theGeom) {
+        if (!geomAndPuId) {
           nonExistingPus.push(filteredRow.pu);
           return;
         }
+
+        const { theGeom, projectPuId } = geomAndPuId;
 
         featuresDataInsertValues.push({
           id: v4(),

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1659032419406-MoveAmountFromLegacyProjectToFeaturesData.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1659032419406-MoveAmountFromLegacyProjectToFeaturesData.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MoveAmountFromLegacyProjectToFeaturesData1659032419406
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE features_data
+        ADD COLUMN amount_from_legacy_project double precision;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE scenario_features_data
+        DROP COLUMN amount_from_legacy_project;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE features_data
+        ADD COLUMN project_pu_id uuid;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE features_data
+        ADD FOREIGN KEY (project_pu_id) REFERENCES projects_pu(id) 
+        ON DELETE cascade;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE scenario_features_data
+        ADD COLUMN amount_from_legacy_project double precision;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE features_data
+        DROP COLUMN amount_from_legacy_project;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE features_data
+        DROP COLUMN project_pu_id;
+    `);
+  }
+}

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-data.piece-exporter.e2e-spec.ts
@@ -103,7 +103,6 @@ const getFixtures = async () => {
   const amountOfPlatformFeatures = 2;
   const recordsOfDataForEachFeature = 3;
   const recordsOfOutputDataForEachScenarioFeaturesData = 2;
-  const expectedAmountFromLegacyProject = 153;
 
   return {
     cleanUp: async () => {
@@ -157,7 +156,6 @@ const getFixtures = async () => {
         featureIds,
         scenarioId,
         undefined,
-        { amountFromLegacyProject: expectedAmountFromLegacyProject },
       );
     },
     GivenIncorrectScenarioFeaturesData: async () => {
@@ -215,8 +213,7 @@ const getFixtures = async () => {
               (sfd) =>
                 sfd.apiFeature.featureClassName ===
                   sfd.featureDataFeature.featureClassName &&
-                sfd.apiFeature.isCustom === sfd.featureDataFeature.isCustom &&
-                sfd.amountFromLegacyProject === expectedAmountFromLegacyProject,
+                sfd.apiFeature.isCustom === sfd.featureDataFeature.isCustom,
             ),
           );
         },

--- a/api/apps/geoprocessing/test/integration/cloning/piece-importers/scenario-features-data.piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-importers/scenario-features-data.piece-importer.e2e-spec.ts
@@ -136,7 +136,6 @@ const getFixtures = async () => {
   const amountOfPlatformFeatures = 2;
   const recordsOfDataForEachFeature = 3;
   const recordsOfOutputDataForEachScenarioFeaturesData = 2;
-  const expectedAmountFromLegacyProject = 135;
 
   return {
     cleanUp: async () => {
@@ -278,7 +277,6 @@ const getFixtures = async () => {
           totalArea: 100,
           currentArea: 100,
           featureId: index,
-          amountFromLegacyProject: expectedAmountFromLegacyProject,
           outputFeaturesData: Array(
             recordsOfOutputDataForEachScenarioFeaturesData,
           )
@@ -353,9 +351,8 @@ const getFixtures = async () => {
 
           expect(
             scenarioFeaturesData.every(
-              ({ featureData, apiFeatureId, amountFromLegacyProject }) =>
-                featureData.featureId === apiFeatureId &&
-                amountFromLegacyProject === expectedAmountFromLegacyProject,
+              ({ featureData, apiFeatureId }) =>
+                featureData.featureId === apiFeatureId,
             ),
           ).toEqual(true);
 

--- a/api/apps/geoprocessing/test/integration/legacy-project-import/features.legacy-piece-importer.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/legacy-project-import/features.legacy-piece-importer.e2e-spec.ts
@@ -198,7 +198,7 @@ describe(FeaturesLegacyProjectPieceImporter, () => {
       .ThenADuplicateFeatureNamesErrorShouldBeThrown();
   });
 
-  it('imports successfully scenario pus data and scenario pus cost data', async () => {
+  it('imports successfully features and features data', async () => {
     const specDatFileType = LegacyProjectImportFileType.SpecDat;
     const puvsprDatFileType = LegacyProjectImportFileType.PuvsprDat;
 
@@ -334,6 +334,7 @@ const getFixtures = async () => {
     return [firstFeature, secondFeature, thirdFeature, fourthFeature];
   };
 
+  const expectedAmountFromLegacyProject = 100;
   const pus = await GivenProjectPus(
     geoEntityManager,
     projectId,
@@ -440,7 +441,7 @@ const getFixtures = async () => {
       const puvsprRows = featuresWithPuids.flatMap(({ id, puids }) => {
         return puids.map((puid) => ({
           species: id,
-          amount: 0.3,
+          amount: expectedAmountFromLegacyProject,
           pu: puid,
         }));
       });
@@ -514,6 +515,14 @@ const getFixtures = async () => {
           expect(insertedFeaturesData).toHaveLength(
             amountOfFeaturesData - amountOfNonExistingPuids,
           );
+          expect(
+            insertedFeaturesData.every(
+              ({ amountFromLegacyProject, projectPuId }) =>
+                amountFromLegacyProject === expectedAmountFromLegacyProject &&
+                projectPuId &&
+                pus.map(({ id }) => id).includes(projectPuId),
+            ),
+          ).toEqual(true);
         },
       };
     },

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/index.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/index.ts
@@ -62,10 +62,10 @@ export const clonePieceImportOrder: Record<ClonePiece, number> = {
   [ClonePiece.ProjectCustomProtectedAreas]: 1,
   //
   [ClonePiece.ProjectCustomFeatures]: 2,
+  [ClonePiece.ScenarioProtectedAreas]: 2,
+  [ClonePiece.ScenarioPlanningUnitsData]: 2,
   //
   [ClonePiece.ProjectPuvsprCalculations]: 3,
-  [ClonePiece.ScenarioProtectedAreas]: 3,
-  [ClonePiece.ScenarioPlanningUnitsData]: 3,
   [ClonePiece.ScenarioFeaturesData]: 3,
   //
   [ClonePiece.ScenarioRunResults]: 4,

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/index.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/index.ts
@@ -60,16 +60,17 @@ export const clonePieceImportOrder: Record<ClonePiece, number> = {
   [ClonePiece.PlanningAreaCustom]: 1,
   [ClonePiece.PlanningUnitsGrid]: 1,
   [ClonePiece.ProjectCustomProtectedAreas]: 1,
-  [ClonePiece.ProjectCustomFeatures]: 1,
   //
-  [ClonePiece.ProjectPuvsprCalculations]: 2,
-  [ClonePiece.ScenarioProtectedAreas]: 2,
-  [ClonePiece.ScenarioPlanningUnitsData]: 2,
-  [ClonePiece.ScenarioFeaturesData]: 2,
+  [ClonePiece.ProjectCustomFeatures]: 2,
   //
-  [ClonePiece.ScenarioRunResults]: 3,
-  [ClonePiece.MarxanExecutionMetadata]: 3,
-  [ClonePiece.FeaturesSpecification]: 3,
+  [ClonePiece.ProjectPuvsprCalculations]: 3,
+  [ClonePiece.ScenarioProtectedAreas]: 3,
+  [ClonePiece.ScenarioPlanningUnitsData]: 3,
+  [ClonePiece.ScenarioFeaturesData]: 3,
+  //
+  [ClonePiece.ScenarioRunResults]: 4,
+  [ClonePiece.MarxanExecutionMetadata]: 4,
+  [ClonePiece.FeaturesSpecification]: 4,
 };
 
 export class ClonePieceRelativePathResolver {

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-custom-features.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-custom-features.ts
@@ -17,6 +17,8 @@ type FeatureData = {
   the_geom: string;
   properties: Record<string, string | number>;
   source: GeometrySource;
+  amount_from_legacy_project: number | null;
+  projectPuPuid: number | undefined;
 };
 
 export type ProjectCustomFeature = {

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-features-data.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-features-data.ts
@@ -25,7 +25,6 @@ export type FeatureDataElement = {
   metadata?: Record<'sepdistance', number | string>;
   featureId: number;
   specificationId?: string;
-  amountFromLegacyProject?: number | null;
   outputFeaturesData: OutputFeatureDataElement[];
 };
 

--- a/api/libs/features/src/scenario-features-data.geo.entity.ts
+++ b/api/libs/features/src/scenario-features-data.geo.entity.ts
@@ -102,12 +102,6 @@ export class ScenarioFeaturesData {
   })
   featureId!: number;
 
-  @Column({
-    name: 'amount_from_legacy_project',
-    type: 'double precision',
-  })
-  amountFromLegacyProject?: number | null;
-
   @ApiProperty({
     description: `0-100 (%) value of target protection coverage of all available species.`,
   })

--- a/api/libs/geofeatures/src/geo-feature.geo.entity.ts
+++ b/api/libs/geofeatures/src/geo-feature.geo.entity.ts
@@ -1,6 +1,7 @@
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
 import { ApiProperty } from '@nestjs/swagger';
 import { Geometry } from 'geojson';
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { GeometrySource } from './geometry-source.enum';
 
 @Entity('features_data')
@@ -25,7 +26,26 @@ export class GeoFeatureGeometry {
   @Column('uuid', { name: 'feature_id' })
   featureId?: string;
 
+  @Column({
+    name: 'amount_from_legacy_project',
+    type: 'double precision',
+    nullable: true,
+  })
+  amountFromLegacyProject?: number | null;
+
   @ApiProperty()
   @Column({ name: 'hash', insert: false, update: false })
   hash!: string;
+
+  @Column('uuid', { name: 'project_pu_id', nullable: true })
+  projectPuId?: string | null;
+
+  @ManyToOne(() => ProjectsPuEntity, (projectPu) => projectPu.id, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    referencedColumnName: 'id',
+    name: 'project_pu_id',
+  })
+  projectPu?: ProjectsPuEntity;
 }

--- a/api/libs/puvspr-calculations/src/puvspr-calculations.service.ts
+++ b/api/libs/puvspr-calculations/src/puvspr-calculations.service.ts
@@ -118,20 +118,15 @@ export class PuvsprCalculationsService {
           from
           (
               select
-               the_geom as the_geom,
-               sfd.amount_from_legacy_project as amount_from_legacy_project
+               fd.project_pu_id as puid,
+               fd.amount_from_legacy_project as amount_from_legacy_project
               from scenario_features_data sfd
-              inner join features_data fd on sfd.feature_class_id = fd.id where sfd.scenario_id = $1
+              inner join features_data fd on 
+              sfd.feature_class_id = fd.id where sfd.scenario_id = $1
               AND sfd.api_feature_id = $2
-          ) species,
-          (
-              select the_geom, ppu.puid as puid, ppu.id as id, spd.scenario_id
-              from planning_units_geom pug
-              inner join projects_pu ppu on pug.id = ppu.geom_id
-              inner join scenarios_pu_data spd on ppu.id = spd.project_pu_id
-              where spd.scenario_id = $1 order by ppu.puid asc
-          ) pu
-          where ST_Equals(species.the_geom,pu.the_geom)
+          ) species
+          LEFT JOIN projects_pu pu
+          ON pu.id = species.puid
           )
           select * from all_amount_per_planning_unit where amount > 0  order by puid;
         `,


### PR DESCRIPTION
This PR moves `amount_from_legacy_project` column from `scenario_features_data` to `feratures_data` and adds `project_pu_id` FK to `projects_pu` in `features_data`.

It also change the way we check if a project is a legacy project using the `ProjectSourcesEnum`, this is need as in case we clone a legacy project the previous check would fail as it would not be considered a legacy project.

### Feature relevant tickets

[move amount from legacy project column from scenarios_features_data to features data](https://vizzuality.atlassian.net/browse/MARXAN-1728)
