### PR TITLE
only purge expired private project exports [MARXAN-1823]

### DIFF
--- a/api/apps/api/config/default.json
+++ b/api/apps/api/config/default.json
@@ -67,7 +67,7 @@
       "artifactValidityInHours": 168,
       "cleanupTemporaryFolders": true,
       "cleanupCronJobSettings": {
-        "interval": "0 0 1 1 *"
+        "interval": "23 5 * * *"
       }
     }
   },


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Fix overly eager query - it would identify all project exports created over the configured timespan as to be purged, whereas exports of published projects must never be purged.

The PR also actually enables scheduled cleanups (until now they were conservatively semi-paused, executing only once yearly).

### Designs

N/A

### Testing instructions

Exports of published projects should never be purged

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MARXAN-1823

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file