### PR TITLE
add ability to list protected areas by project, with count of scenarios where each protected area is used [MRXN23-251] [MRXN23-282]

### DIFF
--- a/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
@@ -27,6 +27,7 @@ import { ImplementsAcl } from '@marxan-api/decorators/acl.decorator';
 import { ProtectedArea } from '@marxan/protected-areas';
 import { ProjectProtectedAreasService } from './project-protected-areas.service';
 import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
+import { assertDefined } from '@marxan/utils';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -43,6 +44,7 @@ export class ProjectProtectedAreasController {
   })
   @ApiOkResponse({
     type: ProtectedArea,
+    isArray: true,
   })
   @ApiUnauthorizedResponse()
   @ApiForbiddenResponse()
@@ -51,9 +53,11 @@ export class ProjectProtectedAreasController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<ProtectedArea[]> {
+    assertDefined(req.user);
+
     const result = await this.projectProtectedAreasService.listForProject(
       projectId,
-      req.user?.id,
+      req.user.id,
     );
 
     if (isLeft(result)) {

--- a/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+
+import { projectResource } from './project.api.entity';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { apiGlobalPrefixes } from '@marxan-api/api.config';
+import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
+
+import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
+
+import { isLeft } from 'fp-ts/Either';
+import {
+  ImplementsAcl,
+} from '@marxan-api/decorators/acl.decorator';
+
+import { ProtectedArea } from '@marxan/protected-areas';
+import { ProjectProtectedAreasService } from './project-protected-areas.service';
+import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
+
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+@ApiTags(projectResource.className)
+@Controller(`${apiGlobalPrefixes.v1}/projects`)
+export class ProjectProtectedAreasController {
+  constructor(
+    private readonly projectProtectedAreasService: ProjectProtectedAreasService,
+  ) {}
+
+  @ImplementsAcl()
+  @ApiOperation({
+    description: 'List all protected areas for a project',
+  })
+  @ApiOkResponse({
+    type: ProtectedArea,
+  })
+  @ApiUnauthorizedResponse()
+  @ApiForbiddenResponse()
+  @Get(':projectId/protected-areas')
+  async findAllProtectedAreasForProject(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<ProtectedArea[]> {
+    const result = await this.projectProtectedAreasService.listForProject(
+      projectId,
+      req.user?.id,
+    );
+
+    if (isLeft(result)) {
+      throw mapAclDomainToHttpError(result.left, {
+        projectId,
+      });
+    } else {
+      return result.right;
+    }
+  }
+}

--- a/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.controller.ts
@@ -22,9 +22,7 @@ import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
 
 import { isLeft } from 'fp-ts/Either';
-import {
-  ImplementsAcl,
-} from '@marxan-api/decorators/acl.decorator';
+import { ImplementsAcl } from '@marxan-api/decorators/acl.decorator';
 
 import { ProtectedArea } from '@marxan/protected-areas';
 import { ProjectProtectedAreasService } from './project-protected-areas.service';

--- a/api/apps/api/src/modules/projects/project-protected-areas.service.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.service.ts
@@ -13,6 +13,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { Repository } from 'typeorm';
 import { projectNotFound } from './projects.service';
+import { ProtectedAreasCrudService } from '../protected-areas/protected-areas-crud.service';
 
 
 @Injectable()
@@ -22,6 +23,7 @@ export class ProjectProtectedAreasService {
     protected readonly repository: Repository<ProtectedArea>,
     private readonly projectAclService: ProjectAclService,
     private readonly projectsCrud: ProjectsCrudService,
+    private readonly protectedAreasCrudService: ProtectedAreasCrudService,
   ) {}
 
   async listForProject(
@@ -34,11 +36,7 @@ export class ProjectProtectedAreasService {
 
     const project = await this.projectsCrud.getById(projectId);
 
-    const projectCustomAreas = await this.repository.find({
-      where: {
-        projectId: project.id,
-      },
-    })
+    const projectCustomAreas = await this.protectedAreasCrudService.listForProject(project.id);
     
     return right(projectCustomAreas);
   }

--- a/api/apps/api/src/modules/projects/project-protected-areas.service.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.service.ts
@@ -1,0 +1,45 @@
+import {
+  forbiddenError,
+} from '@marxan-api/modules/access-control';
+import {
+  Injectable,
+} from '@nestjs/common';
+import { Either, left, right } from 'fp-ts/Either';
+
+import { ProjectsCrudService } from './projects-crud.service';
+import { ProjectAclService } from '../access-control/projects-acl/project-acl.service';
+import { ProtectedArea } from '@marxan/protected-areas';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { Repository } from 'typeorm';
+import { projectNotFound } from './projects.service';
+
+
+@Injectable()
+export class ProjectProtectedAreasService {
+  constructor(
+    @InjectRepository(ProtectedArea, DbConnections.geoprocessingDB)
+    protected readonly repository: Repository<ProtectedArea>,
+    private readonly projectAclService: ProjectAclService,
+    private readonly projectsCrud: ProjectsCrudService,
+  ) {}
+
+  async listForProject(
+    projectId: string,
+    userId: string,
+  ): Promise<Either<typeof forbiddenError | typeof projectNotFound, ProtectedArea[]>> {
+    if (!(await this.projectAclService.canViewProject(userId, projectId))) {
+      return left(forbiddenError);
+    }
+
+    const project = await this.projectsCrud.getById(projectId);
+
+    const projectCustomAreas = await this.repository.find({
+      where: {
+        projectId: project.id,
+      },
+    })
+    
+    return right(projectCustomAreas);
+  }
+}

--- a/api/apps/api/src/modules/projects/project-protected-areas.service.ts
+++ b/api/apps/api/src/modules/projects/project-protected-areas.service.ts
@@ -1,9 +1,5 @@
-import {
-  forbiddenError,
-} from '@marxan-api/modules/access-control';
-import {
-  Injectable,
-} from '@nestjs/common';
+import { forbiddenError } from '@marxan-api/modules/access-control';
+import { Injectable } from '@nestjs/common';
 import { Either, left, right } from 'fp-ts/Either';
 
 import { ProjectsCrudService } from './projects-crud.service';
@@ -14,7 +10,6 @@ import { DbConnections } from '@marxan-api/ormconfig.connections';
 import { Repository } from 'typeorm';
 import { projectNotFound } from './projects.service';
 import { ProtectedAreasCrudService } from '../protected-areas/protected-areas-crud.service';
-
 
 @Injectable()
 export class ProjectProtectedAreasService {
@@ -29,15 +24,19 @@ export class ProjectProtectedAreasService {
   async listForProject(
     projectId: string,
     userId: string,
-  ): Promise<Either<typeof forbiddenError | typeof projectNotFound, ProtectedArea[]>> {
+  ): Promise<
+    Either<typeof forbiddenError | typeof projectNotFound, ProtectedArea[]>
+  > {
     if (!(await this.projectAclService.canViewProject(userId, projectId))) {
       return left(forbiddenError);
     }
 
     const project = await this.projectsCrud.getById(projectId);
 
-    const projectCustomAreas = await this.protectedAreasCrudService.listForProject(project.id);
-    
+    const projectCustomAreas = await this.protectedAreasCrudService.listForProject(
+      project.id,
+    );
+
     return right(projectCustomAreas);
   }
 }

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -50,6 +50,7 @@ import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/outpu
 import { ProjectProtectedAreasController } from './project-protected-areas.controller';
 import { ProjectProtectedAreasService } from './project-protected-areas.service';
 import { ProjectAclModule } from '../access-control/projects-acl/project-acl.module';
+import { ProtectedAreasCrudModule } from '../protected-areas/protected-areas-crud.module';
 import { ProjectCostSurfaceController } from './project-cost-surface.controller';
 
 @Module({
@@ -92,6 +93,7 @@ import { ProjectCostSurfaceController } from './project-cost-surface.controller'
     LegacyProjectImportRepositoryModule,
     ApiEventsModule,
     OutputProjectSummariesModule,
+    ProtectedAreasCrudModule,
   ],
   providers: [
     ProjectProtectedAreasService,

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -47,6 +47,9 @@ import { ProjectsProxyController } from '@marxan-api/modules/projects/projects-p
 import { WebshotModule } from '@marxan/webshot';
 import { GeoFeatureTagsModule } from '@marxan-api/modules/geo-feature-tags/geo-feature-tags.module';
 import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.module';
+import { ProjectProtectedAreasController } from './project-protected-areas.controller';
+import { ProjectProtectedAreasService } from './project-protected-areas.service';
+import { ProjectAclModule } from '../access-control/projects-acl/project-acl.module';
 import { ProjectCostSurfaceController } from './project-cost-surface.controller';
 
 @Module({
@@ -79,6 +82,7 @@ import { ProjectCostSurfaceController } from './project-cost-surface.controller'
     ShapefilesModule,
     PlanningUnitGridModule,
     ProjectBlmModule,
+    ProjectAclModule,
     CloneModule,
     LegacyProjectImportModule,
     AccessControlModule,
@@ -90,6 +94,7 @@ import { ProjectCostSurfaceController } from './project-cost-surface.controller'
     OutputProjectSummariesModule,
   ],
   providers: [
+    ProjectProtectedAreasService,
     ProjectsCrudService,
     ProjectsService,
     GeoFeatureSerializer,
@@ -107,6 +112,7 @@ import { ProjectCostSurfaceController } from './project-cost-surface.controller'
     ProjectsListingController,
     ProjectDetailsController,
     ProjectsController,
+    ProjectProtectedAreasController,
     ProjectsProxyController,
     ProjectCostSurfaceController,
   ],

--- a/api/apps/api/src/modules/protected-areas/protected-areas-crud.module.ts
+++ b/api/apps/api/src/modules/protected-areas/protected-areas-crud.module.ts
@@ -6,10 +6,12 @@ import { ProtectedArea } from '@marxan/protected-areas';
 import { ProtectedAreasCrudService } from './protected-areas-crud.service';
 import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
 import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { Scenario } from '../scenarios/scenario.api.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ProtectedArea], DbConnections.geoprocessingDB),
+    TypeOrmModule.forFeature([Scenario]),
   ],
   providers: [ProtectedAreasCrudService, ProxyService],
   controllers: [ProtectedAreasController],

--- a/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
+++ b/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
@@ -152,7 +152,7 @@ export class ProtectedAreasCrudService extends AppBaseService<
         'countryId',
         'status',
         'designation',
-        'scenarioUsageCount'
+        'scenarioUsageCount',
       ],
       keyForAttribute: 'camelCase',
     };

--- a/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
+++ b/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
@@ -1,9 +1,9 @@
 import { BaseServiceResource } from '@marxan-api/types/resource.interface';
 
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AppInfoDTO } from '@marxan-api/dto/info.dto';
-import { Repository, SelectQueryBuilder } from 'typeorm';
+import { IsNull, Not, Repository, SelectQueryBuilder } from 'typeorm';
 import { CreateProtectedAreaDTO } from './dto/create.protected-area.dto';
 import { UpdateProtectedAreaDTO } from './dto/update.protected-area.dto';
 import { ProtectedArea } from '@marxan/protected-areas';
@@ -24,6 +24,8 @@ import { apiConnections } from '../../ormconfig';
 import { AppConfig } from '@marxan-api/utils/config.utils';
 import { IUCNCategory } from '@marxan/iucn';
 import { isDefined } from '@marxan/utils';
+import { Scenario } from '../scenarios/scenario.api.entity';
+import { groupBy } from 'lodash';
 
 const protectedAreaFilterKeyNames = [
   'fullName',
@@ -76,6 +78,8 @@ export class ProtectedAreasCrudService extends AppBaseService<
   constructor(
     @InjectRepository(ProtectedArea, apiConnections.geoprocessingDB.name)
     protected readonly repository: Repository<ProtectedArea>,
+    @InjectRepository(Scenario)
+    protected readonly scenarioRepository: Repository<Scenario>,
   ) {
     super(repository, 'protected_area', 'protected_areas', {
       logging: { muteAll: AppConfig.getBoolean('logging.muteAll', false) },
@@ -148,6 +152,7 @@ export class ProtectedAreasCrudService extends AppBaseService<
         'countryId',
         'status',
         'designation',
+        'scenarioUsageCount'
       ],
       keyForAttribute: 'camelCase',
     };
@@ -239,20 +244,59 @@ export class ProtectedAreasCrudService extends AppBaseService<
   }
 
   async listForProject(projectId: string) {
-    const projectCustomAreas = await this.repository.find({
-      where: {
-        projectId,
-      },
-      order: {
-        fullName: 'ASC',
-      },
-    });
+    /**
+     * Get a list of protected areas used in project scenarios and assemble this
+     * into a map of protected area ids to lists of the scenarios where each
+     * protected area is in use.
+     */
+    const protectedAreaUsedInProjectScenarios = await this.scenarioRepository
+      .find({
+        where: {
+          projectId,
+          protectedAreaFilterByIds: Not(IsNull()),
+        },
+      })
+      .then((scenarios) =>
+        groupBy(
+          scenarios.flatMap((scenario) =>
+            scenario.protectedAreaFilterByIds
+              ?.filter(isDefined)
+              .map((protectedAreaId) => ({
+                scenarioId: scenario.id,
+                protectedAreaId,
+              })),
+          ),
+          'protectedAreaId',
+        ),
+      );
+
+    /**
+     * Get a list of all the protected areas that are linked to a given project,
+     * and add a count of the number of scenarios where each protected area is
+     * used.
+     */
+    const projectCustomProtectedAreas = await this.repository
+      .find({
+        where: {
+          projectId,
+        },
+        order: {
+          fullName: 'ASC',
+        },
+      })
+      .then((protectedAreas) =>
+        protectedAreas.map((protectedArea) => ({
+          ...protectedArea,
+          scenarioUsageCount:
+            protectedAreaUsedInProjectScenarios[protectedArea.id]?.length ?? 0,
+        })),
+      );
 
     const serializer = new JSONAPISerializer.Serializer(
       'protected_areas',
       this.serializerConfig,
     );
 
-  return serializer.serialize(projectCustomAreas);
+    return serializer.serialize(projectCustomProtectedAreas);
   }
 }

--- a/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
+++ b/api/apps/api/src/modules/protected-areas/protected-areas-crud.service.ts
@@ -237,4 +237,22 @@ export class ProtectedAreasCrudService extends AppBaseService<
       )
       .getMany();
   }
+
+  async listForProject(projectId: string) {
+    const projectCustomAreas = await this.repository.find({
+      where: {
+        projectId,
+      },
+      order: {
+        fullName: 'ASC',
+      },
+    });
+
+    const serializer = new JSONAPISerializer.Serializer(
+      'protected_areas',
+      this.serializerConfig,
+    );
+
+  return serializer.serialize(projectCustomAreas);
+  }
 }

--- a/api/apps/api/test/scenario-protected-areas/fixtures.ts
+++ b/api/apps/api/test/scenario-protected-areas/fixtures.ts
@@ -57,6 +57,7 @@ export const getFixtures = async () => {
   });
 
   return {
+    GivenProjectExists: () => projectId,
     GivenScenarioInsideNAM41WasCreated: async () => {
       const { id } = await GivenScenarioExists(app, projectId, ownerToken);
       scenarioId = id;
@@ -93,6 +94,11 @@ export const getFixtures = async () => {
       request(app.getHttpServer())
         .get(`/api/v1/scenarios/${scenarioId}/protected-areas`)
         .set('Authorization', `Bearer ${userWithNoRoleToken}`),
+    WhenGettingProtectedAreasListForProject: async (projectId: string) =>
+      request(app.getHttpServer())
+        .get(`/api/v1/projects/${projectId}/protected-areas`)
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .then((response) => response.body),
     ThenItContainsRelevantWdpa: async (response: any) => {
       expect(response).toEqual([
         {
@@ -102,6 +108,13 @@ export const getFixtures = async () => {
           selected: false,
         },
       ]);
+    },
+    ThenItContainsListOfCustomProtectedAreas: async (response: any) => {
+      expect(response.data).toHaveLength(1);
+      expect(response.data[0].attributes.fullName).toBe(
+        'custom protected area',
+      );
+      expect(response.data[0].attributes.scenarioUsageCount).toBe(1);
     },
     GivenCustomProtectedAreaWasAddedToProject: async () => {
       const ids: { id: string }[] = await wdpa.query(

--- a/api/apps/api/test/scenario-protected-areas/list-project-protected-ares.e2e-spec.ts
+++ b/api/apps/api/test/scenario-protected-areas/list-project-protected-ares.e2e-spec.ts
@@ -1,0 +1,25 @@
+import { IUCNCategory } from '@marxan/iucn';
+import { FixtureType } from '@marxan/utils/tests/fixture-type';
+import { getFixtures } from './fixtures';
+
+let fixtures: FixtureType<typeof getFixtures>;
+
+beforeEach(async () => {
+  fixtures = await getFixtures();
+});
+
+test(`getting list of protected areas with scenario usage count for a project`, async () => {
+  const projectId = fixtures.GivenProjectExists();
+  await fixtures.GivenGlobalProtectedAreaWasCreated(IUCNCategory.III);
+  const scenario: string = await fixtures.GivenScenarioInsideNAM41WasCreated();
+  const areaId = await fixtures.GivenCustomProtectedAreaWasAddedToProject();
+  await fixtures.GivenAreasWereSelectedAsOwner(
+    scenario,
+    IUCNCategory.III,
+    areaId,
+  );
+  const areas = await fixtures.WhenGettingProtectedAreasListForProject(
+    projectId,
+  );
+  await fixtures.ThenItContainsListOfCustomProtectedAreas(areas);
+});

--- a/api/libs/protected-areas/src/protected-areas.geo.entity.ts
+++ b/api/libs/protected-areas/src/protected-areas.geo.entity.ts
@@ -106,4 +106,9 @@ export class ProtectedArea extends TimeUserEntityMetadata {
     name: 'project_id',
   })
   projectId?: string | null;
+
+  /**
+   * How many scenarios actively use this protected area.
+   */
+  scenarioUsageCount?: number;
 }


### PR DESCRIPTION
### Testing instructions

`GET /api/v1/projects/:projectId/protected-areas` should return a response such as the one below, with all of the user-uploaded protected areas listed in alphabetical order (by `fullName`), including a `scenarioUsageCount`.

```
{
    "data": [
        {
            "type": "protected_areas",
            "id": "3902bb73-c95c-42e1-b69f-e7f185d3cb45",
            "attributes": {
                "wdpaId": null,
                "fullName": "pa elephant",
                "iucnCategory": null,
                "shapeLength": null,
                "shapeArea": null,
                "countryId": null,
                "status": null,
                "designation": null,
                "scenarioUsageCount": 0
            }
        }
    ]
}
```

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-251
https://vizzuality.atlassian.net/browse/MRXN23-282

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file