### PR TITLE
[MRXN23-214] updates download cost-surface template endpoint

### DIFF
--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -20,6 +20,7 @@ import { useMe } from 'hooks/me';
 import { useProjectUsers } from 'hooks/project-users';
 
 import { ItemProps } from 'components/scenarios/item/component';
+import type { Project } from 'types/project-model';
 
 import DOWNLOADS from 'services/downloads';
 import PROJECTS from 'services/projects';
@@ -32,8 +33,6 @@ import {
   SaveScenarioProps,
   UseDeleteScenarioProps,
   DeleteScenarioProps,
-  UseDownloadScenarioCostSurfaceProps,
-  DownloadScenarioCostSurfaceProps,
   UseUploadScenarioCostSurfaceProps,
   UploadScenarioCostSurfaceProps,
   UseUploadScenarioPUProps,
@@ -667,34 +666,28 @@ export function useCostSurfaceRange(id) {
   }, [query, data]);
 }
 
-export function useDownloadCostSurface({
-  requestConfig = {
-    method: 'GET',
-  },
-}: UseDownloadScenarioCostSurfaceProps) {
+export function useDownloadCostSurface() {
   const { data: session } = useSession();
 
-  const downloadScenarioCostSurface = ({ id }: DownloadScenarioCostSurfaceProps) => {
-    return DOWNLOADS.request({
-      url: `/scenarios/${id}/cost-surface/shapefile-template`,
+  const downloadScenarioCostSurface = ({ pid }: { pid: Project['id'] }) => {
+    return DOWNLOADS.get<ArrayBuffer>(`/projects/${pid}/project-grid/shapefile-template`, {
       responseType: 'arraybuffer',
       headers: {
         Authorization: `Bearer ${session.accessToken}`,
         'Content-Type': 'application/zip',
       },
-      ...requestConfig,
     });
   };
 
   return useMutation(downloadScenarioCostSurface, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       const { data: blob } = data;
-      const { id } = variables;
+      const { pid } = variables;
 
       const url = window.URL.createObjectURL(new Blob([blob]));
       const link = document.createElement('a');
       link.href = url;
-      link.setAttribute('download', `cost-surface-${id}.zip`);
+      link.setAttribute('download', `cost-surface-${pid}.zip`);
       document.body.appendChild(link);
       link.click();
       link.remove();

--- a/app/hooks/scenarios/types.ts
+++ b/app/hooks/scenarios/types.ts
@@ -48,14 +48,6 @@ export interface UploadScenarioPUProps {
   data: FormData;
 }
 
-export interface UseDownloadScenarioCostSurfaceProps {
-  requestConfig?: AxiosRequestConfig;
-}
-
-export interface DownloadScenarioCostSurfaceProps {
-  id?: string;
-}
-
 export interface UseUploadScenarioCostSurfaceProps {
   requestConfig?: AxiosRequestConfig;
 }

--- a/app/layout/scenarios/edit/planning-unit/cost-surface/component.tsx
+++ b/app/layout/scenarios/edit/planning-unit/cost-surface/component.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
-import { useDropzone } from 'react-dropzone';
+import { DropzoneProps, FileError, useDropzone } from 'react-dropzone';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
 
@@ -34,20 +34,21 @@ import ARROW_LEFT_SVG from 'svgs/ui/arrow-right-2.svg?sprite';
 import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
 
 export interface ScenariosCostSurfaceProps {
+  // todo: improve typing of "s"
   onChangeSection: (s: string) => void;
 }
 
-export const ScenariosCostSurface: React.FC<ScenariosCostSurfaceProps> = ({
+export const ScenariosCostSurface = ({
   onChangeSection,
-}: ScenariosCostSurfaceProps) => {
+}: ScenariosCostSurfaceProps): JSX.Element => {
   const [opened, setOpened] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [successFile, setSuccessFile] = useState(null);
+  const [successFile, setSuccessFile] = useState<{ name: string }>(null);
 
   const { addToast } = useToasts();
   const plausible = usePlausible();
   const { query } = useRouter();
-  const { pid, sid } = query;
+  const { pid, sid } = query as { pid: string; sid: string };
 
   const dispatch = useDispatch();
   const scenarioSlice = getScenarioEditSlice(sid);
@@ -55,7 +56,7 @@ export const ScenariosCostSurface: React.FC<ScenariosCostSurfaceProps> = ({
 
   const { user } = useMe();
   const editable = useCanEditScenario(pid, sid);
-  const downloadMutation = useDownloadCostSurface({});
+  const downloadMutation = useDownloadCostSurface();
   const uploadMutation = useUploadCostSurface({
     requestConfig: {
       method: 'POST',
@@ -64,7 +65,7 @@ export const ScenariosCostSurface: React.FC<ScenariosCostSurfaceProps> = ({
 
   const onDownload = useCallback(() => {
     downloadMutation.mutate(
-      { id: `${sid}` },
+      { pid },
       {
         onSuccess: () => {},
         onError: () => {
@@ -81,9 +82,9 @@ export const ScenariosCostSurface: React.FC<ScenariosCostSurfaceProps> = ({
         },
       }
     );
-  }, [sid, downloadMutation, addToast]);
+  }, [pid, downloadMutation, addToast]);
 
-  const onDropAccepted = async (acceptedFiles) => {
+  const onDropAccepted = (acceptedFiles: Parameters<DropzoneProps['onDropAccepted']>[0]) => {
     setLoading(true);
 
     const f = acceptedFiles[0];
@@ -147,11 +148,11 @@ export const ScenariosCostSurface: React.FC<ScenariosCostSurfaceProps> = ({
     );
   };
 
-  const onDropRejected = (rejectedFiles) => {
+  const onDropRejected = (rejectedFiles: Parameters<DropzoneProps['onDropRejected']>[0]) => {
     const r = rejectedFiles[0];
 
-    // `file-too-large` backend error message is not friendly.
-    // It'll display the max size in bytes which the average user may not understand.
+    // ? `file-too-large` backend error message is not friendly.
+    // ? It'll display the max size in bytes which the average user may not understand.
     const errors = r.errors.map((error) => {
       return error.code === 'file-too-large'
         ? {
@@ -166,7 +167,7 @@ export const ScenariosCostSurface: React.FC<ScenariosCostSurfaceProps> = ({
       <>
         <h2 className="font-medium">Error!</h2>
         <ul className="text-sm">
-          {errors.map((e) => (
+          {errors.map((e: FileError) => (
             <li key={`${e.code}`}>{e.message}</li>
           ))}
         </ul>


### PR DESCRIPTION
## Updates download cost-surface template endpoint

### Overview
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/39897f85-3cf5-4c7c-9f8d-1b44f137b3d5)


This PR updates the endpoint used to download the cost-surface template. It also adds some typing here and there, because it's cool.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-214

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file