### PR TITLE
[FE]: removes job done status as condition to display status progress

### DIFF
--- a/app/hooks/projects/index.ts
+++ b/app/hooks/projects/index.ts
@@ -183,7 +183,7 @@ export function useProject(id: Project['id']) {
   return useQuery({
     queryKey: ['project', id],
     queryFn: async () =>
-      PROJECTS.request<{ data: Partial<Project> }>({
+      PROJECTS.request<{ data: Project }>({
         method: 'GET',
         url: `/${id}`,
         headers: {
@@ -194,7 +194,7 @@ export function useProject(id: Project['id']) {
         },
       }).then((response) => response.data.data),
     enabled: !!id,
-    placeholderData: {},
+    placeholderData: {} as Project,
   });
 }
 

--- a/app/layout/projects/show/map/index.tsx
+++ b/app/layout/projects/show/map/index.tsx
@@ -61,7 +61,7 @@ export const ProjectMap = (): JSX.Element => {
   const { query } = useRouter();
 
   const { pid, tab } = query as { pid: string; tab: string };
-  const { data = {} } = useProject(pid);
+  const { data } = useProject(pid);
 
   const {
     id,

--- a/app/layout/projects/show/status/component.tsx
+++ b/app/layout/projects/show/status/component.tsx
@@ -21,14 +21,11 @@ import {
   useProjectJobFailure,
   useProjectTextFailure,
   useProjectJobDone,
-  useProjectTextDone,
   useProjectJobRunning,
   useProjectTextRunning,
 } from './utils';
 
-export interface ProjectStatusProps {}
-
-export const ProjectStatus: React.FC<ProjectStatusProps> = () => {
+export const ProjectStatus = (): JSX.Element => {
   const { query } = useRouter();
   const { pid } = query as { pid: string };
 
@@ -47,7 +44,6 @@ export const ProjectStatus: React.FC<ProjectStatusProps> = () => {
   // Done
   const JOB_DONE_REF = useRef<Job>(null);
   const JOB_DONE = useProjectJobDone(JOBS, new Date(projectData?.lastModifiedAt).getTime());
-  const TEXT_DONE = useProjectTextDone(JOB_DONE, JOB_DONE_REF);
 
   // Running
   const JOB_RUNNING = useProjectJobRunning(JOBS, JOB_FAILURE);
@@ -84,7 +80,7 @@ export const ProjectStatus: React.FC<ProjectStatusProps> = () => {
 
   return (
     <div className="pointer-events-none absolute left-0 top-0 z-50 flex h-full w-full flex-col justify-end">
-      {(JOB_RUNNING || JOB_FAILURE || JOB_DONE) && (
+      {(JOB_RUNNING || JOB_FAILURE) && (
         <motion.div
           className="pointer-events-auto absolute left-0 top-0 z-10 h-full w-full bg-black bg-opacity-75"
           key="status-overlay"
@@ -93,7 +89,7 @@ export const ProjectStatus: React.FC<ProjectStatusProps> = () => {
         />
       )}
 
-      {(JOB_RUNNING || JOB_DONE) && !JOB_FAILURE && (
+      {JOB_RUNNING && !JOB_FAILURE && (
         <motion.div
           className="pointer-events-auto absolute left-1/2 top-1/2 z-10"
           key="status-text"
@@ -101,9 +97,7 @@ export const ProjectStatus: React.FC<ProjectStatusProps> = () => {
           animate={{ opacity: 1, y: '-50%', x: '-50%' }}
         >
           <div className="w-full max-w-md space-y-5 p-10 text-center">
-            <h3 className="font-heading text-xs uppercase tracking-wide">
-              {TEXT_RUNNING || TEXT_DONE}
-            </h3>
+            <h3 className="font-heading text-xs uppercase tracking-wide">{TEXT_RUNNING}</h3>
 
             <Icon icon={PROCESSING_SVG} className="m-auto" style={{ width: 40, height: 10 }} />
 

--- a/app/layout/projects/show/status/utils.tsx
+++ b/app/layout/projects/show/status/utils.tsx
@@ -75,20 +75,6 @@ export const useProjectJobDone = (jobs, lastJobCheck) => {
   }, [jobs, lastJobCheck]);
 };
 
-export const useProjectTextDone = (JOB_DONE, JOB_DONE_REF) => {
-  return useMemo(() => {
-    if (JOB_DONE && TEXTS_RUNNING[JOB_DONE.kind]) {
-      return TEXTS_RUNNING[JOB_DONE.kind || JOB_DONE_REF?.current?.kind]();
-    }
-
-    if (JOB_DONE && !TEXTS_RUNNING[JOB_DONE.kind]) {
-      console.warn(`${JOB_DONE.kind} does not have a proper TEXT`);
-    }
-
-    return null;
-  }, [JOB_DONE, JOB_DONE_REF]);
-};
-
 export const useProjectJobRunning = (jobs, JOB_FAILURE) => {
   return useMemo(() => {
     return !JOB_FAILURE && jobs.find((j) => j.status === 'running');

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -98,7 +98,7 @@ export const ScenariosEditMap = (): JSX.Element => {
     layerSettings,
   } = useAppSelector((state) => state[`/scenarios/${sid}/edit`]);
 
-  const { data = {} } = useProject(pid);
+  const { data } = useProject(pid);
   const { bbox } = data;
 
   const BBOX = useBBOX({

--- a/app/layout/scenarios/reports/blm/map/component.tsx
+++ b/app/layout/scenarios/reports/blm/map/component.tsx
@@ -33,7 +33,7 @@ export const ScreenshotBLMMap: React.FC<ScreenshotBLMMapProps> = ({
 
   const dispatch = useDispatch();
 
-  const { data = {} } = useProject(pid);
+  const { data } = useProject(pid);
   const { bbox } = data;
 
   const BBOX = useBBOX({

--- a/app/layout/scenarios/reports/frequency/map/component.tsx
+++ b/app/layout/scenarios/reports/frequency/map/component.tsx
@@ -33,7 +33,7 @@ export const ScreenshotBLMMap: React.FC<ScreenshotBLMMapProps> = ({
 
   const dispatch = useDispatch();
 
-  const { data = {} } = useProject(pid);
+  const { data } = useProject(pid);
   const { bbox } = data;
   const BBOX = useBBOX({
     bbox,

--- a/app/layout/scenarios/reports/solutions/selected-solution-page/map/component.tsx
+++ b/app/layout/scenarios/reports/solutions/selected-solution-page/map/component.tsx
@@ -34,7 +34,7 @@ export const ScenariosReportMap: React.FC<ScenariosReportMapProps> = ({
 
   const dispatch = useDispatch();
 
-  const { data = {} } = useProject(pid);
+  const { data } = useProject(pid);
   const { bbox } = data;
   const BBOX = useBBOX({
     bbox,

--- a/app/layout/scenarios/reports/solutions/selection-frequency-page/map/component.tsx
+++ b/app/layout/scenarios/reports/solutions/selection-frequency-page/map/component.tsx
@@ -34,7 +34,7 @@ export const ScenariosReportMap: React.FC<ScenariosReportMapProps> = ({
 
   const dispatch = useDispatch();
 
-  const { data = {} } = useProject(pid);
+  const { data } = useProject(pid);
   const { bbox } = data;
   const BBOX = useBBOX({
     bbox,


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/0c38d610-61c4-4b99-83c0-b88042e809b5)


This PR aims to hide the status screen when a job is done. Keeping the condition came out in a visual bug when sometimes a process was done (and the API informed about it) but we kept the status screen visible while nothing was running in the background.

An example is when a user tries to download a project, after clicking to generate the report, once done, the status screen is still visible despite not running anything in the API.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

- Go to the project `/projects/{id}` page and click on `Downlaod` button,
- generate a new export. You will notice the background darken as the status screen is visible. This is fine.
- after finishing generating the report, the status screen should be gone.

### Feature relevant tickets

–

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file