### PR TITLE
[MRXN23-419]: PA selector: fixes setting default values after uploading shapefile

### DIFF
--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -608,14 +608,7 @@ export function useUploadPA({
     });
   };
 
-  return useMutation(uploadPAShapefile, {
-    onSuccess: (data: any, variables, context) => {
-      console.info('Success', data, variables, context);
-    },
-    onError: (error, variables, context) => {
-      console.info('Error', error, variables, context);
-    },
-  });
+  return useMutation(uploadPAShapefile);
 }
 
 export function useCostSurfaceRange(id) {

--- a/app/layout/project/sidebar/scenario/grid-setup/protected-areas/categories/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/protected-areas/categories/index.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Form as FormRFF, Field as FieldRFF } from 'react-final-form';
-import { useDispatch } from 'react-redux';
 
 import { useRouter } from 'next/router';
 
+import { useAppDispatch } from 'store/hooks';
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import intersection from 'lodash/intersection';
@@ -31,14 +31,13 @@ import ProtectedAreaUploader from './pa-uploader';
 export const WDPACategories = ({ onContinue }): JSX.Element => {
   const [submitting, setSubmitting] = useState(false);
   const { addToast } = useToasts();
-  const formRef = useRef(null);
 
-  const { push, query } = useRouter();
+  const { query } = useRouter();
   const { pid, sid } = query as { pid: string; sid: string };
 
   const scenarioSlice = getScenarioEditSlice(sid);
   const { setWDPACategories, setWDPAThreshold } = scenarioSlice.actions;
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const editable = useCanEditScenario(pid, sid);
   const { data: projectData } = useProject(pid);
@@ -178,13 +177,8 @@ export const WDPACategories = ({ onContinue }): JSX.Element => {
 
   useEffect(() => {
     dispatch(setWDPACategories(INITIAL_VALUES));
-    // We need to setWDPACategories' initial values on first render only.
-    // The way to pull this off is to add no dependencies to useEffect, but
-    // eslint will complain about it. So we disable this check.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [dispatch, setWDPACategories, INITIAL_VALUES]);
 
-  // Loading
   if ((scenarioIsFetching && !scenarioIsFetched) || (wdpaIsFetching && !wdpaIsFetched)) {
     return (
       <Loading
@@ -205,7 +199,6 @@ export const WDPACategories = ({ onContinue }): JSX.Element => {
       </div>
       <FormRFF
         onSubmit={onSubmit}
-        key="protected-areas-categories"
         mutators={{
           removeWDPAFilter: (args, state, utils) => {
             const [id, arr] = args;
@@ -215,17 +208,15 @@ export const WDPACategories = ({ onContinue }): JSX.Element => {
             if (i > -1) {
               newArr.splice(i, 1);
             }
+
             utils.changeValue(state, 'wdpaIucnCategories', () => newArr);
           },
         }}
+        initialValuesEqual={() => true}
         initialValues={INITIAL_VALUES}
       >
         {({ form, values, handleSubmit }) => {
-          formRef.current = form;
-
-          const { values: stateValues } = formRef?.current?.getState();
-
-          dispatch(setWDPACategories(stateValues));
+          dispatch(setWDPACategories(values));
 
           const plainWDPAOptions = WDPA_OPTIONS.map((o) => o.value);
           const plainProjectPAOptions = PROJECT_PA_OPTIONS.map((o) => o.value);


### PR DESCRIPTION
## PA selector: fixes setting default values after uploading shapefile

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/f5f6a7bb-3ee7-4a87-9125-100c0da20655)

Fixes an issue where the form would reset the default values of the selector after uploading a shapefile.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

- Go to `/projects/{pid}/scenarios/{sid}/edit?tab=protected-areas`,
- Click on the selector and add/remove an option,
- Upload a shapefile and check the number of options selected in the selector.
- It should be up to date with your most recent selection (previously it would go back to the default value coming from API)

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-419

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file