### PR TITLE
New ProjectCostSurfaceController [MRXN23-92]

### DIFF
--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -1,0 +1,132 @@
+import {
+  Controller,
+  forwardRef,
+  Get,
+  Header,
+  Inject,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Req,
+  Res,
+  UploadedFile,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { projectResource } from '@marxan-api/modules/projects/project.api.entity';
+import { apiGlobalPrefixes } from '@marxan-api/api.config';
+import { ApiConsumesShapefile } from '@marxan-api/decorators/shapefile.decorator';
+import {
+  GeometryFileInterceptor,
+  GeometryKind,
+} from '@marxan-api/decorators/file-interceptors.decorator';
+import { asyncJobTag } from '@marxan-api/dto/async-job-tag';
+import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
+import {
+  AsyncJobDto,
+  JsonApiAsyncJobMeta,
+} from '@marxan-api/dto/async-job.dto';
+import { ensureShapefileHasRequiredFiles } from '@marxan-api/utils/file-uploads.utils';
+import { isLeft } from 'fp-ts/Either';
+import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
+import { scenarioResource } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { ScenariosService } from '@marxan-api/modules/scenarios/scenarios.service';
+import { CostRangeDto } from '@marxan-api/modules/scenarios/dto/cost-range.dto';
+import { plainToClass } from 'class-transformer';
+import { Response } from 'express';
+import { marxanRunFiles } from '@marxan-api/modules/scenarios/scenarios.controller';
+import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
+import { ImplementsAcl } from '@marxan-api/decorators/acl.decorator';
+
+@ApiTags(projectResource.className)
+@Controller(`${apiGlobalPrefixes.v1}/projects`)
+export class ProjectCostSurfaceController {
+  constructor(
+    @Inject(forwardRef(() => ScenariosService))
+    public readonly scenarioService: ScenariosService,
+  ) {}
+
+  @ImplementsAcl()
+  @UseGuards(JwtAuthGuard)
+  @ApiConsumesShapefile({ withGeoJsonResponse: false })
+  @GeometryFileInterceptor(GeometryKind.ComplexWithProperties)
+  @ApiTags(asyncJobTag)
+  @Post(`:scenarioId/cost-surface/shapefile`)
+  async processCostSurfaceShapefile(
+    @Param('scenarioId') scenarioId: string,
+    @Req() req: RequestWithAuthenticatedUser,
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<JsonApiAsyncJobMeta> {
+    await ensureShapefileHasRequiredFiles(file);
+
+    const result = await this.scenarioService.processCostSurfaceShapefile(
+      scenarioId,
+      req.user.id,
+      file,
+    );
+
+    if (isLeft(result)) {
+      throw mapAclDomainToHttpError(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: scenarioResource.name.plural,
+      });
+    }
+    return AsyncJobDto.forScenario().asJsonApiMetadata();
+  }
+
+  @ImplementsAcl()
+  @UseGuards(JwtAuthGuard)
+  @Get(`:scenarioId/cost-surface`)
+  @ApiOkResponse({ type: CostRangeDto })
+  async getCostRange(
+    @Param('scenarioId') scenarioId: string,
+    @Req() req: RequestWithAuthenticatedUser,
+  ): Promise<CostRangeDto> {
+    const result = await this.scenarioService.getCostRange(
+      scenarioId,
+      req.user.id,
+    );
+    if (isLeft(result)) {
+      throw mapAclDomainToHttpError(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: scenarioResource.name.plural,
+      });
+    }
+    return plainToClass<CostRangeDto, CostRangeDto>(CostRangeDto, result.right);
+  }
+
+  @ImplementsAcl()
+  @UseGuards(JwtAuthGuard)
+  @ApiTags(marxanRunFiles)
+  @Header('Content-Type', 'text/csv')
+  @ApiOkResponse({
+    schema: {
+      type: 'string',
+    },
+  })
+  @ApiOperation({
+    description: `Uploaded cost surface data`,
+  })
+  @Get(`:scenarioId/marxan/dat/pu.dat`)
+  async getScenarioCostSurface(
+    @Param('scenarioId', ParseUUIDPipe) scenarioId: string,
+    @Req() req: RequestWithAuthenticatedUser,
+    @Res() res: Response,
+  ): Promise<void> {
+    const result = await this.scenarioService.getCostSurfaceCsv(
+      scenarioId,
+      req.user.id,
+      res,
+    );
+
+    if (isLeft(result)) {
+      throw mapAclDomainToHttpError(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: scenarioResource.name.plural,
+      });
+    }
+  }
+}

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -82,37 +82,4 @@ export class ProjectCostSurfaceController {
     }
     return plainToClass<CostRangeDto, CostRangeDto>(CostRangeDto, result.right);
   }
-
-  @ImplementsAcl()
-  @UseGuards(JwtAuthGuard)
-  @ApiTags(marxanRunFiles)
-  @Header('Content-Type', 'text/csv')
-  @ApiOkResponse({
-    schema: {
-      type: 'string',
-    },
-  })
-  @ApiOperation({
-    description: `Uploaded cost surface data`,
-  })
-  @Get(`:scenarioId/marxan/dat/pu.dat`)
-  async getScenarioCostSurface(
-    @Param('scenarioId', ParseUUIDPipe) scenarioId: string,
-    @Req() req: RequestWithAuthenticatedUser,
-    @Res() res: Response,
-  ): Promise<void> {
-    const result = await this.scenarioService.getCostSurfaceCsv(
-      scenarioId,
-      req.user.id,
-      res,
-    );
-
-    if (isLeft(result)) {
-      throw mapAclDomainToHttpError(result.left, {
-        scenarioId,
-        userId: req.user.id,
-        resourceType: scenarioResource.name.plural,
-      });
-    }
-  }
 }

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Header,
   Inject,
+  NotImplementedException,
   Param,
   ParseUUIDPipe,
   Post,
@@ -22,11 +23,6 @@ import {
 } from '@marxan-api/decorators/file-interceptors.decorator';
 import { asyncJobTag } from '@marxan-api/dto/async-job-tag';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
-import {
-  AsyncJobDto,
-  JsonApiAsyncJobMeta,
-} from '@marxan-api/dto/async-job.dto';
-import { ensureShapefileHasRequiredFiles } from '@marxan-api/utils/file-uploads.utils';
 import { isLeft } from 'fp-ts/Either';
 import { mapAclDomainToHttpError } from '@marxan-api/utils/acl.utils';
 import { scenarioResource } from '@marxan-api/modules/scenarios/scenario.api.entity';
@@ -48,31 +44,21 @@ export class ProjectCostSurfaceController {
 
   @ImplementsAcl()
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ description: 'To be implemented' })
   @ApiConsumesShapefile({ withGeoJsonResponse: false })
   @GeometryFileInterceptor(GeometryKind.ComplexWithProperties)
   @ApiTags(asyncJobTag)
-  @Post(`:scenarioId/cost-surface/shapefile`)
+  @Post(`:projectId/cost-surface/shapefile`)
   async processCostSurfaceShapefile(
-    @Param('scenarioId') scenarioId: string,
+    @Param(':projectId') projectId: string,
     @Req() req: RequestWithAuthenticatedUser,
     @UploadedFile() file: Express.Multer.File,
-  ): Promise<JsonApiAsyncJobMeta> {
-    await ensureShapefileHasRequiredFiles(file);
-
-    const result = await this.scenarioService.processCostSurfaceShapefile(
-      scenarioId,
-      req.user.id,
-      file,
-    );
-
-    if (isLeft(result)) {
-      throw mapAclDomainToHttpError(result.left, {
-        scenarioId,
-        userId: req.user.id,
-        resourceType: scenarioResource.name.plural,
-      });
-    }
-    return AsyncJobDto.forScenario().asJsonApiMetadata();
+  ): Promise<NotImplementedException> {
+    /**
+     * @todo: We will have to move ScenarioService.processCostSurfaceShapefile logic to another project-scoped
+     *        service and fire it from here.
+     */
+    throw new NotImplementedException();
   }
 
   @ImplementsAcl()

--- a/api/apps/api/src/modules/projects/projects.module.ts
+++ b/api/apps/api/src/modules/projects/projects.module.ts
@@ -47,6 +47,7 @@ import { ProjectsProxyController } from '@marxan-api/modules/projects/projects-p
 import { WebshotModule } from '@marxan/webshot';
 import { GeoFeatureTagsModule } from '@marxan-api/modules/geo-feature-tags/geo-feature-tags.module';
 import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/output-project-summaries/output-project-summaries.module';
+import { ProjectCostSurfaceController } from './project-cost-surface.controller';
 
 @Module({
   imports: [
@@ -107,6 +108,7 @@ import { OutputProjectSummariesModule } from '@marxan-api/modules/projects/outpu
     ProjectDetailsController,
     ProjectsController,
     ProjectsProxyController,
+    ProjectCostSurfaceController,
   ],
   // @ToDo Remove TypeOrmModule after project publish will stop use the ProjectRepository
   exports: [ProjectsCrudService, TypeOrmModule, ProjectsService],

--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -1019,6 +1019,35 @@ export class ScenariosController {
     return this.scenarioSolutionSerializer.serialize(result.right);
   }
 
+  @ImplementsAcl()
+  @UseGuards(JwtAuthGuard)
+  @ApiTags(marxanRunFiles)
+  @Header('Content-Type', 'text/csv')
+  @ApiOkResponse({
+    schema: {
+      type: 'string',
+    },
+  })
+  @ApiOperation({
+    description: `Uploaded cost surface data`,
+  })
+  @Get(`:scenarioId/marxan/dat/pu.dat`)
+  async getPuDatFile(
+    @Param('scenarioId', ParseUUIDPipe) scenarioId: string,
+    @Req() req: RequestWithAuthenticatedUser,
+    @Res() res: Response,
+  ): Promise<void> {
+    const result = await this.service.getPuDatCsv(scenarioId, req.user.id, res);
+
+    if (isLeft(result)) {
+      throw mapAclDomainToHttpError(result.left, {
+        scenarioId,
+        userId: req.user.id,
+        resourceType: scenarioResource.name.plural,
+      });
+    }
+  }
+
   @ApiOkResponse({
     type: ProtectedAreaDto,
     isArray: true,

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -612,7 +612,7 @@ export class ScenariosService {
     return right(geoJson);
   }
 
-  async getCostSurfaceCsv(
+  async getPuDatCsv(
     scenarioId: string,
     userId: string,
     stream: stream.Writable,

--- a/api/apps/api/test/business-critical/marxan-run/execute-marxan-run.e2e-spec.ts
+++ b/api/apps/api/test/business-critical/marxan-run/execute-marxan-run.e2e-spec.ts
@@ -12,7 +12,6 @@ describe.skip(`Marxan run`, () => {
     await fixtures.GivenUserIsLoggedIn();
     await fixtures.GivenProjectOrganizationExists();
     await fixtures.GivenScenarioExists(`Mouse`);
-    await fixtures.GivenCostSurfaceTemplateFilled();
     await fixtures.WhenMarxanExecutionIsRequested();
     await fixtures.WhenMarxanExecutionIsCompleted();
     await fixtures.ThenResultsAreAvailable();

--- a/api/apps/api/test/business-critical/marxan-run/fixtures.ts
+++ b/api/apps/api/test/business-critical/marxan-run/fixtures.ts
@@ -42,7 +42,7 @@ export const getFixtures = async () => {
     },
     GivenCostSurfaceTemplateFilled: async () => {
       await request(app.getHttpServer())
-        .get(`/api/v1/scenarios/${scenario}/cost-surface/shapefile-template`)
+        .get(`/api/v1/projects/${scenario}/cost-surface/shapefile-template`)
         .set('Authorization', `Bearer ${authToken}`);
     },
     WhenMarxanExecutionIsRequested: async () => {

--- a/api/apps/api/test/business-critical/marxan-run/fixtures.ts
+++ b/api/apps/api/test/business-critical/marxan-run/fixtures.ts
@@ -40,11 +40,6 @@ export const getFixtures = async () => {
         ScenariosTestUtils.deleteScenario(app, authToken, scenario),
       );
     },
-    GivenCostSurfaceTemplateFilled: async () => {
-      await request(app.getHttpServer())
-        .get(`/api/v1/projects/${scenario}/cost-surface/shapefile-template`)
-        .set('Authorization', `Bearer ${authToken}`);
-    },
     WhenMarxanExecutionIsRequested: async () => {
       // TODO currently not implemented yet: 501
       await request(app.getHttpServer())

--- a/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
+++ b/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
@@ -152,24 +152,24 @@ export const getFixtures = async () => {
     WhenGettingMarxanDataAsOwner: async () =>
       (
         await request(app.getHttpServer())
-          .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
+          .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
           .set('Authorization', `Bearer ${ownerToken}`)
       ).text,
     WhenGettingMarxanDataAsContributor: async () =>
       (
         await request(app.getHttpServer())
-          .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
+          .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
           .set('Authorization', `Bearer ${contributorToken}`)
       ).text,
     WhenGettingMarxanDataAsViewer: async () =>
       (
         await request(app.getHttpServer())
-          .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
+          .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
           .set('Authorization', `Bearer ${viewerToken}`)
       ).text,
     WhenGettingMarxanDataAsUserNotInScenario: async () =>
       await request(app.getHttpServer())
-        .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
+        .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
         .set('Authorization', `Bearer ${userNotInScenarioToken}`),
     WhenGettingPuInclusionStateAsOwner: async () =>
       (

--- a/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
+++ b/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
@@ -152,24 +152,24 @@ export const getFixtures = async () => {
     WhenGettingMarxanDataAsOwner: async () =>
       (
         await request(app.getHttpServer())
-          .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
+          .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
           .set('Authorization', `Bearer ${ownerToken}`)
       ).text,
     WhenGettingMarxanDataAsContributor: async () =>
       (
         await request(app.getHttpServer())
-          .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
+          .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
           .set('Authorization', `Bearer ${contributorToken}`)
       ).text,
     WhenGettingMarxanDataAsViewer: async () =>
       (
         await request(app.getHttpServer())
-          .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
+          .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
           .set('Authorization', `Bearer ${viewerToken}`)
       ).text,
     WhenGettingMarxanDataAsUserNotInScenario: async () =>
       await request(app.getHttpServer())
-        .get(`/api/v1/projects/${scenarioId}/marxan/dat/pu.dat`)
+        .get(`/api/v1/scenarios/${scenarioId}/marxan/dat/pu.dat`)
         .set('Authorization', `Bearer ${userNotInScenarioToken}`),
     WhenGettingPuInclusionStateAsOwner: async () =>
       (


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

- Adds a new ProjectCostSurfaceControler
- Moves all cost surface related operations from ScenarioController to ProjectCostSurfaceControler
- Updates tests / fixtures


Following the API conventions in the scope of this task, no functionality is added, besides creating new endpoints.
Access control is handled at service level since 49ea0d52c98c530cc6eb3250711b3476a51ba6d8 as opposed to how is done in different controlers, the only auth stuff being used is the built-in module with some custom decorators.

I also realized that there are no tests specifically hitting the moved endpoints, however acl methods being used in said endpoints are tested hitting another endpoints

This being said I think it would be redundant to add more tests hitting those new endpoints



### Testing instructions

CI happy we happy

### Feature relevant tickets

1. [MARXN-23-92](https://vizzuality.atlassian.net/browse/MRXN23-92)

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file