### PR TITLE
tweak tolerance for st_removerepeatedpoints() [MRXN23-281]

### DIFF
--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -73,7 +73,7 @@ export class FeatureService {
   ): Promise<Buffer> {
     const { z, x, y, id } = tileSpecification;
     const attributes = 'feature_id, properties';
-    const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, 0.1) as the_geom, properties, feature_id from "${this.featuresRepository.metadata.tableName}")`;
+    const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, 0.01) as the_geom, properties, feature_id from "${this.featuresRepository.metadata.tableName}")`;
     const customQuery = this.buildFeaturesWhereQuery(id, bbox);
     return this.tileService.getTile({
       z,


### PR DESCRIPTION
For full context, see the Jira issue linked below

### Testing instructions

Tiles of features that include "very small" regular polygons should display correctly: for example, for features created from an hexagonal grid when uploading features from shapefiles, the polygons that make up the feature should show as filled hexagons, not as triangles that join only some of the vertices of the hexagons.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-281

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file