### PR TITLE
fix default BESTSCORE value [MARXAN-1819]

### DIFF
--- a/api/apps/api/test/scenario-input-files/scenario-input-files.e2e-spec.ts
+++ b/api/apps/api/test/scenario-input-files/scenario-input-files.e2e-spec.ts
@@ -98,7 +98,7 @@ describe(`when getting input.dat`, () => {
       RUNMODE 1
       HEURTYPE -1
       RANDSEED -1
-      BESTSCORE 0
+      BESTSCORE -1
       CLUMPTYPE 0
       ITIMPTYPE 0
       MISSLEVEL 1
@@ -149,7 +149,7 @@ describe(`when getting input.dat`, () => {
       RUNMODE 1
       HEURTYPE -1
       RANDSEED -1
-      BESTSCORE 0
+      BESTSCORE -1
       CLUMPTYPE 0
       ITIMPTYPE 0
       MISSLEVEL 1
@@ -200,7 +200,7 @@ describe(`when getting input.dat`, () => {
       RUNMODE 1
       HEURTYPE -1
       RANDSEED -1
-      BESTSCORE 0
+      BESTSCORE -1
       CLUMPTYPE 0
       ITIMPTYPE 0
       MISSLEVEL 1

--- a/api/libs/marxan-input/src/__snapshots__/marxan-input.spec.ts.snap
+++ b/api/libs/marxan-input/src/__snapshots__/marxan-input.spec.ts.snap
@@ -31,7 +31,7 @@ Array [
     },
     "property": "HEURTYPE",
     "target": MarxanParameters {
-      "BESTSCORE": 0,
+      "BESTSCORE": -1,
       "BLM": 1,
       "CLUMPTYPE": 0,
       "COOLFAC": 0,

--- a/api/libs/marxan-input/src/marxan-input.spec.ts
+++ b/api/libs/marxan-input/src/marxan-input.spec.ts
@@ -48,7 +48,7 @@ describe(`when empty input is provided`, () => {
   it(`should resolve to defaults`, () => {
     expect(sut.from({})).toMatchInlineSnapshot(`
       MarxanParameters {
-        "BESTSCORE": 0,
+        "BESTSCORE": -1,
         "BLM": 1,
         "CLUMPTYPE": 0,
         "COOLFAC": 0,

--- a/api/libs/marxan-input/src/marxan-parameters.ts
+++ b/api/libs/marxan-input/src/marxan-parameters.ts
@@ -40,7 +40,7 @@ export class MarxanParametersDefaults {
   BLM = 1;
   PROP = 0.5;
   RANDSEED = -1;
-  BESTSCORE = 0;
+  BESTSCORE = -1;
   NUMREPS = 10;
   NUMITNS = 1000000;
   STARTTEMP = -1;


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Default should be `-1`.

### Designs

N/A

### Testing instructions

When entering the tab to set advanced Marxan settings, BESTSCORE should be set to `-1`.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-1819

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file