### PR TITLE
feat: improve geo clean up service

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1659439420578-RenameCleanUpPreparationTables.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1659439420578-RenameCleanUpPreparationTables.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameCleanUpPreparationTables1659439420578
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE project_geodata_cleanup_preparation
+        RENAME TO dangling_projects;
+    `);
+
+    await queryRunner.query(`
+        ALTER TABLE scenario_geodata_cleanup_preparation
+        RENAME TO dangling_scenarios;
+    `);
+
+    await queryRunner.query(`
+        ALTER TABLE features_data_cleanup_preparation
+        RENAME TO dangling_features;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE dangling_projects
+        RENAME TO project_geodata_cleanup_preparation;
+    `);
+
+    await queryRunner.query(`
+        ALTER TABLE dangling_scenarios
+        RENAME TO scenario_geodata_cleanup_preparation;
+    `);
+
+    await queryRunner.query(`
+        ALTER TABLE dangling_features
+        RENAME TO features_data_cleanup_preparation;
+    `);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/cleanup-tasks/cleanup-tasks.service.ts
+++ b/api/apps/geoprocessing/src/modules/cleanup-tasks/cleanup-tasks.service.ts
@@ -56,7 +56,7 @@ export class CleanupTasksService implements CleanupTasks {
 
     await this.storeDanglingFeatureIds(apiFeaturesIds, geoFeatureIds);
 
-    await this.deleteDanglinFeatureIdsInGeoDb();
+    await this.deleteDanglingFeatureIdsInGeoDb();
   }
 
   async getProjectIdsInUse() {

--- a/api/apps/geoprocessing/src/modules/cleanup-tasks/cleanup-tasks.service.ts
+++ b/api/apps/geoprocessing/src/modules/cleanup-tasks/cleanup-tasks.service.ts
@@ -386,7 +386,7 @@ export class CleanupTasksService implements CleanupTasks {
     );
   }
 
-  async deleteDanglinFeatureIdsInGeoDb() {
+  async deleteDanglingFeatureIdsInGeoDb() {
     // For every related entity, we look for matching ids inside entity table
     // and compare it with intermediate dangling_features table to delete records
     await this.geoEntityManager.query(


### PR DESCRIPTION
This PR improves geo clean up service adding locks to projects, scenarios and features tables when searching for the in use ids.

Also, in the before implementation, in `cleanupProjectsDanglingData` function, we were removing `features` rows when a feature is from a project that is not in `projects` table, I believe this is not necessary because, there is already a foreing key between `features` and `projects` tables with `on delete` action

### Feature relevant tickets

[improve geodata garbage collection](https://vizzuality.atlassian.net/browse/MARXAN-1694)

