### PR TITLE
[MRXN23-410]: updates planning unit status tab order

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/planning-unit-status/actions-summary/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/planning-unit-status/actions-summary/index.tsx
@@ -178,44 +178,6 @@ export const ActionsSummary = ({
 
   return (
     <div className="flex flex-col divide-y-2 divide-gray-500">
-      {/* // ? Available areas  */}
-      <div className="flex flex-col space-y-3 py-3">
-        <div className="flex">
-          <span className="flex flex-1 items-center space-x-2">
-            <Icon
-              icon={HEXAGON_SVG}
-              className="fill-none h-5 w-5 stroke-current stroke-[1.5px] text-yellow-300"
-            />
-            <span className="text-sm text-white">Available areas</span>
-          </span>
-          <span
-            className={cn('flex flex-1 items-center justify-center text-sm text-white', {
-              'text-yellow-300': puAction === 'available',
-            })}
-          >
-            {puTmpAvailableValue.length + puAvailableValue.length} PU
-          </span>
-          <div className="flex flex-1 justify-end">
-            <Button
-              className={cn('invisible', {
-                visible: PUData.available.length > 0,
-              })}
-              theme="secondary"
-              size="s"
-              data-up-action="available"
-              onClick={onClearAreas}
-            >
-              <div className="flex items-center space-x-2">
-                <span>Clear</span>
-                <Icon icon={CLOSE_SVG} className="h-2 w-2" />
-              </div>
-            </Button>
-          </div>
-        </div>
-        {puAction === 'available' && (
-          <ActionsSummaryButtons onCancel={() => onCancelPUSelection('available')} />
-        )}
-      </div>
       {/* // ? Included areas  */}
       <div className="flex flex-col space-y-3 py-3">
         <div className="flex">
@@ -290,6 +252,44 @@ export const ActionsSummary = ({
         </div>
         {puAction === 'exclude' && (
           <ActionsSummaryButtons onCancel={() => onCancelPUSelection('exclude')} />
+        )}
+      </div>
+      {/* // ? Available areas  */}
+      <div className="flex flex-col space-y-3 py-3">
+        <div className="flex">
+          <span className="flex flex-1 items-center space-x-2">
+            <Icon
+              icon={HEXAGON_SVG}
+              className="fill-none h-5 w-5 stroke-current stroke-[1.5px] text-yellow-300"
+            />
+            <span className="text-sm text-white">Available areas</span>
+          </span>
+          <span
+            className={cn('flex flex-1 items-center justify-center text-sm text-white', {
+              'text-yellow-300': puAction === 'available',
+            })}
+          >
+            {puTmpAvailableValue.length + puAvailableValue.length} PU
+          </span>
+          <div className="flex flex-1 justify-end">
+            <Button
+              className={cn('invisible', {
+                visible: PUData.available.length > 0,
+              })}
+              theme="secondary"
+              size="s"
+              data-up-action="available"
+              onClick={onClearAreas}
+            >
+              <div className="flex items-center space-x-2">
+                <span>Clear</span>
+                <Icon icon={CLOSE_SVG} className="h-2 w-2" />
+              </div>
+            </Button>
+          </div>
+        </div>
+        {puAction === 'available' && (
+          <ActionsSummaryButtons onCancel={() => onCancelPUSelection('available')} />
         )}
       </div>
     </div>

--- a/app/layout/project/sidebar/scenario/grid-setup/planning-unit-status/tabs/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/planning-unit-status/tabs/index.tsx
@@ -31,19 +31,6 @@ export const PlanningUnitTabs: React.FC<PlanningUnitTabsProps> = ({
       >
         Include areas
       </button>
-
-      <button
-        type="button"
-        className={cn({
-          [BUTTON_COMMON_CLASSES]: true,
-          [BUTTON_ACTIVE_CLASSES]: type === 'available',
-          'text-white/40': type !== 'available',
-        })}
-        onClick={() => onChange('available')}
-      >
-        Available areas
-      </button>
-
       <button
         type="button"
         className={cn({
@@ -54,6 +41,17 @@ export const PlanningUnitTabs: React.FC<PlanningUnitTabsProps> = ({
         onClick={() => onChange('exclude')}
       >
         Exclude areas
+      </button>
+      <button
+        type="button"
+        className={cn({
+          [BUTTON_COMMON_CLASSES]: true,
+          [BUTTON_ACTIVE_CLASSES]: type === 'available',
+          'text-white/40': type !== 'available',
+        })}
+        onClick={() => onChange('available')}
+      >
+        Available areas
       </button>
     </div>
   );

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -256,9 +256,9 @@ export const ScenariosEditMap: React.FC = () => {
     if (tab === TABS['scenario-planning-unit-status']) {
       return [
         ...(protectedCategories.length ? ['wdpa-percentage'] : []),
-        'lock-available',
         'lock-in',
         'lock-out',
+        'lock-available',
         'pugrid',
       ];
     }


### PR DESCRIPTION
## Updates order of planning units

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/a971d94c-52c7-407e-b61b-050612d99d07)
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/0dcd2f7a-da2b-4999-a055-d08e17fc17b7)



### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-410

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file