### PR TITLE
Fix protectedByDefault over-ride for makeAvailable claims

### DIFF
--- a/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
@@ -243,7 +243,6 @@ export class ScenarioPlanningUnitsInclusionProcessor
       {
         lockStatus: LockStatus.Available,
         setByUser: true,
-        protectedByDefault: false,
       },
     );
   }

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
@@ -296,7 +296,6 @@ export const createWorld = async (app: INestApplication) => {
           .where('scenarioPuData.scenario_id = :scenarioId', { scenarioId })
           .andWhere('scenarioPuData.lockin_status IS NULL')
           .andWhere('scenarioPuData.lock_status_set_by_user = true')
-          .andWhere('scenarioPuData.protected_by_default = false')
           .getMany()
       )
         .map((entity) => entity.id)


### PR DESCRIPTION
## ProtectedByDefault over-ride for makeAvailable claims

### Overview

When PUs are in locked-in by default status because of being considered protected, if I make some of these “available” and I then clear the “available” status, the PUs that were explicitly set as available earlier on are now not locked in again (the PU fill-color stays blue but they are not coloured with the pale blue-green stroke on their edges).

This is a bug in api applyClaims() method that resets protectedByDefault to false when applying makeAvailable claims.

PR removes protectedByDefault reset and adds a new test covering the use case

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file