### PR TITLE
only mark scenario as run once it finished running successfully [MRXN23-280]

### DIFF
--- a/api/apps/api/src/modules/scenarios/marxan-run/run.handler.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/run.handler.ts
@@ -39,9 +39,6 @@ export class RunHandler {
       scenarioId: scenario.id,
       assets,
     });
-    await this.scenarios.update(scenario.id, {
-      ranAtLeastOnce: true,
-    });
     const kind = API_EVENT_KINDS.scenario__run__submitted__v1__alpha1;
     await this.apiEvents.create({
       topic: scenario.id,

--- a/api/apps/api/src/modules/scenarios/marxan-run/run.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios/marxan-run/run.service.spec.ts
@@ -44,7 +44,6 @@ test(`scheduling job`, async () => {
   await runService.run({ id: 'scenario-1' });
 
   // then
-  fixtures.ThenShouldUpdateScenario();
   fixtures.ThenShouldEmitSubmittedEvent(`1234`);
   fixtures.ThenShouldAddJob();
   fixtures.ThenShouldUseDefaultBlm();
@@ -59,7 +58,6 @@ test(`scheduling job with overriding blm`, async () => {
   await runService.run({ id: 'scenario-1', boundaryLengthModifier: 78 }, -123);
 
   // then
-  fixtures.ThenShouldUpdateScenario();
   fixtures.ThenShouldEmitSubmittedEvent(`1234`);
   fixtures.ThenShouldAddJob();
   fixtures.ThenShouldUseBlm(-123);
@@ -74,7 +72,6 @@ test(`scheduling job with scenario that has blm`, async () => {
   await runService.run({ id: 'scenario-1', boundaryLengthModifier: 78 });
 
   // then
-  fixtures.ThenShouldUpdateScenario();
   fixtures.ThenShouldEmitSubmittedEvent(`1234`);
   fixtures.ThenShouldAddJob();
   fixtures.ThenShouldUseBlm(78);
@@ -446,12 +443,6 @@ async function getFixtures() {
       expect(fixtures.activeJob.updateProgress).toBeCalledWith({
         canceled: true,
         scenarioId: `scenario-1`,
-      });
-    },
-    ThenShouldUpdateScenario() {
-      expect(fixtures.fakeScenarioRepo.update).toBeCalledTimes(1);
-      expect(fixtures.fakeScenarioRepo.update).toBeCalledWith(`scenario-1`, {
-        ranAtLeastOnce: true,
       });
     },
     ThenShouldEmitSubmittedEvent(id: string) {

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-blm/marxan-sandbox-blm-runner.service.ts
@@ -23,6 +23,8 @@ export class MarxanSandboxBlmRunnerService
   implements SandboxRunner<JobData, void> {
   readonly #controllers: Record<string, AbortController> = {};
   private readonly logger: Logger = new Logger('Marxan Sandbox Blm Runner');
+  @InjectEntityManager(geoprocessingConnections.apiDB)
+  private readonly apiEntityManager!: EntityManager;
 
   constructor(
     private readonly moduleRef: ModuleRef,
@@ -30,8 +32,6 @@ export class MarxanSandboxBlmRunnerService
     private readonly marxanRunnerFactory: MarxanRunnerFactory,
     private readonly eventBus: EventBus,
     private readonly webshotService: WebshotService,
-    @InjectEntityManager(geoprocessingConnections.apiDB)
-    private readonly apiEntityManager: EntityManager,
   ) {}
 
   kill(ofScenarioId: string): void {

--- a/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-single/marxan-sandbox-runner.service.ts
+++ b/api/apps/geoprocessing/src/marxan-sandboxed-runner/adapters-single/marxan-sandbox-runner.service.ts
@@ -11,12 +11,17 @@ import { Cancellable } from '../ports/cancellable';
 import { SandboxRunnerInputFiles } from '../ports/sandbox-runner-input-files';
 import { SandboxRunner } from '../ports/sandbox-runner';
 import { SandboxRunnerOutputHandler } from '../ports/sandbox-runner-output-handler';
+import { EntityManager } from 'typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 
 @Injectable()
 export class MarxanSandboxRunnerService
   implements SandboxRunner<JobData, ExecutionResult> {
   readonly #controllers: Record<string, AbortController> = {};
   readonly #logger = new Logger(this.constructor.name);
+  @InjectEntityManager(geoprocessingConnections.apiDB)
+  private readonly apiEntityManager!: EntityManager;
 
   constructor(
     private readonly workspaceService: WorkspaceBuilder,
@@ -89,6 +94,9 @@ export class MarxanSandboxRunnerService
             marxanRun.stdError,
           );
           await workspace.cleanup();
+
+          await this.markScenarioAsRunSuccessfully(forScenarioId);
+
           resolve(output);
         } catch (error) {
           await this.outputFilesHandler
@@ -135,5 +143,12 @@ export class MarxanSandboxRunnerService
     });
 
     return controller;
+  }
+
+  private async markScenarioAsRunSuccessfully(scenarioId: string) {
+    await this.apiEntityManager.query(
+      'update scenarios set ran_at_least_once = true where id = $1',
+      [scenarioId],
+    );
   }
 }


### PR DESCRIPTION
Only mark a scenario as `ranAtLeastOnce: true` after it has run fully and successfully.

### Testing instructions

Create new scenario, set it to run with a high enough number of iteration to give some time to check if the `Scenario.ranAtLeastOnce` flag is flipped from the initial default (`false`) to `true` while the Marxan solver is running.

Without this PR, the property should be flipped almost instantly after pressing the Run button (or triggering a marxan run via the API directly). With this PR, the property should only be flipped to `true` only after Marxan has run fully and successfully (so, it should stay `false` if the Marxan run is interrupted in flight or fails for whatever reason.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-280

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file