### PR TITLE
Enable patch version updates on k8s

### DIFF
--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -71,26 +71,28 @@ module "kubernetes" {
 }
 
 module "data_node_pool" {
-  source         = "./modules/node_pool"
-  name           = "data"
-  aks_cluster_id = module.kubernetes.cluster_id
-  resource_group = data.azurerm_resource_group.resource_group
-  project_name   = var.project_name
-  subnet_id      = module.network.aks_subnet_id
-  node_labels    = {
+  source               = "./modules/node_pool"
+  name                 = "data"
+  aks_cluster_id       = module.kubernetes.cluster_id
+  resource_group       = data.azurerm_resource_group.resource_group
+  project_name         = var.project_name
+  subnet_id            = module.network.aks_subnet_id
+  orchestrator_version = var.kubernetes_version
+  node_labels          = {
     type : "data"
   }
 }
 
 module "app_node_pool" {
-  source         = "./modules/node_pool"
-  name           = "app"
-  aks_cluster_id = module.kubernetes.cluster_id
-  resource_group = data.azurerm_resource_group.resource_group
-  project_name   = var.project_name
-  subnet_id      = module.network.aks_subnet_id
-  vm_size        = "Standard_F4s_v2"
-  node_labels    = {
+  source               = "./modules/node_pool"
+  name                 = "app"
+  aks_cluster_id       = module.kubernetes.cluster_id
+  resource_group       = data.azurerm_resource_group.resource_group
+  project_name         = var.project_name
+  subnet_id            = module.network.aks_subnet_id
+  vm_size              = "Standard_F4s_v2"
+  orchestrator_version = var.kubernetes_version
+  node_labels          = {
     type : "app"
   }
 }

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -57,6 +57,7 @@ module "kubernetes" {
   resource_group           = data.azurerm_resource_group.resource_group
   project_name             = var.project_name
   aks_subnet_id            = module.network.aks_subnet_id
+  kubernetes_version       = var.kubernetes_version
   virtual_networks_to_link = {
     (module.network.core_vnet_name) = module.network.core_vnet_id
     (module.network.aks_vnet_name)  = module.network.aks_vnet_id

--- a/infrastructure/base/modules/kubernetes/main.tf
+++ b/infrastructure/base/modules/kubernetes/main.tf
@@ -57,11 +57,23 @@ resource "azurerm_private_dns_zone_virtual_network_link" "link" {
 }
 
 resource "azurerm_kubernetes_cluster" "k8s_cluster" {
-  name                = var.project_name
-  location            = var.resource_group.location
-  resource_group_name = var.resource_group.name
-  dns_prefix          = var.project_name
-  kubernetes_version  = var.kubernetes_version
+  name                      = var.project_name
+  location                  = var.resource_group.location
+  resource_group_name       = var.resource_group.name
+  dns_prefix                = var.project_name
+  kubernetes_version        = var.kubernetes_version
+  automatic_channel_upgrade = "patch"
+
+  maintenance_window {
+    allowed {
+      day   = "Sunday"
+      hours = [22, 23]
+    }
+    allowed {
+      day   = "Monday"
+      hours = [1, 2, 3, 4, 5]
+    }
+  }
 
   private_dns_zone_id = azurerm_private_dns_zone.private_dns_zone.id
 
@@ -101,5 +113,9 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.aks_identity.id]
+  }
+
+  lifecycle {
+    ignore_changes = [kubernetes_version]
   }
 }

--- a/infrastructure/base/modules/kubernetes/main.tf
+++ b/infrastructure/base/modules/kubernetes/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
   resource_group_name       = var.resource_group.name
   dns_prefix                = var.project_name
   kubernetes_version        = var.kubernetes_version
-  automatic_channel_upgrade = "patch"
+#  automatic_channel_upgrade = "patch"
 
   maintenance_window {
     allowed {
@@ -115,7 +115,7 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
     identity_ids = [azurerm_user_assigned_identity.aks_identity.id]
   }
 
-  lifecycle {
-    ignore_changes = [kubernetes_version]
-  }
+#  lifecycle {
+#    ignore_changes = [kubernetes_version]
+#  }
 }

--- a/infrastructure/base/modules/kubernetes/main.tf
+++ b/infrastructure/base/modules/kubernetes/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
   resource_group_name       = var.resource_group.name
   dns_prefix                = var.project_name
   kubernetes_version        = var.kubernetes_version
-#  automatic_channel_upgrade = "patch"
+  automatic_channel_upgrade = "patch"
 
   maintenance_window {
     allowed {
@@ -101,13 +101,14 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
 
 
   default_node_pool {
-    name                = "default"
-    node_count          = 1
-    vm_size             = "Standard_D2_v2"
-    vnet_subnet_id      = var.aks_subnet_id
-    enable_auto_scaling = var.enable_auto_scaling
-    min_count           = var.min_node_count
-    max_count           = var.max_node_count
+    name                 = "default"
+    node_count           = 1
+    vm_size              = "Standard_D2_v2"
+    vnet_subnet_id       = var.aks_subnet_id
+    enable_auto_scaling  = var.enable_auto_scaling
+    min_count            = var.min_node_count
+    max_count            = var.max_node_count
+    orchestrator_version = var.kubernetes_version
   }
 
   identity {
@@ -115,7 +116,7 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
     identity_ids = [azurerm_user_assigned_identity.aks_identity.id]
   }
 
-#  lifecycle {
-#    ignore_changes = [kubernetes_version]
-#  }
+  #  lifecycle {
+  #    ignore_changes = [kubernetes_version]
+  #  }
 }

--- a/infrastructure/base/modules/kubernetes/variables.tf
+++ b/infrastructure/base/modules/kubernetes/variables.tf
@@ -10,7 +10,6 @@ variable "resource_group" {
 variable "kubernetes_version" {
   type        = string
   description = "Version of kubernetes to deploy"
-  default     = "1.22.6"
 }
 
 variable "gateway_subnet_id" {

--- a/infrastructure/base/modules/node_pool/main.tf
+++ b/infrastructure/base/modules/node_pool/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool" {
   min_count             = var.min_node_count
   max_count             = var.max_node_count
   vnet_subnet_id        = var.subnet_id
+  orchestrator_version = var.orchestrator_version
 
   node_labels = var.node_labels
 

--- a/infrastructure/base/modules/node_pool/variables.tf
+++ b/infrastructure/base/modules/node_pool/variables.tf
@@ -44,3 +44,7 @@ variable "node_labels" {
 variable "subnet_id" {
   type = string
 }
+
+variable "orchestrator_version" {
+  type = string
+}

--- a/infrastructure/base/variables.tf
+++ b/infrastructure/base/variables.tf
@@ -120,5 +120,4 @@ variable "mapbox_api_token" {
 variable "kubernetes_version" {
   type        = string
   description = "Version of kubernetes to deploy"
-  default     = "1.22.11"
 }

--- a/infrastructure/base/variables.tf
+++ b/infrastructure/base/variables.tf
@@ -116,3 +116,9 @@ variable "mapbox_api_token" {
   type        = string
   description = "Mapbox API token"
 }
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Version of kubernetes to deploy"
+  default     = "1.22.11"
+}

--- a/infrastructure/kubernetes/main.tf
+++ b/infrastructure/kubernetes/main.tf
@@ -64,8 +64,8 @@ module "k8s_storage" {
 }
 
 module "email_templates" {
-  source = "./modules/email-templates"
-  domain = var.email_domain
+  source        = "./modules/email-templates"
+  domain        = var.email_domain
   support_email = var.support_email
 }
 
@@ -243,14 +243,14 @@ module "db_tunnel_production" {
 module "cloning_storage_backup_cronjob_production" {
   count = var.deploy_production ? 1 : 0
 
-  source                             = "./modules/backup"
-  namespace                          = "production"
-  cloning_pvc_name                   = local.cloning_pvc_name
-  cloning_volume_mount_path          = local.cloning_volume_mount_path
-  azure_storage_account_name         = var.storage_account_name
-  restic_repository                  = "azure:${data.terraform_remote_state.core.outputs.cloning_storage_backup_container_production}:/restic-backups/cloning-storage-production"
-  restic_forget_cli_parameters       = "--keep-daily 60 --keep-weekly 52"
-  schedule                           = "15 23 * * *"
+  source                       = "./modules/backup"
+  namespace                    = "production"
+  cloning_pvc_name             = local.cloning_pvc_name
+  cloning_volume_mount_path    = local.cloning_volume_mount_path
+  azure_storage_account_name   = var.storage_account_name
+  restic_repository            = "azure:${data.terraform_remote_state.core.outputs.cloning_storage_backup_container_production}:/restic-backups/cloning-storage-production"
+  restic_forget_cli_parameters = "--keep-daily 60 --keep-weekly 52"
+  schedule                     = "15 23 * * *"
 }
 
 
@@ -324,14 +324,14 @@ module "api_staging" {
 }
 
 module "geoprocessing_staging" {
-  source                    = "./modules/geoprocessing"
-  namespace                 = "staging"
-  image                     = "${data.terraform_remote_state.core.outputs.container_registry_hostname}/marxan-geoprocessing:staging"
-  deployment_name           = "geoprocessing"
-  cleanup_temporary_folders = "false"
-  geo_postgres_logging      = "query"
-  temp_data_pvc_name        = local.temp_data_pvc_name
-  cloning_pvc_name          = local.cloning_pvc_name
+  source                      = "./modules/geoprocessing"
+  namespace                   = "staging"
+  image                       = "${data.terraform_remote_state.core.outputs.container_registry_hostname}/marxan-geoprocessing:staging"
+  deployment_name             = "geoprocessing"
+  cleanup_temporary_folders   = "false"
+  geo_postgres_logging        = "query"
+  temp_data_pvc_name          = local.temp_data_pvc_name
+  cloning_pvc_name            = local.cloning_pvc_name
   temp_data_volume_mount_path = local.temp_data_volume_mount_path
   cloning_volume_mount_path   = local.cloning_volume_mount_path
 
@@ -405,12 +405,36 @@ module "db_tunnel_staging" {
 }
 
 module "cloning_storage_backup_cronjob_staging" {
-  source                             = "./modules/backup"
-  namespace                          = "staging"
-  cloning_pvc_name                   = local.cloning_pvc_name
-  cloning_volume_mount_path          = local.cloning_volume_mount_path
-  azure_storage_account_name         = var.storage_account_name
-  restic_repository                  = "azure:${data.terraform_remote_state.core.outputs.cloning_storage_backup_container_staging}:/restic-backups/cloning-storage-staging"
-  restic_forget_cli_parameters       = "--keep-daily 30 --keep-weekly 8"
-  schedule                           = "15 6 * * *"
+  source                       = "./modules/backup"
+  namespace                    = "staging"
+  cloning_pvc_name             = local.cloning_pvc_name
+  cloning_volume_mount_path    = local.cloning_volume_mount_path
+  azure_storage_account_name   = var.storage_account_name
+  restic_repository            = "azure:${data.terraform_remote_state.core.outputs.cloning_storage_backup_container_staging}:/restic-backups/cloning-storage-staging"
+  restic_forget_cli_parameters = "--keep-daily 30 --keep-weekly 8"
+  schedule                     = "15 6 * * *"
+}
+
+module "staging_ping_test" {
+  count = var.deploy_staging ? 1 : 0
+
+  source                = "./modules/ping_test"
+  namespace             = "staging"
+  resource_group        = data.azurerm_resource_group.resource_group
+  project_name          = var.project_name
+  location              = data.azurerm_resource_group.resource_group.location
+  domain                = "staging.${var.domain}"
+  alert_email_addresses = var.alert_email_addresses
+}
+
+module "production_ping_test" {
+  count = var.deploy_production ? 1 : 0
+
+  source                = "./modules/ping_test"
+  namespace             = "production"
+  resource_group        = data.azurerm_resource_group.resource_group
+  project_name          = var.project_name
+  location              = data.azurerm_resource_group.resource_group.location
+  domain                = var.domain
+  alert_email_addresses = var.alert_email_addresses
 }

--- a/infrastructure/kubernetes/modules/ping_test/configuration.xml.tpl
+++ b/infrastructure/kubernetes/modules/ping_test/configuration.xml.tpl
@@ -1,0 +1,11 @@
+<WebTest Name="WebTest1" Id="ABD48585-0831-40CB-9069-682EA6BB3583" Enabled="True" CssProjectStructure="" CssIteration=""
+         Timeout="0" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description=""
+         CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False"
+         RecordedResultFile="" ResultsLocale="">
+  <Items>
+    <Request Method="GET" Guid="a5f10126-e4cd-570d-961c-cea43999a200" Version="1.1" Url="${url}"
+             ThinkTime="0" Timeout="300" ParseDependentRequests="True" FollowRedirects="True" RecordResult="True"
+             Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl=""
+             ReportingName="" IgnoreHttpStatusCode="False"/>
+  </Items>
+</WebTest>

--- a/infrastructure/kubernetes/modules/ping_test/main.tf
+++ b/infrastructure/kubernetes/modules/ping_test/main.tf
@@ -1,0 +1,117 @@
+data "azurerm_log_analytics_workspace" "log_analytics_workspace" {
+  name                = var.project_name
+  resource_group_name = var.resource_group.name
+}
+
+data "template_file" "configuration-frontend" {
+  template = "${file("${path.module}/configuration.xml.tpl")}"
+  vars     = {
+    url = "https://${var.domain}"
+  }
+}
+
+data "template_file" "configuration-api" {
+  template = "${file("${path.module}/configuration.xml.tpl")}"
+  vars     = {
+    url = "https://api.${var.domain}/api/ping"
+  }
+}
+
+resource "azurerm_application_insights" "application_insights" {
+  name                = "${var.project_name}-${var.namespace}"
+  location            = var.location
+  resource_group_name = var.resource_group.name
+  application_type    = "web"
+  workspace_id        = data.azurerm_log_analytics_workspace.log_analytics_workspace.id
+}
+
+resource "azurerm_application_insights_web_test" "frontend" {
+  name                    = "${var.project_name}-${var.namespace}-webtest-frontend"
+  location                = azurerm_application_insights.application_insights.location
+  resource_group_name     = var.resource_group.name
+  application_insights_id = azurerm_application_insights.application_insights.id
+  kind                    = "ping"
+  frequency               = var.frequency
+  timeout                 = 30
+  enabled                 = true
+  geo_locations           = ["emea-gb-db3-azr", "us-fl-mia-edge"]
+
+  configuration = data.template_file.configuration-frontend.rendered
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_application_insights_web_test" "api" {
+  name                    = "${var.project_name}-${var.namespace}-webtest-api"
+  location                = azurerm_application_insights.application_insights.location
+  resource_group_name     = var.resource_group.name
+  application_insights_id = azurerm_application_insights.application_insights.id
+  kind                    = "ping"
+  frequency               = var.frequency
+  timeout                 = 30
+  enabled                 = true
+  geo_locations           = ["emea-gb-db3-azr", "us-fl-mia-edge"]
+
+  configuration = data.template_file.configuration-api.rendered
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_monitor_action_group" "action_group" {
+  name                = "${var.project_name}-${var.namespace}"
+  resource_group_name = azurerm_application_insights.application_insights.resource_group_name
+  short_name          = var.project_name
+
+  dynamic "email_receiver" {
+    for_each = var.alert_email_addresses
+    content {
+      name                    = email_receiver.key
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "metric_alert_frontend" {
+  name                = "${var.project_name}-${var.namespace}-metricalert-frontend"
+  resource_group_name = azurerm_application_insights.application_insights.resource_group_name
+  scopes              = [
+    azurerm_application_insights_web_test.frontend.id, azurerm_application_insights.application_insights.id
+  ]
+  description = "PING test alert for ${var.project_name} ${var.namespace} frontend"
+  severity    = 0
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_web_test.frontend.id
+    component_id          = azurerm_application_insights.application_insights.id
+    failed_location_count = 2
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group.id
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "metric_alert_api" {
+  name                = "${var.project_name}-${var.namespace}-metricalert-api"
+  resource_group_name = azurerm_application_insights.application_insights.resource_group_name
+  scopes              = [
+    azurerm_application_insights_web_test.api.id, azurerm_application_insights.application_insights.id
+  ]
+  description = "PING test alert for ${var.project_name} ${var.namespace} api"
+  severity    = 0
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_web_test.api.id
+    component_id          = azurerm_application_insights.application_insights.id
+    failed_location_count = 2
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.action_group.id
+  }
+}

--- a/infrastructure/kubernetes/modules/ping_test/variables.tf
+++ b/infrastructure/kubernetes/modules/ping_test/variables.tf
@@ -1,0 +1,31 @@
+variable "project_name" {
+  type        = string
+  description = "A project name to use when naming resources."
+}
+
+variable "resource_group" {
+  description = "The Azure resource group where the module will create its resources"
+}
+
+variable "location" {
+  description = "Specifies the location where firewall will be deployed"
+  type        = string
+}
+
+variable "frequency" {
+  description = "Interval in seconds between test runs"
+  default = 600
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "domain" {
+  description = "Domain to test"
+  type = string
+}
+
+variable "alert_email_addresses" {
+  description = "key-value pair of name of email receiver and their email address"
+}

--- a/infrastructure/kubernetes/variables.tf
+++ b/infrastructure/kubernetes/variables.tf
@@ -35,7 +35,7 @@ variable "email_domain" {
 }
 
 variable "support_email" {
-  type = string
+  type        = string
   description = "Email address to which users can send support requests"
 }
 
@@ -75,4 +75,14 @@ variable "project_tags" {
 variable "deploy_production" {
   type        = bool
   description = "If the production deployment should be created"
+}
+
+variable "deploy_staging" {
+  type        = bool
+  description = "If the staging deployment should be created. Not fully implemented"
+  default     = true
+}
+
+variable "alert_email_addresses" {
+  description = "Key-value pair of name of email receiver and their email address. Used for sending ping test alert emails"
 }


### PR DESCRIPTION
Tried to apply this, ran into the following:

> │ Error: updating Cluster: (Managed Cluster Name "marxan-tnc" / Resource Group "marxan-rg"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="BadRequest" Message="To enabled Auto Upgrade, agentpools and cluster kubernetes versions must be at least (lowest supported minor version - 1) for rapid and stable channel or supported for patch and node-image channel."

Need to further look into it, didn't want to invest more time without ok from the client