### PR TITLE
[api] Clear PU status by category

### DIFF
--- a/api/apps/api/src/modules/scenarios/dto/clear-lock-status-param.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/clear-lock-status-param.dto.ts
@@ -1,0 +1,10 @@
+import { IsEnum, IsUUID } from 'class-validator';
+import { LockStatus } from '@marxan/scenarios-planning-unit';
+
+export class ClearLockStatusParams {
+  @IsUUID()
+  id!: string;
+
+  @IsEnum(LockStatus)
+  kind!: LockStatus;
+}

--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
@@ -32,7 +32,7 @@ export class ScenarioPlanningUnitsService {
     scenarioId: string,
     lockStatus: LockStatus,
   ): Promise<ScenariosPlanningUnitGeoEntity[]> {
-    return this.puRepo.find({
+    return await this.puRepo.find({
       where: {
         scenarioId,
         lockStatus,

--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
@@ -28,6 +28,18 @@ export class ScenarioPlanningUnitsService {
     });
   }
 
+  async getByStatus(
+    scenarioId: string,
+    lockStatus: LockStatus,
+  ): Promise<ScenariosPlanningUnitGeoEntity[]> {
+    return this.puRepo.find({
+      where: {
+        scenarioId,
+        lockStatus,
+      },
+    });
+  }
+
   async resetLockStatus(scenarioId: string): Promise<void> {
     return await this.entityManager.transaction(async (manager) => {
       await manager.update(

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -530,7 +530,7 @@ export class ScenariosController {
   @Delete(':id/planning-units/status/:kind')
   async clearPlanningUnitsStatus(
     @Param('id', ParseUUIDPipe) id: string,
-    @Param('kind', ParseUUIDPipe) kind: LockStatus,
+    @Param('kind') kind: string,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<JsonApiAsyncJobMeta> {
     const result = await this.service.clearLockStatuses(id, req.user.id, kind);

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -530,7 +530,7 @@ export class ScenariosController {
   @Delete(':id/planning-units/status/:kind')
   async clearPlanningUnitsStatus(
     @Param('id', ParseUUIDPipe) id: string,
-    @Param('kind') kind: string,
+    @Param('kind') kind: LockStatus,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<JsonApiAsyncJobMeta> {
     const result = await this.service.clearLockStatuses(id, req.user.id, kind);

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -108,8 +108,8 @@ import { forbiddenError } from '../access-control';
 import { scenarioNotFound } from '../blm/values/blm-repos';
 import { RequestScenarioCloneResponseDto } from './dto/scenario-clone.dto';
 import { ensureShapefileHasRequiredFiles } from '@marxan-api/utils/file-uploads.utils';
-import { LockStatus } from '@marxan/scenarios-planning-unit';
 import { WebshotPdfReportConfig } from '@marxan/webshot/webshot.dto';
+import { ClearLockStatusParams } from '@marxan-api/modules/scenarios/dto/clear-lock-status-param.dto';
 
 const basePath = `${apiGlobalPrefixes.v1}/scenarios`;
 const solutionsSubPath = `:id/marxan/solutions`;
@@ -529,14 +529,17 @@ export class ScenariosController {
   @ApiOkResponse()
   @Delete(':id/planning-units/status/:kind')
   async clearPlanningUnitsStatus(
-    @Param('id', ParseUUIDPipe) id: string,
-    @Param('kind') kind: LockStatus,
+    @Param() params: ClearLockStatusParams,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<JsonApiAsyncJobMeta> {
-    const result = await this.service.clearLockStatuses(id, req.user.id, kind);
+    const result = await this.service.clearLockStatuses(
+      params.id,
+      req.user.id,
+      params.kind,
+    );
     if (isLeft(result)) {
       throw mapAclDomainToHttpError(result.left, {
-        scenarioId: id,
+        scenarioId: params.id,
         userId: req.user.id,
         resourceType: scenarioResource.name.plural,
       });

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -435,7 +435,7 @@ export class ScenariosService {
   async clearLockStatuses(
     scenarioId: string,
     userId: string,
-    kind: LockStatus,
+    kind: string,
   ): Promise<
     Either<
       | typeof forbiddenError
@@ -485,7 +485,7 @@ export class ScenariosService {
 
   private async mapCurrentPuStatusesAndClearRequested(
     scenarioId: string,
-    kindToClear: LockStatus,
+    kindToClear: string,
   ): Promise<AdjustPlanningUnitsInput> {
     const lockedInPus = await this.planningUnitsService.getByStatus(
       scenarioId,

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -435,7 +435,7 @@ export class ScenariosService {
   async clearLockStatuses(
     scenarioId: string,
     userId: string,
-    kind: string,
+    kind: LockStatus,
   ): Promise<
     Either<
       | typeof forbiddenError
@@ -485,7 +485,7 @@ export class ScenariosService {
 
   private async mapCurrentPuStatusesAndClearRequested(
     scenarioId: string,
-    kindToClear: string,
+    kindToClear: LockStatus,
   ): Promise<AdjustPlanningUnitsInput> {
     const lockedInPus = await this.planningUnitsService.getByStatus(
       scenarioId,

--- a/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
+++ b/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
@@ -35,7 +35,7 @@ export const HasExpectedJobDetails = (job: Job) =>
   `,
   );
 
-export const HasExpectedJobDetailsWhenClearing = (job: Job) =>
+export const HasExpectedJobDetailsWhenClearingLockedIn = (job: Job) =>
   expect(job.data).toMatchInlineSnapshot(
     {
       exclude: {
@@ -52,6 +52,69 @@ export const HasExpectedJobDetailsWhenClearing = (job: Job) =>
       },
       "makeAvailable": Object {
         "pu": Array [],
+      },
+      "scenarioId": Any<String>,
+    }
+  `,
+  );
+
+export const HasExpectedJobDetailsWhenClearingLockedOut = (job: Job) =>
+  expect(job.data).toMatchInlineSnapshot(
+    {
+      include: {
+        pu: expect.arrayContaining([
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+        ]),
+      },
+      scenarioId: expect.any(String),
+    },
+    `
+    Object {
+      "include": Object {
+        "pu": ArrayContaining [
+          Any<String>,
+          Any<String>,
+          Any<String>,
+        ],
+      },
+      "makeAvailable": Object {
+        "pu": Array [],
+      },
+      "scenarioId": Any<String>,
+    }
+  `,
+  );
+
+export const HasExpectedJobDetailsWhenClearingAvailable = (job: Job) =>
+  expect(job.data).toMatchInlineSnapshot(
+    {
+      exclude: {
+        pu: expect.arrayContaining([expect.any(String)]),
+      },
+      include: {
+        pu: expect.arrayContaining([
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+        ]),
+      },
+      scenarioId: expect.any(String),
+    },
+    `
+    Object {
+      "exclude": Object {
+        "pu": ArrayContaining [
+          Any<String>,
+        ],
+      },
+      "include": Object {
+        "pu": ArrayContaining [
+          Any<String>,
+          Any<String>,
+          Any<String>,
+        ],
       },
       "scenarioId": Any<String>,
     }

--- a/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
+++ b/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
@@ -34,3 +34,26 @@ export const HasExpectedJobDetails = (job: Job) =>
     }
   `,
   );
+
+export const HasExpectedJobDetailsWhenClearing = (job: Job) =>
+  expect(job.data).toMatchInlineSnapshot(
+    {
+      exclude: {
+        pu: expect.arrayContaining([expect.any(String)]),
+      },
+      scenarioId: expect.any(String),
+    },
+    `
+    Object {
+      "exclude": Object {
+        "pu": ArrayContaining [
+          Any<String>,
+        ],
+      },
+      "makeAvailable": Object {
+        "pu": Array [],
+      },
+      "scenarioId": Any<String>,
+    }
+  `,
+  );

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -31,7 +31,7 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
   });
 
   it(`clearing locked in PUs triggers the job`, async () => {
-    const result = await world.WhenClearingLockedInPUsStatusWithExisitingPu();
+    const result = await world.WhenClearingLockedInPUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();
     HasExpectedJobDetailsWhenClearingLockedIn(job);
@@ -39,7 +39,7 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
   });
 
   it(`clearing locked out PUs triggers the job`, async () => {
-    const result = await world.WhenClearingLockedOutPUsStatusWithExisitingPu();
+    const result = await world.WhenClearingLockedOutPUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();
     HasExpectedJobDetailsWhenClearingLockedOut(job);
@@ -47,7 +47,7 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
   });
 
   it(`clearing available PUs triggers the job`, async () => {
-    const result = await world.WhenClearingAvailablePUsStatusWithExisitingPu();
+    const result = await world.WhenClearingAvailablePUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();
     HasExpectedJobDetailsWhenClearingAvailable(job);

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -30,6 +30,14 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
     queue.disposeFakeJobs();
   });
 
+  it(`sending incorrect kind returns error`, async () => {
+    const result = await world.WhenClearingAvailablePUsStatusWithIncorrectStatusType();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].meta.rawError.response.message[0]).toEqual(
+      'kind must be a valid enum value',
+    );
+  });
+
   it(`clearing locked in PUs triggers the job`, async () => {
     const result = await world.WhenClearingLockedInPUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -30,7 +30,7 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
     queue.disposeFakeJobs();
   });
 
-  it(` clearing locked in PUs triggers the job`, async () => {
+  it(`clearing locked in PUs triggers the job`, async () => {
     const result = await world.WhenClearingLockedInPUsStatusWithExisitingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -18,35 +18,39 @@ let queue: FakeQueue;
 
 let world: PromiseType<ReturnType<typeof createWorld>>;
 
-beforeEach(async () => {
-  app = await bootstrapApplication();
-  jwtToken = await GivenUserIsLoggedIn(app);
-  queue = FakeQueue.getByName(updateQueueName);
-  world = await createWorld(app, jwtToken);
-});
-
 describe(`when requesting to clear PUs statuses by kind`, () => {
-  describe(`when desired PU ids are available`, () => {
-    it(` when clearing locked in PUs triggers the job`, async () => {
-      const result = await world.WhenClearingLockedInPUsStatusWithExisitingPu();
-      const job = Object.values(queue.jobs)[0];
-      expect(result.meta.started).toBeTruthy();
-      HasExpectedJobDetailsWhenClearingLockedIn(job);
-      HasRelevantJobName(job, world.scenarioId);
-    });
-    it(`when clearing locked out PUs triggers the job`, async () => {
-      const result = await world.WhenClearingLockedOutPUsStatusWithExisitingPu();
-      const job = Object.values(queue.jobs)[0];
-      expect(result.meta.started).toBeTruthy();
-      HasExpectedJobDetailsWhenClearingLockedOut(job);
-      HasRelevantJobName(job, world.scenarioId);
-    });
-    it(`when clearing available PUs triggers the job`, async () => {
-      const result = await world.WhenClearingAvailablePUsStatusWithExisitingPu();
-      const job = Object.values(queue.jobs)[0];
-      expect(result.meta.started).toBeTruthy();
-      HasExpectedJobDetailsWhenClearingAvailable(job);
-      HasRelevantJobName(job, world.scenarioId);
-    });
+  beforeEach(async () => {
+    app = await bootstrapApplication();
+    jwtToken = await GivenUserIsLoggedIn(app);
+    queue = FakeQueue.getByName(updateQueueName);
+    world = await createWorld(app, jwtToken);
+  });
+
+  afterEach(async () => {
+    queue.disposeFakeJobs();
+  });
+
+  it(` clearing locked in PUs triggers the job`, async () => {
+    const result = await world.WhenClearingLockedInPUsStatusWithExisitingPu();
+    const job = Object.values(queue.jobs)[0];
+    expect(result.meta.started).toBeTruthy();
+    HasExpectedJobDetailsWhenClearingLockedIn(job);
+    HasRelevantJobName(job, world.scenarioId);
+  });
+
+  it(`clearing when clearing locked out PUs triggers the job`, async () => {
+    const result = await world.WhenClearingLockedOutPUsStatusWithExisitingPu();
+    const job = Object.values(queue.jobs)[0];
+    expect(result.meta.started).toBeTruthy();
+    HasExpectedJobDetailsWhenClearingLockedOut(job);
+    HasRelevantJobName(job, world.scenarioId);
+  });
+
+  it(`clearing available PUs triggers the job`, async () => {
+    const result = await world.WhenClearingAvailablePUsStatusWithExisitingPu();
+    const job = Object.values(queue.jobs)[0];
+    expect(result.meta.started).toBeTruthy();
+    HasExpectedJobDetailsWhenClearingAvailable(job);
+    HasRelevantJobName(job, world.scenarioId);
   });
 });

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -1,0 +1,40 @@
+import { INestApplication } from '@nestjs/common';
+import { PromiseType } from 'utility-types';
+import { bootstrapApplication } from '../utils/api-application';
+import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
+
+import { WhenRequestingStatus } from './steps/WhenRequestingStatus';
+import { createWorld } from './steps/world';
+import { FakeQueue } from '../utils/queues';
+import { ExpectBadRequest } from './assertions/expect-bad-request';
+import { HasRelevantJobName } from './assertions/has-relevant-job-name';
+import {
+  HasExpectedJobDetails,
+  HasExpectedJobDetailsWhenClearing,
+} from './assertions/has-expected-job-details';
+import { updateQueueName } from '@marxan-jobs/planning-unit-geometry';
+
+let app: INestApplication;
+let jwtToken: string;
+let queue: FakeQueue;
+
+let world: PromiseType<ReturnType<typeof createWorld>>;
+
+beforeEach(async () => {
+  app = await bootstrapApplication();
+  jwtToken = await GivenUserIsLoggedIn(app);
+  world = await createWorld(app, jwtToken);
+  queue = FakeQueue.getByName(updateQueueName);
+});
+
+describe(`when requesting to clear PUs statuses by kind`, () => {
+  describe(`when desired PU ids are available`, () => {
+    it(`triggers the job`, async () => {
+      const result = await world.WhenClearingPuStatusesByKindWithExisitingPu();
+      const job = Object.values(queue.jobs)[0];
+      expect(result.meta.started).toBeTruthy();
+      HasExpectedJobDetailsWhenClearing(job);
+      HasRelevantJobName(job, world.scenarioId);
+    });
+  });
+});

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -2,15 +2,13 @@ import { INestApplication } from '@nestjs/common';
 import { PromiseType } from 'utility-types';
 import { bootstrapApplication } from '../utils/api-application';
 import { GivenUserIsLoggedIn } from '../steps/given-user-is-logged-in';
-
-import { WhenRequestingStatus } from './steps/WhenRequestingStatus';
 import { createWorld } from './steps/world';
 import { FakeQueue } from '../utils/queues';
-import { ExpectBadRequest } from './assertions/expect-bad-request';
 import { HasRelevantJobName } from './assertions/has-relevant-job-name';
 import {
-  HasExpectedJobDetails,
-  HasExpectedJobDetailsWhenClearing,
+  HasExpectedJobDetailsWhenClearingAvailable,
+  HasExpectedJobDetailsWhenClearingLockedIn,
+  HasExpectedJobDetailsWhenClearingLockedOut,
 } from './assertions/has-expected-job-details';
 import { updateQueueName } from '@marxan-jobs/planning-unit-geometry';
 
@@ -23,17 +21,31 @@ let world: PromiseType<ReturnType<typeof createWorld>>;
 beforeEach(async () => {
   app = await bootstrapApplication();
   jwtToken = await GivenUserIsLoggedIn(app);
-  world = await createWorld(app, jwtToken);
   queue = FakeQueue.getByName(updateQueueName);
+  world = await createWorld(app, jwtToken);
 });
 
 describe(`when requesting to clear PUs statuses by kind`, () => {
   describe(`when desired PU ids are available`, () => {
-    it(`triggers the job`, async () => {
-      const result = await world.WhenClearingPuStatusesByKindWithExisitingPu();
+    it(` when clearing locked in PUs triggers the job`, async () => {
+      const result = await world.WhenClearingLockedInPUsStatusWithExisitingPu();
       const job = Object.values(queue.jobs)[0];
       expect(result.meta.started).toBeTruthy();
-      HasExpectedJobDetailsWhenClearing(job);
+      HasExpectedJobDetailsWhenClearingLockedIn(job);
+      HasRelevantJobName(job, world.scenarioId);
+    });
+    it(`when clearing locked out PUs triggers the job`, async () => {
+      const result = await world.WhenClearingLockedOutPUsStatusWithExisitingPu();
+      const job = Object.values(queue.jobs)[0];
+      expect(result.meta.started).toBeTruthy();
+      HasExpectedJobDetailsWhenClearingLockedOut(job);
+      HasRelevantJobName(job, world.scenarioId);
+    });
+    it(`when clearing available PUs triggers the job`, async () => {
+      const result = await world.WhenClearingAvailablePUsStatusWithExisitingPu();
+      const job = Object.values(queue.jobs)[0];
+      expect(result.meta.started).toBeTruthy();
+      HasExpectedJobDetailsWhenClearingAvailable(job);
       HasRelevantJobName(job, world.scenarioId);
     });
   });

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -38,7 +38,7 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
     HasRelevantJobName(job, world.scenarioId);
   });
 
-  it(`clearing when clearing locked out PUs triggers the job`, async () => {
+  it(`clearing locked out PUs triggers the job`, async () => {
     const result = await world.WhenClearingLockedOutPUsStatusWithExisitingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();

--- a/api/apps/api/test/scenario-pu-change/steps/WhenChangingPlanningUnitInclusivity.ts
+++ b/api/apps/api/test/scenario-pu-change/steps/WhenChangingPlanningUnitInclusivity.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { getDtoByIds } from '../../../src/modules/scenarios/dto/__mocks__/dtos.data';
+import { LockStatus } from '@marxan/scenarios-planning-unit';
 
 export const WhenChangingPlanningUnitInclusivity = async (
   app: INestApplication,
@@ -13,4 +14,16 @@ export const WhenChangingPlanningUnitInclusivity = async (
       .post(`/api/v1/scenarios/${scenarioId}/planning-units`)
       .set('Authorization', `Bearer ${jwtToken}`)
       .send(getDtoByIds(puIds, [], []))
+  ).body;
+
+export const WhenClearingPuStatusesByKind = async (
+  app: INestApplication,
+  scenarioId: string,
+  jwtToken: string,
+  kind: string,
+) =>
+  (
+    await request(app.getHttpServer())
+      .delete(`/api/v1/scenarios/${scenarioId}/planning-units/status/${kind}`)
+      .set('Authorization', `Bearer ${jwtToken}`)
   ).body;

--- a/api/apps/api/test/scenario-pu-change/steps/world.ts
+++ b/api/apps/api/test/scenario-pu-change/steps/world.ts
@@ -48,7 +48,11 @@ export const createWorld = async (app: INestApplication, jwt: string) => {
         jwt,
         scenariosPuData.map((pu) => pu.id),
       ),
-    WhenClearingPuStatusesByKindWithExisitingPu: async () =>
+    WhenClearingLockedInPUsStatusWithExisitingPu: async () =>
       WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.LockedIn),
+    WhenClearingLockedOutPUsStatusWithExisitingPu: async () =>
+      WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.LockedOut),
+    WhenClearingAvailablePUsStatusWithExisitingPu: async () =>
+      WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.Available),
   };
 };

--- a/api/apps/api/test/scenario-pu-change/steps/world.ts
+++ b/api/apps/api/test/scenario-pu-change/steps/world.ts
@@ -7,7 +7,11 @@ import { v4 } from 'uuid';
 import { GivenScenarioPuDataExists } from '../../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
 import { GivenProjectExists } from '../../steps/given-project';
 import { ScenariosTestUtils } from '../../utils/scenarios.test.utils';
-import { WhenChangingPlanningUnitInclusivity } from './WhenChangingPlanningUnitInclusivity';
+import {
+  WhenChangingPlanningUnitInclusivity,
+  WhenClearingPuStatusesByKind,
+} from './WhenChangingPlanningUnitInclusivity';
+import { LockStatus } from '@marxan/scenarios-planning-unit';
 
 export const createWorld = async (app: INestApplication, jwt: string) => {
   const { projectId } = await GivenProjectExists(app, jwt, {
@@ -44,5 +48,7 @@ export const createWorld = async (app: INestApplication, jwt: string) => {
         jwt,
         scenariosPuData.map((pu) => pu.id),
       ),
+    WhenClearingPuStatusesByKindWithExisitingPu: async () =>
+      WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.LockedIn),
   };
 };

--- a/api/apps/api/test/scenario-pu-change/steps/world.ts
+++ b/api/apps/api/test/scenario-pu-change/steps/world.ts
@@ -48,11 +48,11 @@ export const createWorld = async (app: INestApplication, jwt: string) => {
         jwt,
         scenariosPuData.map((pu) => pu.id),
       ),
-    WhenClearingLockedInPUsStatusWithExisitingPu: async () =>
+    WhenClearingLockedInPUsStatusWithExistingPu: async () =>
       WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.LockedIn),
-    WhenClearingLockedOutPUsStatusWithExisitingPu: async () =>
+    WhenClearingLockedOutPUsStatusWithExistingPu: async () =>
       WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.LockedOut),
-    WhenClearingAvailablePUsStatusWithExisitingPu: async () =>
+    WhenClearingAvailablePUsStatusWithExistingPu: async () =>
       WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.Available),
   };
 };

--- a/api/apps/api/test/scenario-pu-change/steps/world.ts
+++ b/api/apps/api/test/scenario-pu-change/steps/world.ts
@@ -54,5 +54,12 @@ export const createWorld = async (app: INestApplication, jwt: string) => {
       WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.LockedOut),
     WhenClearingAvailablePUsStatusWithExistingPu: async () =>
       WhenClearingPuStatusesByKind(app, scenarioId, jwt, LockStatus.Available),
+    WhenClearingAvailablePUsStatusWithIncorrectStatusType: async () =>
+      WhenClearingPuStatusesByKind(
+        app,
+        scenarioId,
+        jwt,
+        'incorrect-status-type',
+      ),
   };
 };

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/planning-unit-inclusion.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/planning-unit-inclusion.e2e-spec.ts
@@ -239,6 +239,7 @@ describe(`when planning units exist for a scenario`, () => {
 
     it(`clears out PUs statuses by kind`, async () => {
       /** Locking and locking out PUs **/
+
       await sut.process(({
         data: {
           scenarioId: world.scenarioId,
@@ -273,14 +274,35 @@ describe(`when planning units exist for a scenario`, () => {
 
       const PUsLockedInByUser = await world.GetPlanningUnitsLockedInByUser();
       const PUsLockedInByProtectedArea = await world.GetPlanningUnitsLockedInByProtectedArea();
+      const lockedOutPUsAfterClearingIncluded = await world.GetLockedOutPlanningUnits();
 
       /** Now excluded PUs should remain as set by user and included PUs should be cleared,
        * leaving as locked in only PUs within protecting area that have setByUser value as false*/
-      expect(lockedOutPUs).toEqual(world.planningUnitsToBeExcluded(forCase));
+      expect(lockedOutPUsAfterClearingIncluded).toEqual(
+        world.planningUnitsToBeExcluded(forCase),
+      );
       expect(PUsLockedInByUser).toEqual([]);
       expect(PUsLockedInByProtectedArea.length).toEqual(
         world.planningUnitsToBeIncluded(forCase).length,
       );
+
+      /** Clearing locked out PUs statuses **/
+
+      await sut.process(({
+        data: {
+          scenarioId: world.scenarioId,
+          include: {
+            pu: PUsLockedInByProtectedArea,
+          },
+          makeAvailable: {
+            pu: [],
+          },
+        },
+      } as unknown) as Job<JobInput>);
+
+      const lockedOutPUsAfterClearingExcluded = await world.GetLockedOutPlanningUnits();
+
+      expect(lockedOutPUsAfterClearingExcluded).toEqual([]);
     }, 10000);
   });
 });

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/planning-unit-inclusion.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/planning-unit-inclusion.e2e-spec.ts
@@ -157,7 +157,7 @@ describe(`when planning units exist for a scenario`, () => {
         },
       } as unknown) as Job<JobInput>);
 
-      const lockedInPUs = await world.GetLockedInByProtectedAreaPlanningUnits();
+      const lockedInPUs = await world.GetPlanningUnitsLockedInByProtectedArea();
       const availablePUsSetByUser = await world.GetAvailablePlanningUnitsChangedByUser();
 
       expect(lockedInPUs.length).toEqual(7);
@@ -175,7 +175,7 @@ describe(`when planning units exist for a scenario`, () => {
         },
       } as unknown) as Job<JobInput>);
 
-      expect(await world.GetLockedInByProtectedAreaPlanningUnits()).toEqual(
+      expect(await world.GetPlanningUnitsLockedInByProtectedArea()).toEqual(
         lockedInPUs.slice(-4),
       );
       expect(await world.GetAvailablePlanningUnitsChangedByUser()).toEqual(
@@ -271,14 +271,16 @@ describe(`when planning units exist for a scenario`, () => {
         },
       } as unknown) as Job<JobInput>);
 
-      const lockedInByUserPUs = await world.GetLockedInByUserPlanningUnits();
-      const lockedIbByProtectedAreaPUs = await world.GetLockedInByProtectedAreaPlanningUnits();
+      const PUsLockedInByUser = await world.GetPlanningUnitsLockedInByUser();
+      const PUsLockedInByProtectedArea = await world.GetPlanningUnitsLockedInByProtectedArea();
 
       /** Now excluded PUs should remain as set by user and included PUs should be cleared,
        * leaving as locked in only PUs within protecting area that have setByUser value as false*/
       expect(lockedOutPUs).toEqual(world.planningUnitsToBeExcluded(forCase));
-      expect(lockedInByUserPUs).toEqual([]);
-      expect(lockedIbByProtectedAreaPUs.length).toEqual(7);
+      expect(PUsLockedInByUser).toEqual([]);
+      expect(PUsLockedInByProtectedArea.length).toEqual(
+        world.planningUnitsToBeIncluded(forCase).length,
+      );
     }, 10000);
   });
 });

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
@@ -236,6 +236,18 @@ export const createWorld = async (app: INestApplication) => {
       )
         .map((entity) => entity.id)
         .sort(sortUuid),
+    GetLockedInByUserPlanningUnits: async () =>
+      (
+        await scenarioPuDataRepo.find({
+          where: {
+            scenarioId,
+            lockStatus: LockStatus.LockedIn,
+            setByUser: true,
+          },
+        })
+      )
+        .map((entity) => entity.id)
+        .sort(sortUuid),
     GetLockedInByProtectedAreaPlanningUnits: async () =>
       (
         await scenarioPuDataRepo.find({

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
@@ -236,7 +236,7 @@ export const createWorld = async (app: INestApplication) => {
       )
         .map((entity) => entity.id)
         .sort(sortUuid),
-    GetLockedInByUserPlanningUnits: async () =>
+    GetPlanningUnitsLockedInByUser: async () =>
       (
         await scenarioPuDataRepo.find({
           where: {
@@ -248,7 +248,7 @@ export const createWorld = async (app: INestApplication) => {
       )
         .map((entity) => entity.id)
         .sort(sortUuid),
-    GetLockedInByProtectedAreaPlanningUnits: async () =>
+    GetPlanningUnitsLockedInByProtectedArea: async () =>
       (
         await scenarioPuDataRepo.find({
           where: {


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Adding possibility for the user to clear selected kind of previously set statuses: Locked-in, Locked-out or Made available.

Process is the following:
 - Endpoint receives scenario id and kind of status to be cleared
 - Service finds all the PU ids that were set by user for each status kind 
 - Removes the kind selected to be cleared from the claims to be sent to status change processor
 - Processor resets all the statuses and ads only received claims. Since no claims for the selected to be cleared statuses will be received - PUs that had this status will be set to:
  available with setbyUser=false OR 
  locked-in with setByUser=false with protectedByDefault=true in case of PUs belonging to a protected area

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file