### PR TITLE
use in-container port by default [MRXN23-50]

### DIFF
--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-shared/assets/asset-fetcher.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-shared/assets/asset-fetcher.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import axios, { CancelTokenSource } from 'axios';
 import { WriteStream } from 'fs';
@@ -29,6 +29,7 @@ export class AssetFetcher {
       );
       assetStream.data.pipe(output);
     } catch (error) {
+      Logger.error(error);
       output.end();
       return;
     }

--- a/env.default
+++ b/env.default
@@ -47,7 +47,7 @@ SIGNUP_CONFIRMATION_TOKEN_PREFIX=/auth/sign-up-confirmation?token=
 WEBSHOT_APP_PORT=3100
 
 NEXT_PUBLIC_URL=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://api:3030
+NEXT_PUBLIC_API_URL=http://localhost:3030
 NEXTAUTH_URL=http://localhost:3000
 NEXT_PUBLIC_MAPBOX_API_TOKEN=
 

--- a/env.default
+++ b/env.default
@@ -33,7 +33,7 @@ BACKEND_HTTP_LOGGING_MORGAN_FORMAT=short
 REDIS_API_SERVICE_PORT=3050
 REDIS_COMMANDER_PORT=9000
 API_LOGGING_MUTE_ALL=true
-API_SERVICE_URL=http://api:3030
+API_SERVICE_URL=http://api:3000
 # Sparkpost API key required for sending emails
 # To boot the application without email support,
 # add, simply add a random, non-empty string


### PR DESCRIPTION
I think we were relying on a networking configuration that is either valid in Compose v1 and not in v2 or on some combination of factors that made it possible in Compose v1 to reach a service running in a container, from a container on the same Docker network, using a port exposed via the `services.<servicename>.ports` configuration section, whereas this is not possible (arguably, for very good reasons) in Compose v2.

This commit fixes the `env.default` file so that it can be used "out of the box" after running `make .env` in a development instance.