### PR TITLE
[api] fixes csv features upload to save features as is_legacy=true for correct puvspr.dat generation [MRXN23-279]

### DIFF
--- a/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
+++ b/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
@@ -222,6 +222,7 @@ export class FeatureAmountUploadService {
         featureClassName: feature.feature_name,
         projectId: projectId,
         creationStatus: JobStatus.done,
+        isLegacy: true,
       };
     });
 

--- a/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
@@ -253,6 +253,8 @@ export const getFixtures = async () => {
       });
       expect(newFeaturesAdded).toHaveLength(2);
       expect(newFeaturesAdded[0].projectId).toBe(projectId);
+      expect(newFeaturesAdded[0].isLegacy).toBe(true);
+      expect(newFeaturesAdded[1].isLegacy).toBe(true);
     },
 
     ThenNewFeaturesAmountsAreCreated: async () => {


### PR DESCRIPTION
## Fix saving features uploaded with cs file

### Overview

Small fix that sets new features, uploaded with csv file, to have value `is_legacy=true`. After csv feature upload project sources has already been being set to `legacy_import`. Setting features as legacy was missing for correct data generation made by `PuvsprDatLegacyProject.getAmountPerPlanningUnitAndFeature()`

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

Upload features from csv file to a projects scenario. New features must have `is_legacy=true` in (apiDB).featuresTable.
Generating puvspr.dat file must return amounts per species per planning units in accordance with csv file data (not an empty table as it is now).
### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file