### PR TITLE
[MRXN23-402]: adds query invalidation for target-spf data

### DIFF
--- a/app/hooks/features/index.ts
+++ b/app/hooks/features/index.ts
@@ -219,9 +219,6 @@ export function useSelectedFeatures(
       headers: {
         Authorization: `Bearer ${session.accessToken}`,
       },
-      params: {
-        omitFields: 'properties',
-      },
     }).then(({ data }) => data);
 
   return useQuery(['selected-features', sid], fetchFeatures, {
@@ -537,13 +534,13 @@ export function useSaveSelectedFeatures({
         Authorization: `Bearer ${session.accessToken}`,
       },
       ...requestConfig,
-    });
+    }).then(({ data }) => data);
   };
 
   return useMutation(saveFeature, {
     onSuccess: (data, variables, context) => {
       const { id } = variables;
-      queryClient.setQueryData(['selected-features', id], data);
+      queryClient.setQueryData(['selected-features', id], { data: data?.data });
 
       console.info('Succces', data, variables, context);
     },

--- a/app/layout/project/sidebar/scenario/grid-setup/features/targets/list/component.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/targets/list/component.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Form as FormRFF, Field as FieldRFF } from 'react-final-form';
+import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useRouter } from 'next/router';
@@ -24,7 +25,8 @@ export const ScenariosFeaturesTargets = ({ onGoBack }: { onGoBack: () => void })
   const [confirmationTarget, setConfirmationTarget] = useState(null);
   const [confirmationFPF, setConfirmationFPF] = useState(null);
 
-  const { push, query } = useRouter();
+  const queryClient = useQueryClient();
+  const { query } = useRouter();
   const { pid, sid } = query as { pid: string; sid: string };
 
   const dispatch = useDispatch();
@@ -188,20 +190,22 @@ export const ScenariosFeaturesTargets = ({ onGoBack }: { onGoBack: () => void })
         }),
       };
 
-      // // Save current features
       selectedFeaturesMutation.mutate(
         {
           id: `${sid}`,
           data,
         },
         {
+          onSuccess: async () => {
+            await queryClient.invalidateQueries(['selected-features', sid]);
+          },
           onSettled: () => {
             setSubmitting(false);
           },
         }
       );
     },
-    [sid, selectedFeaturesData, selectedFeaturesMutation]
+    [sid, queryClient, selectedFeaturesData, selectedFeaturesMutation]
   );
 
   const toggleSeeOnMap = useCallback(


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Fixes issues retaining old data for targets and SPF invalidating the query cache.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-402?focusedCommentId=25688

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file