### PR TITLE
[MRXN23-120]: fixes PU count with protected area set

### DIFF
--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -740,8 +740,6 @@ export function useScenarioPU(
       excluded: ScenarioPlanningUnit['id'][];
       included: ScenarioPlanningUnit['id'][];
       available: ScenarioPlanningUnit['id'][];
-      // includedDefault: ScenarioPlanningUnit['id'][];
-      // excludedDefault: ScenarioPlanningUnit['id'][];
     }
   >
 ) {
@@ -772,8 +770,12 @@ export function useScenarioPU(
       refetchOnWindowFocus: false,
       placeholderData: [],
       select: (data) => {
-        const included = data.filter((p) => p.inclusionStatus === 'locked-in').map((p) => p.id);
-        const excluded = data.filter((p) => p.inclusionStatus === 'locked-out').map((p) => p.id);
+        const included = data
+          .filter((p) => p.inclusionStatus === 'locked-in' && p.setByUser)
+          .map((p) => p.id);
+        const excluded = data
+          .filter((p) => p.inclusionStatus === 'locked-out' && p.setByUser)
+          .map((p) => p.id);
         const available = data
           .filter((p) => p.inclusionStatus === 'available' && p.setByUser)
           .map((p) => p.id);

--- a/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions-summary/component.tsx
+++ b/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions-summary/component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -46,8 +46,6 @@ export const ActionsSummary = ({
     puTmpExcludedValue,
     puTmpAvailableValue,
     puAction,
-    drawingValue,
-    uploadingValue,
     puIncludedValue,
     puExcludedValue,
     puAvailableValue,
@@ -177,39 +175,6 @@ export const ActionsSummary = ({
       setUploadingValue,
     ]
   );
-
-  const showSaveAvailableSelection = useMemo<boolean>(() => {
-    if (puAction === 'available') {
-      return (
-        (method === 'select' && puTmpAvailableValue.length > 0) ||
-        (method === 'draw' && drawingValue?.length > 0) ||
-        (method === 'upload' && uploadingValue)
-      );
-    }
-    return false;
-  }, [puAction, puTmpAvailableValue, drawingValue, uploadingValue, method]);
-
-  const showSaveIncludeSelection = useMemo<boolean>(() => {
-    if (puAction === 'include') {
-      return (
-        (method === 'select' && puTmpIncludedValue.length > 0) ||
-        (method === 'draw' && drawingValue?.length > 0) ||
-        (method === 'upload' && uploadingValue)
-      );
-    }
-    return false;
-  }, [puAction, puTmpIncludedValue, drawingValue, uploadingValue, method]);
-
-  const showSaveExcludeSelection = useMemo<boolean>(() => {
-    if (puAction === 'exclude') {
-      return (
-        (method === 'select' && puTmpExcludedValue.length > 0) ||
-        (method === 'draw' && drawingValue?.length > 0) ||
-        (method === 'upload' && uploadingValue)
-      );
-    }
-    return false;
-  }, [puAction, puTmpExcludedValue, drawingValue, uploadingValue, method]);
 
   return (
     <div className="flex flex-col divide-y-2 divide-gray-500">

--- a/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/component.tsx
+++ b/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/component.tsx
@@ -11,6 +11,7 @@ import { useSaveScenarioPU } from 'hooks/scenarios';
 import { useToasts } from 'hooks/toast';
 
 import Select from 'components/forms/select';
+import ActionsSummary from 'layout/scenarios/edit/planning-unit/adjust-planning-units/actions-summary';
 
 import DrawPUMethod from './draw';
 import SelectPUMethod from './select';
@@ -204,6 +205,7 @@ export const PlanningUnitMethods = () => {
             {values['pu-method'] === 'select' && <SelectPUMethod />}
             {values['pu-method'] === 'draw' && <DrawPUMethod />}
             {values['pu-method'] === 'upload' && <UploadPUMethod />}
+            <ActionsSummary method={values['pu-method']} />
           </form>
         );
       }}

--- a/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/draw/component.tsx
+++ b/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/draw/component.tsx
@@ -6,8 +6,6 @@ import { useRouter } from 'next/router';
 
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
-import ActionsSummary from 'layout/scenarios/edit/planning-unit/adjust-planning-units/actions-summary';
-
 export const DrawPUMethod = (): JSX.Element => {
   const { query } = useRouter();
   const { sid } = query as { sid: string };
@@ -26,12 +24,9 @@ export const DrawPUMethod = (): JSX.Element => {
   }, []);
 
   return (
-    <>
-      <span className="text-sm text-gray-400">
-        Click over the map and draw a shape to include them it the analysis
-      </span>
-      <ActionsSummary method="draw" />
-    </>
+    <span className="text-sm text-gray-400">
+      Click over the map and draw a shape to include them it the analysis
+    </span>
   );
 };
 

--- a/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/select/component.tsx
+++ b/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/select/component.tsx
@@ -1,12 +1,10 @@
 import { useEffect } from 'react';
 
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useRouter } from 'next/router';
 
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
-
-import ActionsSummary from 'layout/scenarios/edit/planning-unit/adjust-planning-units/actions-summary';
 
 export const SelectPUMethod = (): JSX.Element => {
   const { query } = useRouter();
@@ -17,10 +15,6 @@ export const SelectPUMethod = (): JSX.Element => {
 
   const { setClicking, setTmpPuIncludedValue, setTmpPuExcludedValue, setTmpPuAvailableValue } =
     scenarioSlice.actions;
-
-  const { puIncludedValue, puExcludedValue, puAvailableValue } = useSelector(
-    (state) => state[`/scenarios/${sid}/edit`]
-  );
 
   useEffect(() => {
     dispatch(setClicking(true));
@@ -34,12 +28,9 @@ export const SelectPUMethod = (): JSX.Element => {
   }, []);
 
   return (
-    <>
-      <span className="text-sm text-gray-400">
-        Select cells on the map to include them on the analysis
-      </span>
-      <ActionsSummary method="select" />
-    </>
+    <span className="text-sm text-gray-400">
+      Select cells on the map to include them on the analysis
+    </span>
   );
 };
 

--- a/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/upload/component.tsx
+++ b/app/layout/scenarios/edit/planning-unit/adjust-planning-units/actions/upload/component.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useDropzone } from 'react-dropzone';
+import { useDropzone, DropzoneProps } from 'react-dropzone';
 import { useDispatch } from 'react-redux';
 
 import { useRouter } from 'next/router';
@@ -14,7 +14,6 @@ import Icon from 'components/icon';
 import InfoButton from 'components/info-button';
 import Loading from 'components/loading';
 import { PLANNING_UNIT_UPLOADER_MAX_SIZE } from 'constants/file-uploader-size-limits';
-import ActionsSummary from 'layout/scenarios/edit/planning-unit/adjust-planning-units/actions-summary';
 import { cn } from 'utils/cn';
 import { bytesToMegabytes } from 'utils/units';
 
@@ -31,7 +30,7 @@ export const UploadPUMethod = (): JSX.Element => {
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setUploading, setUploadingValue } = scenarioSlice.actions;
 
-  const onDropAccepted = async (acceptedFiles) => {
+  const onDropAccepted = (acceptedFiles: Parameters<DropzoneProps['onDropAccepted']>[0]) => {
     setLoading(true);
     const f = acceptedFiles[0];
 
@@ -40,7 +39,7 @@ export const UploadPUMethod = (): JSX.Element => {
 
     dispatch(setUploading(true));
 
-    await uploadScenarioPUMutation.mutate(
+    uploadScenarioPUMutation.mutate(
       { id: `${sid}`, data },
       {
         onSuccess: ({ data: { data: g } }) => {
@@ -118,7 +117,7 @@ export const UploadPUMethod = (): JSX.Element => {
     );
   };
 
-  const onDropRejected = (rejectedFiles) => {
+  const onDropRejected = (rejectedFiles: Parameters<DropzoneProps['onDropRejected']>[0]) => {
     const r = rejectedFiles[0];
 
     // `file-too-large` backend error message is not friendly.
@@ -126,7 +125,7 @@ export const UploadPUMethod = (): JSX.Element => {
     const errors = r.errors.map((error) => {
       return error.code === 'file-too-large'
         ? {
-            error,
+            code: error.code,
             message: `File is larger than ${bytesToMegabytes(PLANNING_UNIT_UPLOADER_MAX_SIZE)} MB`,
           }
         : error;
@@ -242,8 +241,6 @@ export const UploadPUMethod = (): JSX.Element => {
           </div>
         </div>
       )}
-
-      <ActionsSummary method="upload" />
     </>
   );
 };


### PR DESCRIPTION
## Fixes PU count with protected area set

### Overview

This PR attempts to fix the issue reported [here](https://vizzuality.atlassian.net/browse/MRXN23-120?focusedCommentId=25215) where, once a user created a scenario and sets a protected area, the locked-in PU of the protected area were reflected in the summary in the panel. This lead to display of the _Clear_ button but actually it does nothing as it's trying to revert to the original state of the PUs when it is already there.

Before:
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/685b3ed3-9a32-4c2b-8a10-813a1ef51c08)



The solution is filtering the, in this case, locked-in PUs (_included_ ones for humans) by the property `setByUser` as the protected area setup is not run by the user (well, it is, but the user does not set explicitly the status of the PU) so we can assume there's nothing to clear as there isn't anything set by the user yet.

This also implies those PUs won't be set with the same styles as if the user sets them (which I think is fine).

After: 
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/18b6bb6f-7e1b-46b5-a46c-fd99179ae486)

Note: this filtering also applies now to locked-out and available PUs.

### Designs

–

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [x] Update CHANGELOG file