### PR TITLE
Rollback ScenariosController.getCostRange() as deprecated, fix param bug

### DIFF
--- a/api/apps/api/src/modules/scenarios/scenarios.controller.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.controller.ts
@@ -403,21 +403,21 @@ export class ScenariosController {
   @ApiTags(asyncJobTag)
   @Post(`:scenarioId/cost-surface/shapefile`)
   async processCostSurfaceShapefile(
-    @Param(':scenarioId') scenarioId: string,
+    @Param('scenarioId') scenarioId: string,
     @Req() req: RequestWithAuthenticatedUser,
     @UploadedFile() file: Express.Multer.File,
   ): Promise<JsonApiAsyncJobMeta> {
     await ensureShapefileHasRequiredFiles(file);
 
     const result = await this.service.processCostSurfaceShapefile(
-      req.params.scenarioId,
+      scenarioId,
       req.user.id,
       file,
     );
 
     if (isLeft(result)) {
       throw mapAclDomainToHttpError(result.left, {
-        scenarioId: req.params.scenarioId,
+        scenarioId,
         userId: req.user.id,
         resourceType: scenarioResource.name.plural,
       });


### PR DESCRIPTION
## Rollback ScenariosController.getCostRange() as deprecated, fix param bug

After some investigation of the missing endpoint, the conclusions and sequence of events are the following:
- Following endpoints have been removed from ScenariosController and added to ProjectCostSurfaceController: processCostSurfaceShapefile, getCostRange, getScenarioCostSurface
- Then following endpoints were roll back as deprecated: processCostSurfaceShapefile, getScenarioCostSurface rolled back and renamed to getPuDatFile
- So getCostRange() hasn't been rolled back as deprecated to ScenariosController

In order for FE to be able to work with 'old' endpoints, they need to be the following (implemented in this PR) :
`GET /api/v1/scenarios/{scenarioId}/cost-surface`- to get cost surface range
`POST /api/v1/scenarios/{scenarioId}/cost-surface/shapefile` - to upload shapefil of cost surface

Regarding the bug we have now in marxan23 - for some reason, specifically in thos endpoint @Param() decorator is not working correctly and not extracting `scenarioId' param from query.. However, replacing it with `req.params.scenarioId`works fine

### Overview

_Please write a description. If the PR is hard to understand, provide a quick explanation of the code._

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file