### PR TITLE
[MRXN23-408]: ensures PA list in scenarios keeps up to date after uploading a protected area

### DIFF
--- a/app/hooks/wdpa/index.ts
+++ b/app/hooks/wdpa/index.ts
@@ -20,7 +20,7 @@ export function useWDPACategories({
 }: UseWDPACategoriesProps) {
   const { data: session } = useSession();
 
-  const query = useQuery(
+  return useQuery(
     ['protected-areas', adminAreaId, customAreaId],
     async () =>
       WDPA.request({
@@ -37,20 +37,12 @@ export function useWDPACategories({
         headers: {
           Authorization: `Bearer ${session.accessToken}`,
         },
-      }),
+      }).then(({ data }) => data),
     {
       enabled: !!adminAreaId || !!customAreaId,
+      select: ({ data }) => data,
     }
   );
-
-  const { data } = query;
-
-  return useMemo(() => {
-    return {
-      ...query,
-      data: data?.data?.data,
-    };
-  }, [query, data?.data?.data]);
 }
 
 export function useSaveScenarioProtectedAreas({

--- a/app/layout/project/sidebar/scenario/grid-setup/protected-areas/categories/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/protected-areas/categories/index.tsx
@@ -104,7 +104,6 @@ export const WDPACategories = ({ onContinue }): JSX.Element => {
                 level: 'success',
               }
             );
-            // push(`/projects/${pid}/scenarios/${sid}/edit?tab=${TABS['scenario-protected-areas']}`);
             onContinue();
           },
           onError: () => {
@@ -135,11 +134,10 @@ export const WDPACategories = ({ onContinue }): JSX.Element => {
       if (isModified) {
         onCalculateProtectedAreas(values);
       } else {
-        // push(`/projects/${pid}/scenarios/${sid}/edit?tab=${TABS['scenario-protected-areas']}`);
         onContinue();
       }
     },
-    [wdpaData, onCalculateProtectedAreas, pid, sid, push, onContinue]
+    [wdpaData, onCalculateProtectedAreas, onContinue]
   );
 
   // Constants


### PR DESCRIPTION
## Ensures PA list in scenarios keeps up to date after uploading a protected area

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/50b012ff-b3f3-43e2-bb86-176a68f45f02)


This PR ensures the PA list is kept up to date once the user has uploaded a new PA. The truth is this was already working, but I am adding query invalidation just in case.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

- go to `/projects/{id}/scenarios/{id}/edit?tab=protected-areas`,
- Click on `Upload your protected area network` button and upload a PA.
- Check again the list in the panel, the uploaded PA should be reflected in the list.

NOTE: uploading the same shapefile over again will REPLACE the current PA with the new one, so don't expect having 2 different PAs with the same shapefile.


### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-408

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file