### PR TITLE
feat(Marxan): Adds new service to generate Project Summaries after a run

### DIFF
--- a/api/api.Dockerfile
+++ b/api/api.Dockerfile
@@ -5,7 +5,7 @@ ENV NAME marxan-api
 ENV USER $NAME
 ENV APP_HOME /opt/$NAME
 
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash zip
 RUN addgroup $USER && adduser -s /bin/bash -D -G $USER $USER
 
 WORKDIR $APP_HOME

--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -35,6 +35,7 @@ import { AsyncJobsGarbageCollectorModule } from './modules/async-jobs-garbage-co
 import { ExportCleanupModule } from './modules/export-cleanup/export-cleanup.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { GeoFeatureTagsModule } from './modules/geo-feature-tags/geo-feature-tags.module';
+import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.module';
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { GeoFeatureTagsModule } from './modules/geo-feature-tags/geo-feature-tag
     ThrottlerModule.forRoot(),
     ExportCleanupModule,
     ScheduleModule.forRoot(),
+    OutputProjectSummariesModule,
   ],
   controllers: [AppController, PingController],
   providers: [

--- a/api/apps/api/src/migrations/api/1689091277937-AddOutputProjectSummary.ts
+++ b/api/apps/api/src/migrations/api/1689091277937-AddOutputProjectSummary.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOutputProjectSummary1689091277937
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE output_project_summaries (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            project_id uuid NOT NULL UNIQUE references projects(id) ON DELETE CASCADE,
+            summary_zipped_data bytea NOT NULL,
+            created_at timestamp,
+            last_modified_at timestamp
+          );
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE output_project_summaries`);
+  }
+}

--- a/api/apps/api/src/modules/projects/output-project-summaries/output-project-summaries.module.ts
+++ b/api/apps/api/src/modules/projects/output-project-summaries/output-project-summaries.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OutputProjectSummariesService } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.service';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { OutputProjectSummaryApiEntity } from '@marxan/output-project-summaries';
+import { BestSolutionDataService } from '@marxan-api/modules/projects/output-project-summaries/solution-data/best-solution-data.service';
+import { SummedSolutionDataService } from '@marxan-api/modules/projects/output-project-summaries/solution-data/summed-solution-data.service';
+import { ScenariosOutputResultsApiEntity } from '@marxan/marxan-output';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
+
+@Module({
+  providers: [
+    OutputProjectSummariesService,
+    BestSolutionDataService,
+    SummedSolutionDataService,
+  ],
+  exports: [OutputProjectSummariesService],
+  imports: [
+    TypeOrmModule.forFeature([ProjectsPuEntity], DbConnections.geoprocessingDB),
+    TypeOrmModule.forFeature([
+      Scenario,
+      ScenariosOutputResultsApiEntity,
+      OutputProjectSummaryApiEntity,
+    ]),
+  ],
+})
+export class OutputProjectSummariesModule {}

--- a/api/apps/api/src/modules/projects/output-project-summaries/output-project-summaries.service.ts
+++ b/api/apps/api/src/modules/projects/output-project-summaries/output-project-summaries.service.ts
@@ -1,0 +1,291 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { BestSolutionDataService } from '@marxan-api/modules/projects/output-project-summaries/solution-data/best-solution-data.service';
+import { SummedSolutionDataService } from '@marxan-api/modules/projects/output-project-summaries/solution-data/summed-solution-data.service';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { CsvFormatterStream, FormatterRow, write } from 'fast-csv';
+import { execSync } from 'child_process';
+import { createWriteStream, existsSync, readFileSync } from 'fs';
+import { pipeline } from 'stream/promises';
+import { join as joinPath } from 'path';
+import { Injectable, Logger } from '@nestjs/common';
+import { OutputProjectSummaryApiEntity } from '@marxan/output-project-summaries';
+import { mkdir, rm } from 'fs/promises';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { AppConfig } from '@marxan-api/utils/config.utils';
+
+export const outputProjectSummaryFolder = 'output-project-summary/';
+export const outputProjectSummaryFilename = 'summary.csv';
+export const outputProjectSummaryScenariosFilename = 'scenarios.csv';
+
+@Injectable()
+export class OutputProjectSummariesService {
+  private readonly logger = new Logger(OutputProjectSummariesService.name);
+
+  constructor(
+    private readonly bestSolutionsDataService: BestSolutionDataService,
+    private readonly summedSolutionsDataService: SummedSolutionDataService,
+    @InjectRepository(Scenario)
+    private readonly scenarioRepo: Repository<Scenario>,
+    @InjectRepository(ProjectsPuEntity, DbConnections.geoprocessingDB)
+    private readonly projectsPU: Repository<ProjectsPuEntity>,
+    @InjectRepository(OutputProjectSummaryApiEntity)
+    private readonly outputSummaryRepo: Repository<OutputProjectSummaryApiEntity>,
+  ) {}
+
+  async saveSummaryForProjectOfScenario(scenarioId: string): Promise<void> {
+    const { projectId } = await this.scenarioRepo.findOneOrFail({
+      where: { id: scenarioId },
+    });
+
+    const planningUnits = (await this.projectsPU.find({ where: { projectId } }))
+      .map((pu) => pu.puid)
+      .sort();
+
+    const scenarios = await this.scenarioRepo.find({
+      select: { id: true, projectScenarioId: true, name: true },
+      where: { projectId },
+    });
+
+    const bestSolutionData = await this.getBestSolutionDataForScenarios(
+      scenarios,
+    );
+    const summedSolutionData = await this.getSummedSolutionDataForScenarios(
+      scenarios,
+    );
+
+    const workingDirectory = OutputProjectSummariesService.getProjectTempFolder(
+      projectId,
+    );
+    const csvPath = joinPath(workingDirectory, outputProjectSummaryFolder);
+    await this.createCSVFolder(csvPath);
+
+    const summaryCSVStream = this.arrangeSummaryCSV(
+      planningUnits,
+      scenarios,
+      bestSolutionData,
+      summedSolutionData,
+    );
+    const scenarioCSVStream = this.arrangeScenariosCSV(scenarios);
+
+    await this.writeCSV(
+      workingDirectory,
+      outputProjectSummaryFilename,
+      summaryCSVStream,
+    );
+    await this.writeCSV(
+      workingDirectory,
+      outputProjectSummaryScenariosFilename,
+      scenarioCSVStream,
+    );
+
+    const zipFullPath = this.zipCSVs(projectId, workingDirectory);
+
+    await this.saveSummary(projectId, zipFullPath);
+
+    await this.cleanupProjectTempFolder(projectId);
+  }
+
+  private arrangeSummaryCSV(
+    planningUnits: number[],
+    scenarios: Scenario[],
+    bestSolutionData: ProjectScenarioBestSolutionMapping,
+    summedSolutionData: ProjectScenarioSummedSolutionMapping,
+  ): CsvFormatterStream<FormatterRow, FormatterRow> {
+    const projectScenarioIds = scenarios
+      .map((scenario) => scenario.projectScenarioId)
+      .sort();
+
+    // The headers of the CSV file is dependent on the set of scenarios for the project
+    // it needs to be preocomputed in ascending order
+    // The CSV rows will also be sorted in ascending order by puid
+    // Headers will follow this format: puid, Snnn_best, Snnn_ssoln, Snnn_best, Snnn_ssoln....
+    // a set of 2 column per each scenario, with nnn being the projectScenarioId (within the project)
+    // keep in mind that the projectScenarioId might have gaps in the sequence
+    const headers = [];
+    headers.push('puid');
+    for (const projectScenarioId of projectScenarioIds) {
+      const scenarioId = this.formatProjectScenarioId(projectScenarioId);
+      headers.push(`S${scenarioId}_best`);
+      headers.push(`S${scenarioId}_ssoln`);
+    }
+
+    const csvData = [];
+    csvData.push(headers);
+    for (const planningUnit of planningUnits.sort()) {
+      const row = [planningUnit];
+
+      for (const projectScenarioId of projectScenarioIds) {
+        row.push(bestSolutionData[projectScenarioId][planningUnit]);
+        row.push(summedSolutionData[projectScenarioId][planningUnit]);
+      }
+
+      csvData.push(row);
+    }
+
+    return write(csvData, {
+      headers: true,
+      writeHeaders: true,
+      includeEndRowDelimiter: true,
+    });
+  }
+
+  private arrangeScenariosCSV(
+    scenarios: Scenario[],
+  ): CsvFormatterStream<FormatterRow, FormatterRow> {
+    let csvData: any[][] = [];
+    const headers = ['projectScenarioId', 'uuid', 'name'];
+
+    csvData.push(headers);
+    csvData = csvData.concat(
+      scenarios.map((scenario) => [
+        this.formatProjectScenarioId(scenario.projectScenarioId),
+        scenario.id,
+        scenario.name,
+      ]),
+    );
+
+    return write(csvData, {
+      headers: true,
+      writeHeaders: true,
+      includeEndRowDelimiter: true,
+    });
+  }
+
+  private async writeCSV(
+    workingDirectory: string,
+    csvFileName: string,
+    csvData: CsvFormatterStream<FormatterRow, FormatterRow>,
+  ) {
+    const metadataFolder = joinPath(
+      workingDirectory,
+      outputProjectSummaryFolder,
+      csvFileName,
+    );
+
+    const csvFileWriteStream = createWriteStream(metadataFolder);
+    await pipeline(csvData, csvFileWriteStream);
+  }
+
+  private zipCSVs(projectId: string, workingDirectory: string): string {
+    const zipFileName = OutputProjectSummariesService.zipFilename(projectId);
+    const command = `zip -r ${zipFileName} ${outputProjectSummaryFolder}`;
+
+    execSync(command, { cwd: workingDirectory });
+
+    const zipFullPath = joinPath(workingDirectory, zipFileName);
+    this.logger.log(`Project Summary CSVs zipped on ${zipFullPath}`);
+
+    return zipFullPath;
+  }
+
+  private async getBestSolutionDataForScenarios(
+    scenarios: Scenario[],
+  ): Promise<ProjectScenarioBestSolutionMapping> {
+    const data = await Promise.all(
+      scenarios.map(async ({ id, projectScenarioId }) => {
+        const bestsolutionData = await this.bestSolutionsDataService.getBestSolutionData(
+          id,
+        );
+        const dataMapping = bestsolutionData.reduce(
+          (acc, { planning_unit, selected }) => {
+            acc[planning_unit] = selected;
+            return acc;
+          },
+          {} as PlanningUnitBestSolutionMapping,
+        );
+
+        return { projectScenarioId, dataMapping };
+      }),
+    );
+
+    return data.reduce((acc, { projectScenarioId, dataMapping }) => {
+      acc[projectScenarioId] = dataMapping;
+      return acc;
+    }, {} as ProjectScenarioBestSolutionMapping);
+  }
+
+  private async getSummedSolutionDataForScenarios(
+    scenarios: Scenario[],
+  ): Promise<ProjectScenarioSummedSolutionMapping> {
+    const data = await Promise.all(
+      scenarios.map(async ({ id, projectScenarioId }) => {
+        const solutionData = (
+          await this.summedSolutionsDataService.getSummedSolutionsData(id)
+        ).reduce((acc, { planning_unit, included_count }) => {
+          acc[planning_unit] = included_count;
+          return acc;
+        }, {} as PlanningUnitSummedSolutionMapping);
+
+        return { projectScenarioId, solutionData };
+      }),
+    );
+
+    return data.reduce((acc, { projectScenarioId, solutionData }) => {
+      acc[projectScenarioId] = solutionData;
+      return acc;
+    }, {} as ProjectScenarioSummedSolutionMapping);
+  }
+
+  private async saveSummary(
+    projectId: string,
+    summaryZipFullPath: string,
+  ): Promise<void> {
+    await this.outputSummaryRepo.save(
+      this.outputSummaryRepo.create({
+        projectId,
+        summaryZippedData: readFileSync(summaryZipFullPath),
+      }),
+    );
+  }
+
+  private formatProjectScenarioId(projectScenarioId: number): string {
+    return String(projectScenarioId).padStart(3, '0');
+  }
+
+  static zipFilename(projectId: string) {
+    return `summary-output-${projectId}.zip`;
+  }
+
+  static getProjectTempFolder(projectId: string): string {
+    const tmpFolder = AppConfig.get<string>(
+      'storage.sharedFileStorage.',
+      '/tmp',
+    );
+    return joinPath(tmpFolder, projectId);
+  }
+
+  private async createCSVFolder(pathToCreate: string): Promise<void> {
+    if (!existsSync(pathToCreate)) {
+      await mkdir(pathToCreate, { recursive: true });
+    }
+  }
+
+  private async cleanupProjectTempFolder(projectId: string): Promise<void> {
+    if (
+      !AppConfig.getBoolean(
+        'storage.sharedFileStorage.cleanupTemporaryFolders',
+        true,
+      )
+    ) {
+      return;
+    }
+
+    await rm(OutputProjectSummariesService.getProjectTempFolder(projectId), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+type ProjectScenarioBestSolutionMapping = Record<
+  number,
+  PlanningUnitBestSolutionMapping
+>;
+type ProjectScenarioSummedSolutionMapping = Record<
+  number,
+  PlanningUnitSummedSolutionMapping
+>;
+type PlanningUnitBestSolutionMapping = Record<number, 0 | 1>;
+type PlanningUnitSummedSolutionMapping = Record<number, number>;

--- a/api/apps/api/src/modules/projects/output-project-summaries/output-project-summaries.service.ts
+++ b/api/apps/api/src/modules/projects/output-project-summaries/output-project-summaries.service.ts
@@ -41,7 +41,7 @@ export class OutputProjectSummariesService {
 
     const planningUnits = (await this.projectsPU.find({ where: { projectId } }))
       .map((pu) => pu.puid)
-      .sort();
+      .sort((a, b) => a - b);
 
     const scenarios = await this.scenarioRepo.find({
       select: { id: true, projectScenarioId: true, name: true },
@@ -95,7 +95,7 @@ export class OutputProjectSummariesService {
   ): CsvFormatterStream<FormatterRow, FormatterRow> {
     const projectScenarioIds = scenarios
       .map((scenario) => scenario.projectScenarioId)
-      .sort();
+      .sort((a, b) => a - b);
 
     // The headers of the CSV file is dependent on the set of scenarios for the project
     // it needs to be preocomputed in ascending order
@@ -113,7 +113,7 @@ export class OutputProjectSummariesService {
 
     const csvData = [];
     csvData.push(headers);
-    for (const planningUnit of planningUnits.sort()) {
+    for (const planningUnit of planningUnits.sort((a, b) => a - b)) {
       const row = [planningUnit];
 
       for (const projectScenarioId of projectScenarioIds) {

--- a/api/apps/api/src/modules/projects/output-project-summaries/solution-data/best-solution-data.service.ts
+++ b/api/apps/api/src/modules/projects/output-project-summaries/solution-data/best-solution-data.service.ts
@@ -1,0 +1,38 @@
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { ScenariosOutputResultsApiEntity } from '@marxan/marxan-output';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+
+export class BestSolutionDataService {
+  constructor(
+    @InjectEntityManager(DbConnections.geoprocessingDB)
+    private readonly geoEntityManager: EntityManager,
+    @InjectRepository(ScenariosOutputResultsApiEntity)
+    private readonly scenariosOutputResultsRepo: Repository<ScenariosOutputResultsApiEntity>,
+  ) {}
+
+  async getBestSolutionData(
+    scenarioId: string,
+  ): Promise<{ planning_unit: number; selected: 0 | 1 }[]> {
+    const scenarioOutputResult = await this.scenariosOutputResultsRepo.findOneOrFail(
+      {
+        where: { scenarioId, best: true },
+      },
+    );
+    const bestRunId = scenarioOutputResult.runId;
+
+    return this.geoEntityManager.query(
+      `
+      SELECT
+        ppu.puid as planning_unit,
+        ospd.value[$1] as selected
+      FROM
+        output_scenarios_pu_data ospd
+        JOIN
+          scenarios_pu_data spd on ospd.scenario_pu_id = spd.id
+        JOIN
+          projects_pu ppu on ppu.id = spd.project_pu_id where spd.scenario_id = $2;`,
+      [bestRunId, scenarioId],
+    );
+  }
+}

--- a/api/apps/api/src/modules/projects/output-project-summaries/solution-data/summed-solution-data.service.ts
+++ b/api/apps/api/src/modules/projects/output-project-summaries/solution-data/summed-solution-data.service.ts
@@ -1,0 +1,28 @@
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+
+export class SummedSolutionDataService {
+  constructor(
+    @InjectEntityManager(DbConnections.geoprocessingDB)
+    private readonly geoEntityManager: EntityManager,
+  ) {}
+
+  async getSummedSolutionsData(
+    scenarioId: string,
+  ): Promise<{ planning_unit: number; included_count: number }[]> {
+    return this.geoEntityManager.query(
+      `
+    SELECT
+      ppu.puid as planning_unit,
+      included_count
+    FROM
+      output_scenarios_pu_data ospd
+      JOIN
+        scenarios_pu_data spd on ospd.scenario_pu_id = spd.id
+      JOIN
+        projects_pu ppu on ppu.id = spd.project_pu_id where spd.scenario_id = $1;`,
+      [scenarioId],
+    );
+  }
+}

--- a/api/apps/api/src/modules/scenarios/marxan-run/events.handler.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/events.handler.ts
@@ -12,6 +12,7 @@ import {
 import { ScenarioRunProgressV1Alpha1DTO } from '@marxan-api/modules/api-events/dto/scenario-run-progress-v1-alpha-1';
 import { runEventsToken, runQueueToken } from './tokens';
 import { OutputRepository } from './output.repository';
+import { OutputProjectSummariesService } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.service';
 
 @Injectable()
 export class EventsHandler {
@@ -22,6 +23,7 @@ export class EventsHandler {
     queueEvents: QueueEvents,
     private readonly apiEvents: ApiEventsService,
     private readonly outputs: OutputRepository,
+    private readonly outputProjectSummaryService: OutputProjectSummariesService,
   ) {
     queueEvents.on(`completed`, ({ jobId }, eventId) =>
       this.handleFinished(jobId, eventId),
@@ -83,6 +85,10 @@ export class EventsHandler {
   private async saveOutput(job: Job<JobData, ExecutionResult>) {
     try {
       await this.outputs.saveOutput(job);
+
+      await this.outputProjectSummaryService.saveSummaryForProjectOfScenario(
+        job.data.scenarioId,
+      );
     } catch (error) {
       await this.apiEvents.create({
         topic: job.data.scenarioId,

--- a/api/apps/api/src/modules/scenarios/marxan-run/marxan-run.module.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/marxan-run.module.ts
@@ -20,6 +20,7 @@ import {
 } from './run-service.providers';
 import { RunHandler } from './run.handler';
 import { RunService } from './run.service';
+import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { RunService } from './run.service';
     TypeOrmModule.forFeature([Scenario, ScenariosOutputResultsApiEntity]),
     InputFilesModule,
     OutputFilesModule,
+    OutputProjectSummariesModule,
   ],
   providers: [
     RunHandler,

--- a/api/apps/api/test/jest-e2e.json
+++ b/api/apps/api/test/jest-e2e.json
@@ -96,6 +96,8 @@
     "@marxan/geofeatures/(.*)": "<rootDir>/../../../libs/geofeatures/src/$1",
     "@marxan/geofeatures": "<rootDir>/../../../libs/geofeatures/src",
     "@marxan/domain-ids/(.*)": "<rootDir>/../../../libs/domain-ids/src/$1",
-    "@marxan/domain-ids": "<rootDir>/../../../libs/domain-ids/src"
+    "@marxan/domain-ids": "<rootDir>/../../../libs/domain-ids/src",
+    "@marxan/output-project-summaries/(.*)": "<rootDir>/../../../libs/output-project-summaries/src/$1",
+    "@marxan/output-project-summaries": "<rootDir>/../../../libs/output-project-summaries/src"
   }
 }

--- a/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
+++ b/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
@@ -1,0 +1,349 @@
+import { PromiseType } from 'utility-types';
+import { v4 } from 'uuid';
+
+import {
+  OutputProjectSummariesService,
+  outputProjectSummaryFilename,
+  outputProjectSummaryFolder,
+  outputProjectSummaryScenariosFilename,
+} from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.service';
+import { EntityManager, Repository } from 'typeorm';
+import { getEntityManagerToken, getRepositoryToken } from '@nestjs/typeorm';
+import { ProjectsPuEntity } from '@marxan-jobs/planning-unit-geometry';
+import { parseStream } from 'fast-csv';
+import { Readable } from 'stream';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { bootstrapApplication } from '../utils/api-application';
+import {
+  GivenProjectPuData,
+  GivenScenarioPuData,
+} from '../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
+import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { Project } from '@marxan-api/modules/projects/project.api.entity';
+import { Organization } from '@marxan-api/modules/organizations/organization.api.entity';
+import { Parse, ParseStream } from 'unzipper';
+
+let fixtures: PromiseType<ReturnType<typeof getFixtures>>;
+beforeEach(async () => {
+  fixtures = await getFixtures();
+  await fixtures.cleanup();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+describe('when generating output summary metadata for a project', () => {
+  it('should generate zip files', async () => {
+    // This test will arrange 2 scenarios, with 5 runs, and 5 Planning Units
+    const projectId = await fixtures.GivenProjectExistsOnAPI('project');
+    const scenario1Id = await fixtures.GivenScenarioExistsOnAPI(
+      'scenario1Name',
+      projectId,
+    );
+    const scenario2Id = await fixtures.GivenScenarioExistsOnAPI(
+      'scenario2Name',
+      projectId,
+    );
+
+    const projectPus = await fixtures.GivenProjectPuDataExists(projectId);
+    await fixtures.GivenScenarioPuDataExists(
+      projectId,
+      scenario1Id,
+      projectPus,
+    );
+    await fixtures.GivenScenarioPuDataExists(
+      projectId,
+      scenario2Id,
+      projectPus,
+    );
+
+    await fixtures.GivenOutputScenarioPuDataExists(projectId, scenario1Id, [
+      { puid: 1, includedCount: 5, values: [true, true, true, true, true] },
+      { puid: 2, includedCount: 2, values: [false, false, true, false, true] },
+      { puid: 3, includedCount: 1, values: [false, false, true, false, false] },
+      {
+        puid: 4,
+        includedCount: 0,
+        values: [false, false, false, false, false],
+      },
+      { puid: 5, includedCount: 4, values: [true, true, true, false, true] },
+    ]);
+    await fixtures.GivenOutputScenarioResultsExists(projectId, scenario1Id, [
+      { runNumber: 1, best: false },
+      { runNumber: 2, best: false },
+      { runNumber: 3, best: false },
+      { runNumber: 4, best: false },
+      { runNumber: 5, best: true },
+    ]);
+    await fixtures.GivenOutputScenarioPuDataExists(projectId, scenario2Id, [
+      { puid: 1, includedCount: 4, values: [false, true, true, false, true] },
+      { puid: 2, includedCount: 2, values: [false, false, true, false, true] },
+      { puid: 3, includedCount: 2, values: [false, true, true, false, false] },
+      {
+        puid: 4,
+        includedCount: 1,
+        values: [true, false, false, false, false],
+      },
+      { puid: 5, includedCount: 3, values: [true, true, false, false, false] },
+    ]);
+    await fixtures.GivenOutputScenarioResultsExists(projectId, scenario2Id, [
+      { runNumber: 1, best: true },
+      { runNumber: 2, best: false },
+      { runNumber: 3, best: false },
+      { runNumber: 4, best: false },
+      { runNumber: 5, best: false },
+    ]);
+
+    await fixtures.WhenSavingOutputMetdataForProject(scenario1Id);
+
+    const summaryEntity = await fixtures.ThenOutputSummaryForProjectIsPersisted(
+      projectId,
+    );
+
+    await fixtures.ThenSummaryCSVWasProperlyGenerated(summaryEntity, [
+      {
+        puid: '1',
+        S001_best: 'true',
+        S001_ssoln: '5',
+        S002_best: 'false',
+        S002_ssoln: '4',
+      },
+      {
+        puid: '2',
+        S001_best: 'true',
+        S001_ssoln: '2',
+        S002_best: 'false',
+        S002_ssoln: '2',
+      },
+      {
+        puid: '3',
+        S001_best: 'false',
+        S001_ssoln: '1',
+        S002_best: 'false',
+        S002_ssoln: '2',
+      },
+      {
+        puid: '4',
+        S001_best: 'false',
+        S001_ssoln: '0',
+        S002_best: 'true',
+        S002_ssoln: '1',
+      },
+      {
+        puid: '5',
+        S001_best: 'true',
+        S001_ssoln: '4',
+        S002_best: 'true',
+        S002_ssoln: '3',
+      },
+    ]);
+    await fixtures.ThenScenariosCSVWasProperlyGenerated(summaryEntity, [
+      {
+        projectScenarioId: '001',
+        uuid: scenario1Id,
+        name: 'scenario1Name',
+      },
+      {
+        projectScenarioId: '002',
+        uuid: scenario2Id,
+        name: 'scenario2Name',
+      },
+    ]);
+  });
+});
+
+const NUMBER_OF_PU_IN_SAMPLE = 5;
+
+const getFixtures = async () => {
+  const app = await bootstrapApplication();
+  const apiEntityManager = app.get<EntityManager>(getEntityManagerToken());
+  const geoEntityManager = app.get<EntityManager>(
+    getEntityManagerToken(DbConnections.geoprocessingDB),
+  );
+
+  const outputSummaryService = app.get<OutputProjectSummariesService>(
+    OutputProjectSummariesService,
+  );
+  const scenarioRepo = app.get<Repository<Scenario>>(
+    getRepositoryToken(Scenario),
+  );
+  const projectRepo = app.get<Repository<Project>>(getRepositoryToken(Project));
+  const organizationRepo = app.get<Repository<Organization>>(
+    getRepositoryToken(Organization),
+  );
+
+  return {
+    cleanup: async () => {
+      const clearTable = (em: EntityManager, tableName: string) => {
+        em.createQueryBuilder().delete().from(tableName).execute();
+      };
+
+      await scenarioRepo.delete({});
+      await projectRepo.delete({});
+      await organizationRepo.delete({});
+
+      await clearTable(geoEntityManager, 'output_scenarios_pu_data');
+      await clearTable(geoEntityManager, 'features_data');
+      await clearTable(geoEntityManager, 'planning_units_geom');
+    },
+
+    GivenProjectExistsOnAPI: async (name: string) => {
+      const orgId = v4();
+      const projectId = v4();
+
+      await organizationRepo.insert({ name: 'org', id: orgId });
+      await projectRepo.insert({ id: projectId, name, organizationId: orgId });
+      return projectId;
+    },
+    GivenScenarioExistsOnAPI: async (name: string, projectId: string) => {
+      const id = v4();
+      await scenarioRepo.insert({ id, name, projectId });
+      return id;
+    },
+
+    GivenProjectPuDataExists: async (projectId: string) => {
+      return GivenProjectPuData(
+        geoEntityManager,
+        projectId,
+        NUMBER_OF_PU_IN_SAMPLE,
+      );
+    },
+    GivenScenarioPuDataExists: async (
+      projectId: string,
+      scenarioId: string,
+      projectPus: ProjectsPuEntity[],
+    ) => {
+      return GivenScenarioPuData(
+        geoEntityManager,
+        projectId,
+        scenarioId,
+        projectPus,
+      );
+    },
+    GivenOutputScenarioPuDataExists: async (
+      projectId: string,
+      scenarioId: string,
+      outputData: { puid: number; includedCount: number; values: boolean[] }[],
+    ) => {
+      for (const { puid, includedCount, values } of outputData) {
+        const [{ scenarioPuId }] = await geoEntityManager
+          .createQueryBuilder()
+          .select('spd.id', 'scenarioPuId')
+          .from('scenarios_pu_data', 'spd')
+          .leftJoin('projects_pu', 'pp', 'pp.id = spd.project_pu_id')
+          .where('spd.scenario_id = :scenarioId AND pp.puid = :puid', {
+            scenarioId,
+            projectId,
+            puid,
+          })
+          .execute();
+        if (!scenarioPuId) {
+          fail('No Scenario Pu Data was found');
+        }
+
+        await geoEntityManager
+          .createQueryBuilder()
+          .insert()
+          .into('output_scenarios_pu_data')
+          .values({
+            scenarioPuId,
+            includedCount,
+            values,
+          })
+          .execute();
+      }
+    },
+    GivenOutputScenarioResultsExists: async (
+      projectId: string,
+      scenarioId: string,
+      summaryData: { runNumber: number; best: boolean }[],
+    ) => {
+      const insertValues = summaryData.map(({ runNumber, best }) => ({
+        scenarioId,
+        runId: runNumber,
+        best,
+      }));
+
+      await apiEntityManager.insert('output_scenarios_summaries', insertValues);
+    },
+
+    WhenSavingOutputMetdataForProject: async (scenarioId: string) => {
+      await outputSummaryService.saveSummaryForProjectOfScenario(scenarioId);
+    },
+
+    ThenOutputSummaryForProjectIsPersisted: async (projectId: string) => {
+      const [
+        outputSummary,
+      ] = await apiEntityManager
+        .createQueryBuilder()
+        .select()
+        .from('output_project_summaries', 's')
+        .where(`s.project_id = '${projectId}'`)
+        .execute();
+
+      if (!outputSummary) {
+        fail(`Output Summary was not saved for project ${projectId}`);
+      }
+      return outputSummary;
+    },
+    ThenSummaryCSVWasProperlyGenerated: async (
+      summaryEntity: any,
+      data: any[],
+    ) => {
+      const csvContent = await extractFileFromZip(
+        Readable.from(summaryEntity.summary_zipped_data),
+        `${outputProjectSummaryFolder}${outputProjectSummaryFilename}`,
+      );
+      await ThenOutputCSVWasProperlyGenerated(csvContent, data);
+    },
+    ThenScenariosCSVWasProperlyGenerated: async (
+      summaryEntity: any,
+      data: any[],
+    ) => {
+      const csvContent = await extractFileFromZip(
+        Readable.from(summaryEntity.summary_zipped_data),
+        `${outputProjectSummaryFolder}${outputProjectSummaryScenariosFilename}`,
+      );
+      await ThenOutputCSVWasProperlyGenerated(csvContent, data);
+    },
+  };
+};
+
+async function ThenOutputCSVWasProperlyGenerated(
+  csvContent: Buffer,
+  data: any[],
+) {
+  const csvStream = parseStream(Readable.from(csvContent), {
+    headers: true,
+    objectMode: true,
+  });
+
+  const csvRows = await new Promise((resolve, reject) => {
+    const contents: any[] = [];
+    csvStream.on('data', (chunk) => {
+      contents.push(chunk);
+    });
+    csvStream.on('error', (err) => {
+      reject(err);
+    });
+    csvStream.on('finish', () => {
+      resolve(contents);
+    });
+  });
+  expect(csvRows).toEqual(data);
+}
+
+async function extractFileFromZip(zipStream: Readable, pathToExtract: string) {
+  const unzippedStream: ParseStream = zipStream.pipe(
+    Parse({ forceStream: true }),
+  );
+  for await (const entry of unzippedStream) {
+    if (entry.type === 'File' && entry.path === pathToExtract) {
+      return entry.buffer();
+    } else {
+      entry.autodrain();
+    }
+  }
+
+  fail(`${pathToExtract} could not be found inside zip file`);
+}

--- a/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
+++ b/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
@@ -24,7 +24,6 @@ import { GivenProjectsPu } from '../../../geoprocessing/test/steps/given-project
 let fixtures: PromiseType<ReturnType<typeof getFixtures>>;
 beforeEach(async () => {
   fixtures = await getFixtures();
-  await fixtures.cleanup();
 });
 
 afterEach(async () => {
@@ -147,7 +146,7 @@ describe('when generating output summary metadata for a project', () => {
         name: 'scenario2Name',
       },
     ]);
-  });
+  }, 100000);
 });
 
 const NUMBER_OF_PU_IN_SAMPLE = 5;
@@ -185,6 +184,7 @@ const getFixtures = async () => {
       await clearTable(geoEntityManager, 'scenarios_pu_data');
       await clearTable(geoEntityManager, 'projects_pu');
       await clearTable(geoEntityManager, 'planning_units_geom');
+      await app.close();
     },
 
     GivenProjectExistsOnAPI: async (name: string) => {

--- a/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
+++ b/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
@@ -14,14 +14,12 @@ import { parseStream } from 'fast-csv';
 import { Readable } from 'stream';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { bootstrapApplication } from '../utils/api-application';
-import {
-  GivenProjectPuData,
-  GivenScenarioPuData,
-} from '../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
+import { GivenScenarioPuData } from '../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
 import { Scenario } from '@marxan-api/modules/scenarios/scenario.api.entity';
 import { Project } from '@marxan-api/modules/projects/project.api.entity';
 import { Organization } from '@marxan-api/modules/organizations/organization.api.entity';
 import { Parse, ParseStream } from 'unzipper';
+import { GivenProjectsPu } from '../../../geoprocessing/test/steps/given-projects-pu-exists';
 
 let fixtures: PromiseType<ReturnType<typeof getFixtures>>;
 beforeEach(async () => {
@@ -202,7 +200,7 @@ const getFixtures = async () => {
     },
 
     GivenProjectPuDataExists: async (projectId: string) => {
-      return GivenProjectPuData(
+      return GivenProjectsPu(
         geoEntityManager,
         projectId,
         NUMBER_OF_PU_IN_SAMPLE,

--- a/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
+++ b/api/apps/api/test/project/output-project-summaries.e2e-spec.ts
@@ -182,6 +182,8 @@ const getFixtures = async () => {
 
       await clearTable(geoEntityManager, 'output_scenarios_pu_data');
       await clearTable(geoEntityManager, 'features_data');
+      await clearTable(geoEntityManager, 'scenarios_pu_data');
+      await clearTable(geoEntityManager, 'projects_pu');
       await clearTable(geoEntityManager, 'planning_units_geom');
     },
 

--- a/api/apps/api/test/scenarios/cost-range.service.e2e-spec.ts
+++ b/api/apps/api/test/scenarios/cost-range.service.e2e-spec.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/typeorm';
 import { EntityManager, In, Repository } from 'typeorm';
 import { v4 } from 'uuid';
-import { GivenScenarioPuData } from '../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
+import { GivenScenarioAndProjectPuData } from '../../../geoprocessing/test/steps/given-scenario-pu-data-exists';
 import { bootstrapApplication } from '../utils/api-application';
 
 let fixtures: FixtureType<typeof getFixtures>;
@@ -71,13 +71,15 @@ async function getFixtures() {
 
   return {
     async GivenCostDataInDbForMultipleScenarios() {
-      const { rows: firstScenarioPuData } = await GivenScenarioPuData(
+      const { rows: firstScenarioPuData } = await GivenScenarioAndProjectPuData(
         entityManager,
         projectId,
         scenarioId,
         3,
       );
-      const { rows: secondScenarioPuData } = await GivenScenarioPuData(
+      const {
+        rows: secondScenarioPuData,
+      } = await GivenScenarioAndProjectPuData(
         entityManager,
         anotherProjectId,
         anotherScenarioId,

--- a/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/marxan-run/blm-calibration-run.e2e-spec.ts
@@ -24,7 +24,7 @@ import * as nock from 'nock';
 import { EntityManager, In, Repository } from 'typeorm';
 import { PromiseType } from 'utility-types';
 import { v4 } from 'uuid';
-import { GivenScenarioPuData } from '../../steps/given-scenario-pu-data-exists';
+import { GivenScenarioAndProjectPuData } from '../../steps/given-scenario-pu-data-exists';
 import { Test } from '@nestjs/testing';
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import {
@@ -230,7 +230,7 @@ const getFixtures = async () => {
     GivenScenarioPuDataExists: async () => {
       outputsIds.push(
         ...(
-          await GivenScenarioPuData(
+          await GivenScenarioAndProjectPuData(
             entityManager,
             projectId,
             scenarioId,

--- a/api/apps/geoprocessing/test/integration/marxan-run/marxan-run.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/marxan-run/marxan-run.e2e-spec.ts
@@ -20,8 +20,8 @@ import * as nock from 'nock';
 import { EntityManager, In, Repository } from 'typeorm';
 import { PromiseType } from 'utility-types';
 import { v4 } from 'uuid';
-import { GivenScenarioPuData } from '../../steps/given-scenario-pu-data-exists';
-import { bootstrapApplication, delay } from '../../utils';
+import { GivenScenarioAndProjectPuData } from '../../steps/given-scenario-pu-data-exists';
+import { bootstrapApplication } from '../../utils';
 
 const TEST_TIMEOUT_MULTIPLIER = 35000;
 
@@ -186,7 +186,7 @@ const getFixtures = async () => {
     GivenScenarioPuDataExists: async () => {
       outputsIds.push(
         ...(
-          await GivenScenarioPuData(
+          await GivenScenarioAndProjectPuData(
             entityManager,
             projectId,
             scenarioId,

--- a/api/apps/geoprocessing/test/jest-e2e.json
+++ b/api/apps/geoprocessing/test/jest-e2e.json
@@ -118,6 +118,8 @@
     "@marxan/webshot/(.*)": "<rootDir>../../libs/webshot/src/$1",
     "@marxan/webshot": "<rootDir>../../libs/webshot/src",
     "@marxan/domain-ids/(.*)": "<rootDir>../../libs/domain-ids/src/$1",
-    "@marxan/domain-ids": "<rootDir>../../libs/domain-ids/src"
+    "@marxan/domain-ids": "<rootDir>../../libs/domain-ids/src",
+    "@marxan/output-project-summaries/(.*)": "<rootDir>../../libs/output-project-summaries/src/$1",
+    "@marxan/output-project-summaries": "<rootDir>../../libs/output-project-summaries/src"
   }
 }

--- a/api/apps/geoprocessing/test/steps/given-scenario-pu-data-exists.ts
+++ b/api/apps/geoprocessing/test/steps/given-scenario-pu-data-exists.ts
@@ -172,31 +172,7 @@ export const GivenScenarioAndProjectPuData = async (
 }> => {
   return entityManager.transaction(async (em) => {
     const projectPus = await GivenProjectsPu(em, projectId, count, geomType);
-
-    const scenarioPuData: DeepPartial<ScenariosPuPaDataGeo>[] = projectPus.map(
-      (projectPu) => ({
-        scenarioId,
-        lockStatus: LockStatus.Available,
-        projectPuId: projectPu.id,
-      }),
-    );
-
-    const rows = await em.save(ScenariosPuPaDataGeo, scenarioPuData);
-    return {
-      scenarioId,
-      rows: rows as ScenariosPlanningUnitGeoEntity[],
-    };
-  });
-};
-
-export const GivenProjectPuData = async (
-  entityManager: EntityManager,
-  projectId: string,
-  count = 100,
-  geomType: PlanningUnitGridShape = PlanningUnitGridShape.Square,
-): Promise<ProjectsPuEntity[]> => {
-  return entityManager.transaction(async (em) => {
-    return GivenProjectsPu(em, projectId, count, geomType);
+    return await GivenScenarioPuData(em, projectId, scenarioId, projectPus);
   });
 };
 
@@ -209,19 +185,17 @@ export const GivenScenarioPuData = async (
   scenarioId: string;
   rows: ScenariosPlanningUnitGeoEntity[];
 }> => {
-  return entityManager.transaction(async (em) => {
-    const scenarioPuData: DeepPartial<ScenariosPuPaDataGeo>[] = projectPus.map(
-      (projectPu) => ({
-        scenarioId,
-        lockStatus: LockStatus.Available,
-        projectPuId: projectPu.id,
-      }),
-    );
-
-    const rows = await em.save(ScenariosPuPaDataGeo, scenarioPuData);
-    return {
+  const scenarioPuData: DeepPartial<ScenariosPuPaDataGeo>[] = projectPus.map(
+    (projectPu) => ({
       scenarioId,
-      rows: rows as ScenariosPlanningUnitGeoEntity[],
-    };
-  });
+      lockStatus: LockStatus.Available,
+      projectPuId: projectPu.id,
+    }),
+  );
+
+  const rows = await entityManager.save(ScenariosPuPaDataGeo, scenarioPuData);
+  return {
+    scenarioId,
+    rows: rows as ScenariosPlanningUnitGeoEntity[],
+  };
 };

--- a/api/libs/output-project-summaries/src/index.ts
+++ b/api/libs/output-project-summaries/src/index.ts
@@ -1,0 +1,1 @@
+export { OutputProjectSummaryApiEntity } from './output-project-summary.api.entity';

--- a/api/libs/output-project-summaries/src/output-project-summary.api.entity.ts
+++ b/api/libs/output-project-summaries/src/output-project-summary.api.entity.ts
@@ -1,0 +1,30 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('output_project_summaries')
+export class OutputProjectSummaryApiEntity {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid', { name: 'id' })
+  id!: string;
+
+  @Index()
+  @ApiProperty()
+  @Column('uuid', { name: 'project_id', nullable: false })
+  projectId!: string;
+
+  @ApiProperty()
+  @Column({
+    type: 'bytea',
+    nullable: false,
+    name: `summary_zipped_data`,
+  })
+  summaryZippedData!: Buffer;
+
+  @ApiProperty()
+  @Column({ type: 'timestamp', name: 'created_at' })
+  createdAt!: Date;
+
+  @ApiProperty()
+  @Column({ type: 'timestamp', name: 'last_modified_at' })
+  lastModifiedAt!: Date;
+}

--- a/api/libs/output-project-summaries/tsconfig.lib.json
+++ b/api/libs/output-project-summaries/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/output-project-summaries"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/api/nest-cli.json
+++ b/api/nest-cli.json
@@ -268,6 +268,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/code-guide/tsconfig.lib.json"
       }
+    },
+    "output-project-summaries": {
+      "type": "library",
+      "root": "libs/output-project-summaries",
+      "entryFile": "index",
+      "sourceRoot": "libs/output-project-summaries/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/output-project-summaries/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -271,7 +271,9 @@
       "@marxan/geofeatures/(.*)": "<rootDir>/libs/geofeatures/src/$1",
       "@marxan/geofeatures": "<rootDir>/libs/geofeatures/src",
       "@marxan/domain-ids/(.*)": "<rootDir>/libs/domain-ids/src/$1",
-      "@marxan/domain-ids": "<rootDir>/libs/domain-ids/src"
+      "@marxan/domain-ids": "<rootDir>/libs/domain-ids/src",
+      "@marxan/output-project-summaries/(.*)": "<rootDir>/libs/output-project-summaries/src/$1",
+      "@marxan/output-project-summaries": "<rootDir>/libs/output-project-summaries/src"
     }
   },
   "volta": {

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -99,7 +99,9 @@
       "@marxan/geofeatures": ["libs/geofeatures/src"],
       "@marxan/geofeatures/*": ["libs/geofeatures/src/*"],
       "@marxan/domain-ids": ["libs/domain-ids/src"],
-      "@marxan/domain-ids/*": ["libs/domain-ids/src/*"]
+      "@marxan/domain-ids/*": ["libs/domain-ids/src/*"],
+      "@marxan/output-project-summaries": ["libs/output-project-summaries/src"],
+      "@marxan/output-project-summaries/*": ["libs/output-project-summaries/src/*"],
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Adds a new OutputProjectSummariesService that will generate a series of CSV files with summary info for all the scenarios runs in a given project, and store a zip with those files on the DB. This will be triggered after completing a Marxan run, on the API side at the end of the whole process.

## Substitute this line for a meaningful title for your changes

### Overview

_Please write a description. If the PR is hard to understand, provide a quick explanation of the code._

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file