### PR TITLE
fix(front): use onTarget value on  target achievement and gap analysis

### DIFF
--- a/app/components/gap-analysis/item/component.tsx
+++ b/app/components/gap-analysis/item/component.tsx
@@ -24,6 +24,7 @@ export interface ItemProps {
     value: string;
     unit: string;
   }
+  onTarget: boolean;
   className?: string;
   highlighted?: boolean;
   onHighlight?: () => void;
@@ -33,15 +34,20 @@ export interface ItemProps {
 }
 
 export const Item: React.FC<ItemProps> = ({
-  name, current, target, className, highlighted, muted, onMouseEnter, onMouseLeave, onHighlight,
+  name,
+  current,
+  target,
+  className,
+  onTarget,
+  highlighted,
+  muted,
+  onMouseEnter,
+  onMouseLeave,
+  onHighlight,
 }: ItemProps) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const [chartEl, setChartEl] = useState(null);
   const percentFormatter = useNumberFormatter({ style: 'percent' });
-
-  const isNotMet = useMemo(() => {
-    return current.percent < target.percent;
-  }, [current, target]);
 
   const metStyles = useMemo(() => {
     if (chartEl) {
@@ -73,7 +79,7 @@ export const Item: React.FC<ItemProps> = ({
         'text-white px-4 pt-1 pb-4 border-l-4 transition-opacity duration-300 relative overflow-hidden': true,
         'opacity-20': muted,
         'border-purple-700': true,
-        'pb-8': isNotMet,
+        'pb-8': !onTarget,
         [className]: className !== undefined && className !== null,
       })}
       onMouseEnter={onMouseEnter}
@@ -143,7 +149,7 @@ export const Item: React.FC<ItemProps> = ({
           style={{ width: `${target.percent * 100}%` }}
         />
 
-        {(isNotMet && (
+        {(!onTarget && (
           <div
             className="absolute w-px h-4 transform -translate-y-1/2 bg-red-500 top-1/2"
             style={{

--- a/app/hooks/gap-analysis/index.ts
+++ b/app/hooks/gap-analysis/index.ts
@@ -122,11 +122,13 @@ export function usePreGapAnalysis(sId, options: UseFeaturesOptionsProps = {}) {
           metArea,
           coverageTarget,
           coverageTargetArea,
+          onTarget,
         } = d;
 
         return {
           id,
           name: name || featureClassName || 'Metadata name',
+          onTarget,
           current: {
             percent: met / 100,
             value: format('.3s')(metArea / 1000000),
@@ -219,11 +221,13 @@ export function usePostGapAnalysis(sId, options: UseFeaturesOptionsProps = {}) {
           metArea,
           coverageTarget,
           coverageTargetArea,
+          onTarget,
         } = d;
 
         return {
           id,
           name: name || featureClassName || 'Metadata name',
+          onTarget,
           current: {
             percent: met / 100,
             value: format('.3s')(metArea / 1000000),


### PR DESCRIPTION
## Use onTarget value on  target achievement and gap analysis

### Overview
Split from BE PR
[https://github.com/Vizzuality/marxan-cloud/pull/1256#pullrequestreview-1160014410](https://github.com/Vizzuality/marxan-cloud/pull/1256#pullrequestreview-1160014410)

### Testing instructions
Test with new Andrea and Ana share project `/projects/c2d153f4-d480-4720-bff9-bd4b199da859` and also with other accounts.

### Feature relevant tickets
[MARXAN-1818](https://vizzuality.atlassian.net/browse/MARXAN-1818)
