### PR TITLE
[FE]: adjusts bbox padding for some maps

### DIFF
--- a/app/layout/projects/show/map/index.tsx
+++ b/app/layout/projects/show/map/index.tsx
@@ -195,7 +195,7 @@ export const ProjectMap = (): JSX.Element => {
   useEffect(() => {
     setBounds({
       bbox: BBOX,
-      options: { padding: 50 },
+      options: { padding: { top: 50, right: 50, bottom: 50, left: 575 } },
       viewportOptions: { transitionDuration: 0 },
     });
   }, [BBOX]);

--- a/app/layout/scenarios/new/map/component.tsx
+++ b/app/layout/scenarios/new/map/component.tsx
@@ -63,7 +63,7 @@ export const ScenarioNewMap: React.FC<ScenarioNewMapProps> = () => {
   useEffect(() => {
     setBounds({
       bbox: BBOX,
-      options: { padding: 50 },
+      options: { padding: { top: 50, right: 50, bottom: 50, left: 575 } },
       viewportOptions: { transitionDuration: 0 },
     });
   }, [BBOX]);


### PR DESCRIPTION
## Adjusts BBOX padding of some maps

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/eed35973-c94f-4bc9-99d7-31e02cf22b67)

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/1c075124-dda9-4203-8fb5-2a1e2303c196)



### Designs

–

### Testing instructions

- go to `/projects/{id}` and `/projects/{id}/scenarios/new`,
- The map should be adjusted and centered according to the space available

### Feature relevant tickets

–

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file