### PR TITLE
use current queryRunner rather than a free-floating data source when checking if a migration can rely on PostgreSQL v13 or later [MRXN23-273]

### DIFF
--- a/api/apps/api/src/migrations/api/1610395720000-AddSupportForAuthentication.ts
+++ b/api/apps/api/src/migrations/api/1610395720000-AddSupportForAuthentication.ts
@@ -6,7 +6,7 @@ export class AddSupportForAuthentication1610395720000
   implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<any> {
     // Only CREATEDB privilege required in 13+ rather than SUPERUSER (ht @agnessa)
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
       `);
@@ -42,7 +42,7 @@ DROP TABLE issued_authn_tokens;
 ALTER TABLE users DROP COLUMN password_hash;
     `);
 
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
 DROP EXTENSION IF EXISTS pgcrypto;
       `);

--- a/api/apps/api/src/utils/postgresql.utils.ts
+++ b/api/apps/api/src/utils/postgresql.utils.ts
@@ -1,4 +1,4 @@
-import { apiMigrationDataSource } from '@marxan-api/ormconfig.migration';
+import { QueryRunner } from 'typeorm';
 
 /**
  * Utility functions related to lower-level interaction with PostgreSQL servers.
@@ -9,9 +9,8 @@ export class PostgreSQLUtils {
   /**
    * Check if the PostgreSQL server we are connected to is version 13 or higher.
    */
-  static async version13Plus(): Promise<boolean> {
-    // Here we do not need to initialize DataSource again, because it is happening internally when starting the migration process
-    const postgresqlMajorVersion = await apiMigrationDataSource
+  static async version13Plus(queryRunner: QueryRunner): Promise<boolean> {
+    const postgresqlMajorVersion = await queryRunner
       .query('show server_version')
       .then((result: [{ server_version: string }]) => {
         return result[0].server_version.split('.')[0];

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1611221157285-InitialGeoDBSetup.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1611221157285-InitialGeoDBSetup.ts
@@ -4,7 +4,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class InitialGeoDBSetup1611221157285 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Only CREATEDB privilege required in 13+ rather than SUPERUSER (ht @agnessa)
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
     CREATE EXTENSION IF NOT EXISTS plpgsql;
     CREATE EXTENSION IF NOT EXISTS postgis;
@@ -194,7 +194,7 @@ export class InitialGeoDBSetup1611221157285 implements MigrationInterface {
     `);
 
     // Only CREATEDB privilege required in 13+ rather than SUPERUSER (ht @agnessa)
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
       DROP EXTENSION postgis_topology; -- OPTIONAL
       DROP EXTENSION postgis_raster; -- OPTIONAL

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1611828857842-AddFeatureScenarioOutputEntity.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1611828857842-AddFeatureScenarioOutputEntity.ts
@@ -6,7 +6,7 @@ export class AddFeatureScenarioOutputEntity1611828857842
   implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Only CREATEDB privilege required in 13+ rather than SUPERUSER (ht @agnessa)
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
       ALTER TABLE scenario_features_data
       ADD COLUMN target_met float8,
@@ -21,7 +21,7 @@ export class AddFeatureScenarioOutputEntity1611828857842
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
         ALTER TABLE scenario_features_data
         DROP COLUMN target_met,

--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1641582332000-FixUniquenessOfPuGeoms.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1641582332000-FixUniquenessOfPuGeoms.ts
@@ -4,7 +4,7 @@ import { PostgreSQLUtils } from '@marxan-geoprocessing/utils/postgresql.utils';
 
 export class FixUniquenessOfPuGeoms1641582332000 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
           CREATE EXTENSION IF NOT EXISTS pgcrypto;
         `);
@@ -54,7 +54,7 @@ export class FixUniquenessOfPuGeoms1641582332000 implements MigrationInterface {
         on planning_units_geom(the_geom, type, coalesce(project_id, '00000000-0000-0000-0000-000000000000'));
     `);
 
-    if (await PostgreSQLUtils.version13Plus()) {
+    if (await PostgreSQLUtils.version13Plus(queryRunner)) {
       await queryRunner.query(`
           DROP EXTENSION IF EXISTS pgcrypto;
         `);

--- a/api/apps/geoprocessing/src/utils/postgresql.utils.ts
+++ b/api/apps/geoprocessing/src/utils/postgresql.utils.ts
@@ -1,4 +1,4 @@
-import { geoMigrationDataSource } from '@marxan-geoprocessing/ormconfig.migration';
+import { QueryRunner } from 'typeorm';
 
 /**
  * Utility functions related to lower-level interaction with PostgreSQL servers.
@@ -9,9 +9,8 @@ export class PostgreSQLUtils {
   /**
    * Check if the PostgreSQL server we are connected to is version 13 or higher.
    */
-  static async version13Plus(): Promise<boolean> {
-    // Here we do not need to initialize DataSource again, because it is happening internally when starting the migration process
-    const postgresqlMajorVersion = await geoMigrationDataSource
+  static async version13Plus(queryRunner: QueryRunner): Promise<boolean> {
+    const postgresqlMajorVersion = await queryRunner
       .query('show server_version')
       .then((result: [{ server_version: string }]) => {
         return result[0].server_version.split('.')[0];


### PR DESCRIPTION
### Testing instructions

(careful: this will destroy all data in the instance where the PR is checked!)

`make clean-slate && make start-api` should rebuild and start the API and geoprocessing services correctly (without this fix, the services would fail to start with errors related to the use of `PostgresqlUtils.version13Plus()` in the first migration that uses this function).

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-273

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file