### PR TITLE
[MRXN23-407]:  fixes project creation through shapefile with grid

### DIFF
--- a/app/layout/projects/new/form/component.tsx
+++ b/app/layout/projects/new/form/component.tsx
@@ -167,7 +167,7 @@ const ProjectForm = ({
 
     const registeredFields = form.getRegisteredFields();
     registeredFields.forEach((f) => {
-      const omitFields = ['name', 'description', 'planningUnitGridShape'];
+      const omitFields = ['name', 'description', 'planningUnitGridShape', 'PAOptionSelected'];
       if (!omitFields.includes(f)) {
         form.change(f, null);
       }
@@ -180,7 +180,7 @@ const ProjectForm = ({
 
     const registeredFields = form.getRegisteredFields();
     registeredFields.forEach((f) => {
-      const omitFields = ['name', 'description'];
+      const omitFields = ['name', 'description', 'PAOptionSelected'];
       if (!omitFields.includes(f)) {
         form.change(f, null);
       }
@@ -339,6 +339,7 @@ const ProjectForm = ({
                                   initialSelected={PAOptionSelected}
                                   options={OPTIONS}
                                   onChange={(value: string) => {
+                                    form.change('PAOptionSelected', value);
                                     setPAOptionSelected(value);
                                     resetPlanningArea(form);
                                     resetPlanningAreaGrid(form);


### PR DESCRIPTION
## Fixes project creation through shapefile with grid

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/e7ac7900-2928-4492-a6c3-064a4b4e9be3)

The issue was the property `PAOptionSelected` (the one that determines which kind of layers the map should render) wasn't being passed correctly after moving the form a long time ago.

### Designs

–

### Testing instructions

- go to `/projects/new`,
- In the form, select the `Yes, I have a planning unit shapefile` option and upload the shapefile attached to the task,
- After uploading and saving, the map should look like the image above.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-407

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file