### PR TITLE
Add setByUser property to PU endpoint response, update tests

### DIFF
--- a/api/apps/api/src/modules/analysis/providers/shared/__mocks__/scenario-planning-unit-geo.data.ts
+++ b/api/apps/api/src/modules/analysis/providers/shared/__mocks__/scenario-planning-unit-geo.data.ts
@@ -15,4 +15,5 @@ export const validDataWithGivenPuIds = (
     projectPuId: v4(),
     id: id,
     featureList: [],
+    setByUser: false,
   }));

--- a/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.dto.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.dto.ts
@@ -14,4 +14,7 @@ export class ScenarioPlanningUnitDto {
     enum: LockStatus,
   })
   defaultStatus!: LockStatus;
+
+  @ApiProperty()
+  setByUser!: boolean;
 }

--- a/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.serializer.ts
@@ -19,6 +19,7 @@ export class ScenarioPlanningUnitSerializer {
         defaultStatus: unit.protectedByDefault
           ? LockStatus.LockedIn
           : LockStatus.Available,
+        setByUser: unit.setByUser ?? false,
       })),
     );
   }

--- a/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.serializer.ts
@@ -19,7 +19,7 @@ export class ScenarioPlanningUnitSerializer {
         defaultStatus: unit.protectedByDefault
           ? LockStatus.LockedIn
           : LockStatus.Available,
-        setByUser: unit.setByUser ?? false,
+        setByUser: unit.setByUser,
       })),
     );
   }

--- a/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.e2e-spec.ts
+++ b/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.e2e-spec.ts
@@ -25,21 +25,25 @@ describe(`As owner, when scenario has PUs with cost and lock status`, () => {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'available',
+        setByUser: false,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'locked-in',
+        setByUser: true,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'locked-out',
+        setByUser: true,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'available',
+        setByUser: false,
       },
     ]);
   });
@@ -63,21 +67,25 @@ describe(`As contributor, when scenario has PUs with cost and lock status`, () =
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'available',
+        setByUser: false,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'locked-in',
+        setByUser: true,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'locked-out',
+        setByUser: true,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'available',
+        setByUser: false,
       },
     ]);
   });
@@ -101,21 +109,25 @@ describe(`As viewer, when scenario has PUs with cost and lock status`, () => {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'available',
+        setByUser: false,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'locked-in',
+        setByUser: true,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'locked-out',
+        setByUser: true,
       },
       {
         defaultStatus: 'available',
         id: expect.any(String),
         inclusionStatus: 'available',
+        setByUser: false,
       },
     ]);
   });

--- a/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
+++ b/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
@@ -123,6 +123,7 @@ export const getFixtures = async () => {
             projectPuId: pu.id,
             scenarioId,
             lockStatus: lockStatuses[index] ?? null,
+            setByUser: [1, 2].includes(index) ? true : false,
           }),
         ),
       );

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/planning-unit-inclusion.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/planning-unit-inclusion.e2e-spec.ts
@@ -74,6 +74,33 @@ describe(`when planning units exist for a scenario`, () => {
     }, 10000);
   });
 
+  describe(`when changing lock status from available to available via puids with one single feature per feature collection`, () => {
+    const forCase: ForCase = 'singleFeature';
+    beforeEach(async () => {
+      await world.GivenPlanningUnitsExist(forCase, areaUnitsSample(forCase));
+    });
+
+    afterEach(async () => {
+      await world?.cleanup('singleFeature');
+    });
+
+    it(`marks relevant pu in desired state with setByUser = true`, async () => {
+      const availablePUsNotSetByUser = await world.GetAvailablePlanningUnitsNotSetByUser();
+      await sut.process(({
+        data: {
+          scenarioId: world.scenarioId,
+          makeAvailable: {
+            pu: availablePUsNotSetByUser,
+          },
+        },
+      } as unknown) as Job<JobInput>);
+
+      expect(await world.GetAvailablePlanningUnitsChangedByUser()).toEqual(
+        availablePUsNotSetByUser,
+      );
+    }, 10000);
+  });
+
   describe(`when changing lock status via GeoJSON with multiple features per feature collection`, () => {
     const forCase: ForCase = 'multipleFeatures';
     beforeEach(async () => {

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
@@ -301,6 +301,19 @@ export const createWorld = async (app: INestApplication) => {
       )
         .map((entity) => entity.id)
         .sort(sortUuid),
+
+    GetAvailablePlanningUnitsNotSetByUser: async () =>
+      (
+        await scenarioPuDataRepo
+          .createQueryBuilder('scenarioPuData')
+          .where('scenarioPuData.scenario_id = :scenarioId', { scenarioId })
+          .andWhere('scenarioPuData.lockin_status IS NULL')
+          .andWhere('scenarioPuData.lock_status_set_by_user = false')
+          .andWhere('scenarioPuData.protected_by_default = false')
+          .getMany()
+      )
+        .map((entity) => entity.id)
+        .sort(sortUuid),
     cleanup: async (forCase: ForCase) => {
       await puGeometryRepo.delete({
         id: In(geometriesByCase[forCase].storedGeometries),

--- a/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
+++ b/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
@@ -80,7 +80,7 @@ export class ScenariosPlanningUnitGeoEntity {
     default: false,
     name: `lock_status_set_by_user`,
   })
-  setByUser?: boolean;
+  setByUser!: boolean;
 
   @Column({
     type: 'float8',


### PR DESCRIPTION
## Add setByUser property to PU endpoint respose

### Overview

Apart form 'defaultStatus' and 'inclusionStatus' response will also include 'setByUser' property.

Tests updated accordingly.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file