### PR TITLE
return JSON:API representation of new feature when successfully creating a feature from shapefile [MRXN23-289 ]

### DIFF
--- a/api/apps/api/src/modules/geo-feature-tags/geo-feature-tags.service.ts
+++ b/api/apps/api/src/modules/geo-feature-tags/geo-feature-tags.service.ts
@@ -272,7 +272,7 @@ export class GeoFeatureTagsService {
       tag: string;
     }[] = await this.geoFeatureTagsRepo
       .createQueryBuilder()
-      .select('feature_id', 'tag')
+      .select('tag')
       .where('feature_id = :featureId', { featureId: geoFeature.id })
       .execute();
 

--- a/api/apps/api/src/modules/geo-feature-tags/geo-feature-tags.service.ts
+++ b/api/apps/api/src/modules/geo-feature-tags/geo-feature-tags.service.ts
@@ -273,7 +273,7 @@ export class GeoFeatureTagsService {
     }[] = await this.geoFeatureTagsRepo
       .createQueryBuilder()
       .select('feature_id', 'tag')
-      .where('feature_id = :featureId)', { featureId: geoFeature.id })
+      .where('feature_id = :featureId', { featureId: geoFeature.id })
       .execute();
 
     return {

--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -367,7 +367,7 @@ export class GeoFeaturesService extends AppBaseService<
     projectId: string,
     data: UploadShapefileDTO,
     features: Record<string, any>[],
-  ): Promise<void> {
+  ): Promise<Either<Error, GeoFeature>> {
     const apiQueryRunner = this.apiDataSource.createQueryRunner();
     const geoQueryRunner = this.geoDataSource.createQueryRunner();
 
@@ -377,9 +377,10 @@ export class GeoFeaturesService extends AppBaseService<
     await apiQueryRunner.startTransaction();
     await geoQueryRunner.startTransaction();
 
+    let geoFeature: GeoFeature;
     try {
       // Create single row in features
-      const geofeature = await this.createFeature(
+      geoFeature = await this.createFeature(
         apiQueryRunner.manager,
         projectId,
         data,
@@ -389,7 +390,7 @@ export class GeoFeaturesService extends AppBaseService<
       await this.createFeatureTag(
         apiQueryRunner.manager,
         projectId,
-        geofeature.id,
+        geoFeature.id,
         data.tagName,
       );
 
@@ -397,7 +398,7 @@ export class GeoFeaturesService extends AppBaseService<
       for (const feature of features) {
         await this.createFeatureData(
           geoQueryRunner.manager,
-          geofeature.id,
+          geoFeature.id,
           feature.geometry,
           feature.properties,
         );
@@ -419,6 +420,8 @@ export class GeoFeaturesService extends AppBaseService<
       await apiQueryRunner.release();
       await geoQueryRunner.release();
     }
+
+    return right(geoFeature);
   }
 
   public async updateFeatureForProject(

--- a/api/apps/api/src/modules/projects/dto/upload-shapefile.dto.ts
+++ b/api/apps/api/src/modules/projects/dto/upload-shapefile.dto.ts
@@ -16,11 +16,18 @@ export class UploadShapefileDTO {
   @IsString()
   description?: string;
 
-  @ApiProperty()
+  @ApiPropertyOptional()
   @IsOptional()
   @Validate(IsValidTagNameValidator)
   @MaxLength(tagMaxlength, {
     message: tagMaxLengthErrorMessage,
   })
   tagName?: string;
+
+  /**
+   * `file` data is extracted via the @UploadedFile decorator in the controller;
+   *  the DTO includes this property to document the request body.
+   */
+  @ApiProperty({ type: 'string', format: 'binary' })
+  file: any;
 }

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -24,6 +24,7 @@ import {
 import { projectResource, ProjectResultSingular } from './project.api.entity';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiConsumes,
   ApiCreatedResponse,
   ApiForbiddenResponse,
@@ -729,8 +730,12 @@ export class ProjectsController {
   @ApiOperation({
     description: `Upload shapefiles of species or bioregional features.`,
   })
-  @ApiOkResponse({ type: ShapefileUploadResponse })
+  @ApiOkResponse({ type: GeoFeature })
   @ApiTags(inlineJobTag)
+  @ApiBody({
+    description: 'Shapefile to upload',
+    type: UploadShapefileDTO,
+  })
   @Post(`:id/features/shapefile`)
   @GeometryFileInterceptor(GeometryKind.ComplexWithProperties)
   async uploadFeatures(

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -153,6 +153,7 @@ import { GeoFeatureTagsService } from '@marxan-api/modules/geo-feature-tags/geo-
 import { GetProjectTagsResponseDto } from '@marxan-api/modules/projects/dto/get-project-tags-response.dto';
 import { UpdateProjectTagDTO } from '@marxan-api/modules/projects/dto/update-project-tag.dto';
 import { outputProjectSummaryResource } from './output-project-summaries/output-project-summary.api.entity';
+import { isNil } from 'lodash';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -757,7 +758,13 @@ export class ProjectsController {
       // @debt Use mapDomainToHttpException() instead
       throw new InternalServerErrorException(newFeatureOrError.left);
     } else {
-      return newFeatureOrError.right;
+      const result = await this.geoFeatureService.getById(newFeatureOrError.right.id);
+      if (isNil(result)) {
+        // @debt Use mapDomainToHttpException() instead
+        throw new NotFoundException();
+      }
+
+      return this.geoFeatureSerializer.serialize(result);
     }
   }
 

--- a/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
@@ -63,7 +63,7 @@ test(`if tagging info is included in DTO and valid, created feature should be ta
   );
 
   // ASSERT
-  await fixtures.ThenGeoFeaturesAreCreated(result, name, description);
+  await fixtures.ThenGeoFeaturesAreCreated(result, name, description, tag);
   await fixtures.ThenGeoFeatureTagIsCreated(name, tag);
 });
 
@@ -86,7 +86,7 @@ test(`if there is already an existing feature with a tag that has equivalent cap
   );
 
   // ASSERT
-  await fixtures.ThenGeoFeaturesAreCreated(result, name, description);
+  await fixtures.ThenGeoFeaturesAreCreated(result, name, description, equivalentTag);
   await fixtures.ThenGeoFeatureTagIsCreated(name, equivalentTag);
   // TODO Check for update of last_modified_at for all affected tag rows for project when implemented
 });

--- a/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
@@ -205,10 +205,14 @@ export const getFixtures = async () => {
       result: request.Response,
       name: string,
       description: string,
+      tag?: string,
     ) => {
-      expect(result.body).toEqual({
-        success: true,
-      });
+      // Check response payload, in JSON:API format
+      expect(result.body?.data?.type).toEqual('geo_features');
+      expect(result.body?.data?.attributes?.isCustom).toEqual(true);
+      expect(result.body?.data?.attributes?.featureClassName).toEqual(name);
+      expect(result.body?.data?.attributes?.tag).toEqual(tag);
+
       const features = await geoFeaturesApiRepo.find({
         where: {
           projectId,


### PR DESCRIPTION
### Testing instructions

`POST /api/v1/projects/:projectId/features/shapefile` should return a JSON:API representation of the uploaded feature from shapefile, upon success.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-289

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file