### PR TITLE
use validateSync() (to avoid temporal dead zone?) [MRXN23-292]

### DIFF
--- a/api/apps/api/src/modules/geo-features/import/csv.parser.ts
+++ b/api/apps/api/src/modules/geo-features/import/csv.parser.ts
@@ -1,7 +1,7 @@
 import { FeatureAmountCSVDto } from '@marxan-api/modules/geo-features/dto/feature-amount-csv.dto';
-import { Stream } from 'stream';
+import { Readable } from 'stream';
 import { parseStream } from 'fast-csv';
-import { validateOrReject } from 'class-validator';
+import { validateSync } from 'class-validator';
 import { missingPuidColumnInFeatureAmountCsvUpload } from '@marxan-api/modules/geo-features/geo-features.service';
 import { left } from 'fp-ts/Either';
 
@@ -21,13 +21,11 @@ export async function featureAmountCsvParser(
   fileBuffer: Buffer,
 ): Promise<FeatureAmountCSVDto[]> {
   return new Promise((resolve, reject) => {
-    // TODO: we might want to accumulate all errors and retirve the offending line number
+    // @todo: we might want to accumulate all errors and retrieve the offending line number
     const parsedData: FeatureAmountCSVDto[] = [];
     const seenPuids = new Set();
-    const stream = new Stream.PassThrough();
-    stream.end(fileBuffer);
 
-    parseStream(stream, { headers: true })
+    parseStream(Readable.from(fileBuffer), { headers: true })
       .on('headers', (h) => {
         const uniqueHeaders = [...new Set(h)];
         if (uniqueHeaders.length !== h.length) {
@@ -53,19 +51,15 @@ export async function featureAmountCsvParser(
               featureName: key,
               amount: parseFloat(data[key]),
             });
-            validateOrReject(featureAmount)
-              .then(() => {
-                parsedData.push(featureAmount);
-              })
-              .catch((err) => {
-                reject(new Error(err));
-              });
+            const validationErrors = validateSync(featureAmount);
+            if (validationErrors.length > 0) {
+              reject(validationErrors);
+            }
+            parsedData.push(featureAmount);
           }
         }
       })
-      .on('end', () => {
-        resolve(parsedData);
-      })
+      .on('end', () => resolve(parsedData))
       .on('error', reject);
   });
 }


### PR DESCRIPTION
Uploading CSV files of features from puvspr data is _always_ failing since... some days ago, because by the time we'd call `resolve(featureAmount)` (`on('end')`), in `featureAmountCsvParser()`, `featureAmount` would be null.

I haven't been able to check why the original implementation, which we didn't touch since it was done, has always been working as expected, and then suddenly stopped working, all the time, except it's working just fine when running in CI: I guess this should be best done by `git bisect`ing things, which could take some time.

In the meanwhile, the proposed fix in this PR does solve the problem that sprung up.

### Testing instructions

Uploading features from a puvspr CSV sample file should lead to features being correctly created (please use a valid features.csv file so that we don't have to take into account validation errors).

On the current (and recent) `develop`, the upload would fail with a db error such as

```
query failed: SELECT DISTINCT "features"."feature_class_name" FROM "features" "features" WHERE "features"."project_id" = $1 AND "features"."feature_class_name" IN () -- PARAMETERS: ["<id of the project the features are being uploaded to>"]
```

and in turn this fails because the `featureClassName`s that should be in the `IN()` part of the query are none - no data is returned when resolving the promise returned by `featureAmountCsvParser()`.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-292

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file