### PR TITLE
add ability to list protected areas by project [MRXN23-251]

### DIFF
--- a/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import { projectResource } from './project.api.entity';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { apiGlobalPrefixes } from '@marxan-api/api.config';
+import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
+
+import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
+
+import { isLeft } from 'fp-ts/Either';
+import {
+  ImplementsAcl,
+} from '@marxan-api/decorators/acl.decorator';
+
+import { ProtectedArea } from '@marxan/protected-areas';
+import { ProjectProtectedAreasService } from './project-protected-areas.service';
+import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
+
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+@ApiTags(projectResource.className)
+@Controller(`${apiGlobalPrefixes.v1}/projects`)
+export class ProjectProtectedAreasController {
+  constructor(
+    private readonly projectProtectedAreasService: ProjectProtectedAreasService,
+  ) {}
+
+  @ImplementsAcl()
+  @ApiOperation({
+    description: 'List all protected areas for a project',
+  })
+  @ApiOkResponse({
+    type: ProtectedArea,
+  })
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Get(':projectId/protected-areas')
+  async findAllProtectedAreasForProject(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<ProtectedArea[]> {
+    const result = await this.projectProtectedAreasService.listForProject(
+      projectId,
+      req.user?.id,
+    );
+
+    if (isLeft(result)) {
+      throw mapAclDomainToHttpError(result.left, {
+        projectId,
+      });
+    } else {
+      return result.right;
+    }
+  }
+}

--- a/api/apps/api/src/modules/projects/project-protected-areas.service.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.service.ts
@@ -13,6 +13,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { Repository } from 'typeorm';
 import { projectNotFound } from './projects.service';
+import { ProtectedAreasCrudService } from '../protected-areas/protected-areas-crud.service';
 
 
 @Injectable()
@@ -22,6 +23,7 @@ export class ProjectProtectedAreasService {
     protected readonly repository: Repository<ProtectedArea>,
     private readonly projectAclService: ProjectAclService,
     private readonly projectsCrud: ProjectsCrudService,
+    private readonly protectedAreasCrudService: ProtectedAreasCrudService,
   ) {}
 
   async listForProject(
@@ -34,11 +36,7 @@ export class ProjectProtectedAreasService {
 
     const project = await this.projectsCrud.getById(projectId);
 
-    const projectCustomAreas = await this.repository.find({
-      where: {
-        projectId: project.id,
-      },
-    })
+    const projectCustomAreas = await this.protectedAreasCrudService.listForProject(project.id);
     
     return right(projectCustomAreas);
   }

--- a/api/apps/api/src/modules/projects/project-protected-areas.service.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.service.ts
@@ -1,0 +1,45 @@
+import {
+  forbiddenError,
+} from '@marxan-api/modules/access-control';
+import {
+  Injectable,
+} from '@nestjs/common';
+import { Either, left, right } from 'fp-ts/Either';
+
+import { ProjectsCrudService } from './projects-crud.service';
+import { ProjectAclService } from '../access-control/projects-acl/project-acl.service';
+import { ProtectedArea } from '@marxan/protected-areas';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { Repository } from 'typeorm';
+import { projectNotFound } from './projects.service';
+
+
+@Injectable()
+export class ProjectProtectedAreasService {
+  constructor(
+    @InjectRepository(ProtectedArea, DbConnections.geoprocessingDB)
+    protected readonly repository: Repository<ProtectedArea>,
+    private readonly projectAclService: ProjectAclService,
+    private readonly projectsCrud: ProjectsCrudService,
+  ) {}
+
+  async listForProject(
+    projectId: string,
+    userId: string,
+  ): Promise<Either<typeof forbiddenError | typeof projectNotFound, ProtectedArea[]>> {
+    if (!(await this.projectAclService.canViewProject(userId, projectId))) {
+      return left(forbiddenError);
+    }
+
+    const project = await this.projectsCrud.getById(projectId);
+
+    const projectCustomAreas = await this.repository.find({
+      where: {
+        projectId: project.id,
+      },
+    })
+    
+    return right(projectCustomAreas);
+  }
+}

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -50,6 +50,7 @@ import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/outpu
 import { ProjectProtectedAreasController } from './project-protected-areas.controller';
 import { ProjectProtectedAreasService } from './project-protected-areas.service';
 import { ProjectAclModule } from '../access-control/projects-acl/project-acl.module';
+import { ProtectedAreasCrudModule } from '../protected-areas/protected-areas-crud.module';
 
 @Module({
   imports: [
@@ -91,6 +92,7 @@ import { ProjectAclModule } from '../access-control/projects-acl/project-acl.mod
     LegacyProjectImportRepositoryModule,
     ApiEventsModule,
     OutputProjectSummariesModule,
+    ProtectedAreasCrudModule,
   ],
   providers: [
     ProjectProtectedAreasService,

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -47,6 +47,9 @@ import { ProjectsProxyController } from '@marxan-api/modules/projects/projects-p
 import { WebshotModule } from '@marxan/webshot';
 import { GeoFeatureTagsModule } from '@marxan-api/modules/geo-feature-tags/geo-feature-tags.module';
 import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.module';
+import { ProjectProtectedAreasController } from './project-protected-areas.controller';
+import { ProjectProtectedAreasService } from './project-protected-areas.service';
+import { ProjectAclModule } from '../access-control/projects-acl/project-acl.module';
 
 @Module({
   imports: [
@@ -78,6 +81,7 @@ import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/outpu
     ShapefilesModule,
     PlanningUnitGridModule,
     ProjectBlmModule,
+    ProjectAclModule,
     CloneModule,
     LegacyProjectImportModule,
     AccessControlModule,
@@ -89,6 +93,7 @@ import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/outpu
     OutputProjectSummariesModule,
   ],
   providers: [
+    ProjectProtectedAreasService,
     ProjectsCrudService,
     ProjectsService,
     GeoFeatureSerializer,
@@ -106,6 +111,7 @@ import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/outpu
     ProjectsListingController,
     ProjectDetailsController,
     ProjectsController,
+    ProjectProtectedAreasController,
     ProjectsProxyController,
   ],
   // @ToDo Remove TypeOrmModule after project publish will stop use the ProjectRepository

--- a/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
+++ b/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
@@ -237,4 +237,22 @@ export class ProtectedAreasCrudService extends AppBaseService<
       )
       .getMany();
   }
+
+  async listForProject(projectId: string) {
+    const projectCustomAreas = await this.repository.find({
+      where: {
+        projectId,
+      },
+      order: {
+        fullName: 'ASC',
+      },
+    });
+
+    const serializer = new JSONAPISerializer.Serializer(
+      'protected_areas',
+      this.serializerConfig,
+    );
+
+  return serializer.serialize(projectCustomAreas);
+  }
 }


### PR DESCRIPTION
### Testing instructions

`GET /api/v1/projects/:projectId/protected-areas` should list all the user-uploaded protected areas _available_ within a project.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-251

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file