### PR TITLE
[MRXN23-397]: fixes PU map

### DIFF
--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -524,7 +524,7 @@ export function useSaveScenario({
 
       await queryClient.invalidateQueries(['scenarios', projectId]);
       await queryClient.invalidateQueries(['scenario', id]);
-      queryClient.setQueryData(['scenario', id], data);
+      queryClient.setQueryData(['scenario', id], { data });
     },
   });
 }


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR fixes two issues:
- the scenario data returned by a mutation after saving the new planning units was wrong (`{data: scenario}` vs `scenario`) leading to an undefined result and a wrong layer threshold.
- an issue with the cache of the layers: now we need to ensure the cache is updated whenever the user changes the tab, or the layer will remain untouched regardless of changing the tab and its configuration.

### Designs

–

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-397

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file