### PR TITLE
[MRXN23-395]: updates protected area step improve

### DIFF
--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -33,7 +33,8 @@ export const COLORS = {
       '#de4210',
     ],
   },
-  wdpa: '#00F',
+  wdpa: '#12EC80',
+  'wdpa-preview': '#00f',
   features: '#6F53F7',
   highlightFeatures: '#BE6BFF',
   include: '#03E7D1',
@@ -162,7 +163,7 @@ export const LEGEND_LAYERS = {
       <Icon
         icon={SQUARE_SVG}
         className="mt-0.5 h-3.5 w-3.5 stroke-current stroke-2"
-        style={{ color: COLORS.wdpa }}
+        style={{ color: COLORS['wdpa-preview'] }}
       />
     ),
     settingsManager: {

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -211,7 +211,7 @@ export function useWDPAPreviewLayer({
               ['all', ['in', ['get', 'id'], ['literal', wdpaIucnCategories]]],
             ],
             paint: {
-              'fill-color': COLORS.wdpa,
+              'fill-color': COLORS['wdpa-preview'],
             },
           },
           {
@@ -814,7 +814,7 @@ export function usePUGridLayer({
                         ['has', 'percentageProtected'],
                         ['>=', ['get', 'percentageProtected'], wdpaThreshold],
                       ],
-                      0.5 * WdpaPercentageOpacity,
+                      0.9 * WdpaPercentageOpacity,
                       0,
                     ],
                   },


### PR DESCRIPTION
## Updates protected area step improve

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/15f4da07-63bc-43e3-809c-2cae5ee61923)

Updates colours of Protected Areas and Protected Areas Preview layer to differentiate them better.

Note: this is done without design consent. We might need to change colours later, but, for now, at least the layers can be differentiated.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-395

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file