### PR TITLE
Preview splitted features on the map

### DIFF
--- a/app/components/features/target-spf-item/types.ts
+++ b/app/components/features/target-spf-item/types.ts
@@ -2,6 +2,13 @@ export interface TargetSPFItemProps {
   className?: string;
   isAllTargets: boolean;
   id: string;
+  parentId?: string;
+  splitted?: boolean;
+  splitSelected?: string;
+  splitFeaturesSelected?: {
+    id: string
+  }[];
+  value?: string;
   defaultTarget?: number;
   defaultFPF?: number;
   target?: number;

--- a/app/hooks/features/index.ts
+++ b/app/hooks/features/index.ts
@@ -313,7 +313,7 @@ export function useTargetedFeatures(
       features = [],
     } = parsedData;
 
-    parsedData = features.map((d): SelectedItemProps => {
+    parsedData = features.map((d) => {
       const {
         featureId,
         geoprocessingOperations,
@@ -409,55 +409,59 @@ export function useTargetedFeatures(
 
     parsedData = flatten(parsedData.map((s) => {
       const {
-        id, name, splitSelected, splitFeaturesSelected, intersectFeaturesSelected, marxanSettings,
+        id, name, splitSelected, splitFeaturesSelected, marxanSettings,
       } = s;
       const isSplitted = !!splitSelected;
-      const isIntersected = !!intersectFeaturesSelected?.length;
+      // const isIntersected = !!intersectFeaturesSelected?.length;
 
       // Generate splitted features to target
       if (isSplitted) {
-        return splitFeaturesSelected.map((sf) => {
-          const {
-            id: sfId,
-            name: sfName,
-            marxanSettings: sfMarxanSettings,
-          } = sf;
+        return splitFeaturesSelected
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((sf) => {
+            const {
+              id: sfId,
+              name: sfName,
+              marxanSettings: sfMarxanSettings,
+            } = sf;
 
-          return {
-            ...sf,
-            id: `${id}-${sfId}`,
-            parentId: id,
-            name: `${name} / ${sfName}`,
-            splitted: true,
-            ...!!sfMarxanSettings && {
-              target: sfMarxanSettings.prop * 100,
-              fpf: sfMarxanSettings.fpf,
-            },
-          };
-        });
+            return {
+              ...sf,
+              id: `${id}-${sfId}`,
+              parentId: id,
+              name: `${name} / ${sfName}`,
+              splitted: true,
+              splitSelected,
+              splitFeaturesSelected,
+              ...!!sfMarxanSettings && {
+                target: sfMarxanSettings.prop * 100,
+                fpf: sfMarxanSettings.fpf,
+              },
+            };
+          });
       }
 
-      if (isIntersected) {
-        return flatten(intersectFeaturesSelected.map((ifs) => {
-          const {
-            value: ifId,
-            label: ifName,
-            marxanSettings: ifMarxanSettings,
-          } = ifs;
+      // if (isIntersected) {
+      //   return flatten(intersectFeaturesSelected.map((ifs) => {
+      //     const {
+      //       value: ifId,
+      //       label: ifName,
+      //       marxanSettings: ifMarxanSettings,
+      //     } = ifs;
 
-          return {
-            ...ifs,
-            id: `${id}-${ifId}`,
-            parentId: id,
-            name: `${name} / ${ifName}`,
-            splitted: true,
-            ...!!ifMarxanSettings && {
-              target: ifMarxanSettings.prop * 100,
-              fpf: ifMarxanSettings.fpf,
-            },
-          };
-        }));
-      }
+      //     return {
+      //       ...ifs,
+      //       id: `${id}-${ifId}`,
+      //       parentId: id,
+      //       name: `${name} / ${ifName}`,
+      //       splitted: true,
+      //       ...!!ifMarxanSettings && {
+      //         target: ifMarxanSettings.prop * 100,
+      //         fpf: ifMarxanSettings.fpf,
+      //       },
+      //     };
+      //   }));
+      // }
 
       return {
         ...s,

--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -12,7 +12,9 @@ export const COLORS = {
   'features-preview': {
     default: '#FFCC00',
     hover: '#FF9900',
-    ramp: ['#C21701', '#3278B3', '3DF7B3', '#FFF'],
+    ramp: [
+      '#4b5eef', '#f15100', '#31a904', '#2c18bd', '#bf3220', '#9d2e38', '#e5e001', '#f15100', '#f4af00', '#218134', '#775b32', '#cb9c00', '#294635', '#ba5da9', '#5c3b85', '#de4210',
+    ],
   },
   wdpa: '#00F',
   features: '#6F53F7',
@@ -114,6 +116,7 @@ export const LEGEND_LAYERS = {
 
   'features-preview': (options) => {
     const { items } = options;
+
     return {
       id: 'features-preview',
       name: 'Features preview',
@@ -123,9 +126,13 @@ export const LEGEND_LAYERS = {
         visibility: true,
       },
       items: items.map((item, i) => {
+        const COLOR = (items.length > COLORS['features-preview'].ramp.length)
+          ? chroma.scale(COLORS['features-preview'].ramp).colors(items.length)[i]
+          : COLORS['features-preview'].ramp[i];
+
         return {
           value: item.name,
-          color: chroma.scale(COLORS['features-preview'].ramp).mode('lch').colors(items.length)[i],
+          color: COLOR,
         };
       }),
     };

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -301,7 +301,7 @@ export function useFeaturePreviewLayers({
                 ...F.splitSelected && {
                   filter: [
                     'all',
-                    ['in', ['get', F.splitSelected], ['literal', F.splitFeaturesSelected.map((s) => s.id)]],
+                    ['in', ['to-string', ['get', F.splitSelected]], ['literal', F.splitFeaturesSelected.map((s) => s.id)]],
                   ],
                 },
                 layout: {
@@ -318,7 +318,7 @@ export function useFeaturePreviewLayers({
                 ...F.splitSelected && {
                   filter: [
                     'all',
-                    ['in', ['get', F.splitSelected], ['literal', F.splitFeaturesSelected.map((s) => s.id)]],
+                    ['in', ['to-string', ['get', F.splitSelected]], ['literal', F.splitFeaturesSelected.map((s) => s.id)]],
                   ],
                 },
                 layout: {

--- a/app/hooks/map/types.ts
+++ b/app/hooks/map/types.ts
@@ -1,4 +1,5 @@
 import { ItemProps as SelectedItemProps } from 'components/features/selected-item/component';
+import { TargetSPFItemProps } from 'components/features/target-spf-item/types';
 
 export interface UseGeoJSONLayer {
   cache?: number;
@@ -76,6 +77,19 @@ export interface UseFeaturePreviewLayers {
   active?: boolean;
   bbox?: number[] | unknown;
   features?: SelectedItemProps[];
+  options?: {
+    featuresRecipe?: Record<string, any>[],
+    featureHoverId?: string;
+    selectedFeatures?: Array<string>;
+    opacity?: number;
+    visibility?: boolean;
+  };
+}
+export interface UseTargetedPreviewLayers {
+  cache?: number;
+  active?: boolean;
+  bbox?: number[] | unknown;
+  features?: TargetSPFItemProps[];
   options?: {
     featuresRecipe?: Record<string, any>[],
     featureHoverId?: string;

--- a/app/layout/scenarios/edit/features/set-up/add/list/component.tsx
+++ b/app/layout/scenarios/edit/features/set-up/add/list/component.tsx
@@ -166,8 +166,10 @@ export const ScenariosFeaturesList: React.FC<ScenariosFeaturesListProps> = () =>
       ...feature,
       splitFeaturesSelected: key,
     };
+
     onChange(features);
-  }, []);
+    dispatch(setFeatures(features));
+  }, [dispatch, setFeatures]);
 
   const onRemove = useCallback((id, input) => {
     const { value, onChange } = input;


### PR DESCRIPTION
## Preview splitted features

### Overview

This PR adds the possibility to show preview layers on the map, even if they are splitted. 

I also change a little bit the way we were assigning the colors to those layers to prevent changing the color once you add one layer to the map. Adding the layers 
