### PR TITLE
[api] Fix setByUser filter bug when changing status by kind

### DIFF
--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
@@ -41,6 +41,7 @@ export class ScenarioPlanningUnitsService {
     });
   }
 
+  // @todo: Review the possibility to use @IsNull() in getByStatusSetByUser instead of having this method
   async getAvailablePUsSetByUser(
     scenarioId: string,
   ): Promise<ScenariosPlanningUnitGeoEntity[]> {
@@ -48,7 +49,7 @@ export class ScenarioPlanningUnitsService {
       .createQueryBuilder('scenarioPuData')
       .where('scenarioPuData.scenario_id = :scenarioId', { scenarioId })
       .andWhere('scenarioPuData.lockin_status IS NULL')
-      .andWhere('scenarioPuData.lock_status_set_by_user = false')
+      .andWhere('scenarioPuData.lock_status_set_by_user = true')
       .getMany();
   }
 

--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
@@ -28,7 +28,7 @@ export class ScenarioPlanningUnitsService {
     });
   }
 
-  async getByStatus(
+  async getByStatusSetByUser(
     scenarioId: string,
     lockStatus: LockStatus,
   ): Promise<ScenariosPlanningUnitGeoEntity[]> {
@@ -36,8 +36,20 @@ export class ScenarioPlanningUnitsService {
       where: {
         scenarioId,
         lockStatus,
+        setByUser: true,
       },
     });
+  }
+
+  async getAvailablePUsSetByUser(
+    scenarioId: string,
+  ): Promise<ScenariosPlanningUnitGeoEntity[]> {
+    return await this.puRepo
+      .createQueryBuilder('scenarioPuData')
+      .where('scenarioPuData.scenario_id = :scenarioId', { scenarioId })
+      .andWhere('scenarioPuData.lockin_status IS NULL')
+      .andWhere('scenarioPuData.lock_status_set_by_user = false')
+      .getMany();
   }
 
   async resetLockStatus(scenarioId: string): Promise<void> {
@@ -50,6 +62,7 @@ export class ScenarioPlanningUnitsService {
         },
         {
           lockStatus: LockStatus.Available,
+          setByUser: false,
         },
       );
 
@@ -61,6 +74,7 @@ export class ScenarioPlanningUnitsService {
         },
         {
           lockStatus: LockStatus.LockedIn,
+          setByUser: false,
         },
       );
     });

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -526,6 +526,21 @@ export class ScenariosController {
   }
 
   @ApiTags(asyncJobTag)
+  @ApiParam({
+    name: 'id',
+    description: 'scenario id',
+    type: String,
+    required: true,
+    example: 'e5c3b978-908c-49d3-b1e3-89727e9f999c',
+  })
+  @ApiQuery({
+    name: 'kind',
+    description:
+      'status kind to be cleared - locked-in, locked-out or available',
+    type: String,
+    required: true,
+    example: 'locked-in',
+  })
   @ApiOkResponse()
   @Delete(':id/planning-units/status/:kind')
   async clearPlanningUnitsStatus(

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -487,19 +487,18 @@ export class ScenariosService {
     scenarioId: string,
     kindToClear: LockStatus,
   ): Promise<AdjustPlanningUnitsInput> {
-    const lockedInPus = await this.planningUnitsService.getByStatus(
+    const lockedInPus = await this.planningUnitsService.getByStatusSetByUser(
       scenarioId,
       LockStatus.LockedIn,
     );
 
-    const lockedOutPus = await this.planningUnitsService.getByStatus(
+    const lockedOutPus = await this.planningUnitsService.getByStatusSetByUser(
       scenarioId,
       LockStatus.LockedOut,
     );
 
-    const availablePus = await this.planningUnitsService.getByStatus(
+    const availablePus = await this.planningUnitsService.getAvailablePUsSetByUser(
       scenarioId,
-      LockStatus.Available,
     );
 
     return {

--- a/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
+++ b/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
@@ -41,6 +41,13 @@ export const HasExpectedJobDetailsWhenClearingLockedIn = (job: Job) =>
       exclude: {
         pu: expect.arrayContaining([expect.any(String)]),
       },
+      makeAvailable: {
+        pu: expect.arrayContaining([
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+        ]),
+      },
       scenarioId: expect.any(String),
     },
     `
@@ -51,7 +58,11 @@ export const HasExpectedJobDetailsWhenClearingLockedIn = (job: Job) =>
         ],
       },
       "makeAvailable": Object {
-        "pu": Array [],
+        "pu": ArrayContaining [
+          Any<String>,
+          Any<String>,
+          Any<String>,
+        ],
       },
       "scenarioId": Any<String>,
     }
@@ -62,6 +73,9 @@ export const HasExpectedJobDetailsWhenClearingLockedOut = (job: Job) =>
   expect(job.data).toMatchInlineSnapshot(
     {
       include: {
+        pu: expect.arrayContaining([expect.any(String)]),
+      },
+      makeAvailable: {
         pu: expect.arrayContaining([
           expect.any(String),
           expect.any(String),
@@ -75,12 +89,14 @@ export const HasExpectedJobDetailsWhenClearingLockedOut = (job: Job) =>
       "include": Object {
         "pu": ArrayContaining [
           Any<String>,
-          Any<String>,
-          Any<String>,
         ],
       },
       "makeAvailable": Object {
-        "pu": Array [],
+        "pu": ArrayContaining [
+          Any<String>,
+          Any<String>,
+          Any<String>,
+        ],
       },
       "scenarioId": Any<String>,
     }
@@ -91,14 +107,10 @@ export const HasExpectedJobDetailsWhenClearingAvailable = (job: Job) =>
   expect(job.data).toMatchInlineSnapshot(
     {
       exclude: {
-        pu: expect.arrayContaining([expect.any(String)]),
+        pu: expect.arrayContaining([expect.any(String), expect.any(String)]),
       },
       include: {
-        pu: expect.arrayContaining([
-          expect.any(String),
-          expect.any(String),
-          expect.any(String),
-        ]),
+        pu: expect.arrayContaining([expect.any(String)]),
       },
       scenarioId: expect.any(String),
     },
@@ -107,12 +119,11 @@ export const HasExpectedJobDetailsWhenClearingAvailable = (job: Job) =>
       "exclude": Object {
         "pu": ArrayContaining [
           Any<String>,
+          Any<String>,
         ],
       },
       "include": Object {
         "pu": ArrayContaining [
-          Any<String>,
-          Any<String>,
           Any<String>,
         ],
       },

--- a/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
+++ b/api/apps/api/test/scenario-pu-change/assertions/has-expected-job-details.ts
@@ -107,7 +107,7 @@ export const HasExpectedJobDetailsWhenClearingAvailable = (job: Job) =>
   expect(job.data).toMatchInlineSnapshot(
     {
       exclude: {
-        pu: expect.arrayContaining([expect.any(String), expect.any(String)]),
+        pu: expect.arrayContaining([expect.any(String)]),
       },
       include: {
         pu: expect.arrayContaining([expect.any(String)]),
@@ -118,7 +118,6 @@ export const HasExpectedJobDetailsWhenClearingAvailable = (job: Job) =>
     Object {
       "exclude": Object {
         "pu": ArrayContaining [
-          Any<String>,
           Any<String>,
         ],
       },

--- a/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
+++ b/api/apps/api/test/scenario-pu-change/scenario-pu-status-clear.e2e-spec.ts
@@ -42,6 +42,8 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
     const result = await world.WhenClearingLockedInPUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();
+    expect(job.data.makeAvailable.pu.length).toBe(3);
+    expect(job.data.exclude.pu.length).toBe(1);
     HasExpectedJobDetailsWhenClearingLockedIn(job);
     HasRelevantJobName(job, world.scenarioId);
   });
@@ -50,6 +52,8 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
     const result = await world.WhenClearingLockedOutPUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();
+    expect(job.data.makeAvailable.pu.length).toBe(3);
+    expect(job.data.include.pu.length).toBe(1);
     HasExpectedJobDetailsWhenClearingLockedOut(job);
     HasRelevantJobName(job, world.scenarioId);
   });
@@ -58,6 +62,8 @@ describe(`when requesting to clear PUs statuses by kind`, () => {
     const result = await world.WhenClearingAvailablePUsStatusWithExistingPu();
     const job = Object.values(queue.jobs)[0];
     expect(result.meta.started).toBeTruthy();
+    expect(job.data.include.pu.length).toBe(1);
+    expect(job.data.exclude.pu.length).toBe(1);
     HasExpectedJobDetailsWhenClearingAvailable(job);
     HasRelevantJobName(job, world.scenarioId);
   });

--- a/api/apps/api/test/scenario-pu-change/steps/world.ts
+++ b/api/apps/api/test/scenario-pu-change/steps/world.ts
@@ -4,7 +4,10 @@ import { INestApplication } from '@nestjs/common';
 import { getEntityManagerToken } from '@nestjs/typeorm';
 import { EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
-import { GivenScenarioPuDataExists } from '../../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
+import {
+  GivenScenarioPuDataExists,
+  GivenScenarioPuDataWithStatusesSetByUserExists,
+} from '../../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
 import { GivenProjectExists } from '../../steps/given-project';
 import { ScenariosTestUtils } from '../../utils/scenarios.test.utils';
 import {
@@ -31,7 +34,7 @@ export const createWorld = async (app: INestApplication, jwt: string) => {
     })
   ).data.id;
 
-  const scenariosPuData = await GivenScenarioPuDataExists(
+  const scenariosPuData = await GivenScenarioPuDataWithStatusesSetByUserExists(
     entityManager,
     projectId,
     scenarioId,

--- a/api/apps/geoprocessing/test/steps/given-scenario-pu-data-exists.ts
+++ b/api/apps/geoprocessing/test/steps/given-scenario-pu-data-exists.ts
@@ -61,6 +61,104 @@ export const GivenScenarioPuDataExists = async (
   return rows as ScenariosPuPaDataGeo[];
 };
 
+export const GivenScenarioPuDataWithStatusesSetByUserExists = async (
+  entityManager: EntityManager,
+  projectId: string,
+  scenarioId: string,
+  {
+    protectedByDefault,
+  }: GivenScenarioPuDataExistsOpts = defaultGivenScenarioPuDataExistsOpts,
+): Promise<ScenariosPuPaDataGeo[]> => {
+  const [first, second, third] = await GivenProjectsPuExists(
+    entityManager,
+    projectId,
+  );
+
+  const rows = await entityManager.save(ScenariosPuPaDataGeo, [
+    {
+      scenarioId,
+      lockStatus: LockStatus.Available,
+      projectPuId: first.id,
+      projectPu: first,
+      protectedByDefault,
+      setByUser: false,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.Available,
+      projectPuId: first.id,
+      projectPu: first,
+      protectedByDefault,
+      setByUser: false,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.Available,
+      projectPuId: first.id,
+      projectPu: first,
+      protectedByDefault,
+      setByUser: true,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.Available,
+      projectPuId: first.id,
+      projectPu: first,
+      protectedByDefault,
+      setByUser: true,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.Available,
+      projectPuId: first.id,
+      projectPu: first,
+      protectedByDefault,
+      setByUser: true,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.LockedOut,
+      projectPuId: second.id,
+      projectPu: second,
+      protectedByDefault,
+      setByUser: true,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.LockedOut,
+      projectPuId: second.id,
+      projectPu: second,
+      protectedByDefault,
+      setByUser: false,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.LockedIn,
+      projectPuId: third.id,
+      projectPu: third,
+      protectedByDefault,
+      setByUser: true,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.LockedIn,
+      projectPuId: third.id,
+      projectPu: third,
+      protectedByDefault,
+      setByUser: false,
+    },
+    {
+      scenarioId,
+      lockStatus: LockStatus.LockedIn,
+      projectPuId: third.id,
+      projectPu: third,
+      protectedByDefault,
+      setByUser: false,
+    },
+  ]);
+  return rows as ScenariosPuPaDataGeo[];
+};
+
 export const GivenScenarioPuData = async (
   entityManager: EntityManager,
   projectId: string,


### PR DESCRIPTION

## Fix setByUser filter bug when changing status by kind

### Overview

- New method added to correctly find the PUs that has have been set by user and NOT coincide with status kind to be clear (basically adding filter 
- New separate method for finding the above mentioned PUs with status 'available' - in this case we need to use Query Builder, because in DB available lock status is NULL, and with the latest update of Typeorm repository find method with where condition translates to 'WHERE scenarioPuData.lockin_status =NULL' which leads to corrupted results
- Test preconditions are expanded to have more PUs with both SetByUser property values of true and false, expected results updates

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file