### PR TITLE
fix: use POST verb rather than GET for webshot API endpoint for scenario comparison maps [MRXN23-323]

### DIFF
--- a/api/apps/api/src/modules/projects/projects-proxy.controller.ts
+++ b/api/apps/api/src/modules/projects/projects-proxy.controller.ts
@@ -1,11 +1,10 @@
 import {
   Body,
   Controller,
-  Get,
   Header,
-  InternalServerErrorException,
   Param,
   ParseUUIDPipe,
+  Post,
   Req,
   Res,
   UseGuards,
@@ -56,8 +55,7 @@ export class ProjectsProxyController {
     description: 'Get comparison map for two scenarios in PDF format',
   })
   @Header('content-type', 'application/pdf')
-  //@Get('comparison-map/:scenarioIdA/compare/:scenarioIdB')
-  @Get('comparison-map/:scenarioIdA/compare/:scenarioIdB')
+  @Post('comparison-map/:scenarioIdA/compare/:scenarioIdB')
   async scenarioFrequencyComparisonMap(
     @Body() config: WebshotBasicPdfConfig,
     @Param('scenarioIdA', ParseUUIDPipe) scenarioIdA: string,

--- a/api/apps/api/src/modules/projects/projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.controller.ts
@@ -759,11 +759,13 @@ export class ProjectsController {
       data.features,
     );
 
-    if(isLeft(newFeatureOrError)) {
+    if (isLeft(newFeatureOrError)) {
       // @debt Use mapDomainToHttpException() instead
       throw new InternalServerErrorException(newFeatureOrError.left);
     } else {
-      const result = await this.geoFeatureService.getById(newFeatureOrError.right.id);
+      const result = await this.geoFeatureService.getById(
+        newFeatureOrError.right.id,
+      );
       if (isNil(result)) {
         // @debt Use mapDomainToHttpException() instead
         throw new NotFoundException();

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -57,7 +57,7 @@ export const getFixtures = async () => {
       scenarioIdB: string,
     ) =>
       await request(app.getHttpServer())
-        .get(
+        .post(
           `/api/v1/projects/comparison-map/${scenarioIdA}/compare/${scenarioIdB}`,
         )
         .set('Authorization', `Bearer ${randomUserToken}`)

--- a/api/apps/api/test/project/projects.fixtures.ts
+++ b/api/apps/api/test/project/projects.fixtures.ts
@@ -63,7 +63,7 @@ export const getFixtures = async () => {
         .set('Authorization', `Bearer ${randomUserToken}`)
         .send({ baseUrl: 'webshorUrl' }),
     ThenCorrectPdfBufferIsReceived: (response: request.Response) => {
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(201);
       expect(response.body).toBeInstanceOf(Buffer);
       expect(Object.keys(response.body).length).toBe(1214);
     },

--- a/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
@@ -86,7 +86,12 @@ test(`if there is already an existing feature with a tag that has equivalent cap
   );
 
   // ASSERT
-  await fixtures.ThenGeoFeaturesAreCreated(result, name, description, equivalentTag);
+  await fixtures.ThenGeoFeaturesAreCreated(
+    result,
+    name,
+    description,
+    equivalentTag,
+  );
   await fixtures.ThenGeoFeatureTagIsCreated(name, equivalentTag);
   // TODO Check for update of last_modified_at for all affected tag rows for project when implemented
 });


### PR DESCRIPTION
Like for all other "reverse-proxy" endpoints in front of the webshot service, since we need to be able to accept a request body for these requests.

### Testing instructions

Requests from frontend should be processed correctly, including their body

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file