### PR TITLE
[MRXN23-423]: adds feature flag for CSV feature upload

### DIFF
--- a/app/components/upload-tabs/index.tsx
+++ b/app/components/upload-tabs/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useFeatureFlags } from 'hooks/feature-flags';
+
 import { cn } from 'utils/cn';
 
 const BUTTON_COMMON_CLASSES =
@@ -16,6 +18,8 @@ export const UploadFeatureTabs = ({
   mode: UploadFeatureMode;
   onChange: (mode: UploadFeatureMode) => void;
 }): JSX.Element => {
+  const { CSVUpload } = useFeatureFlags();
+
   return (
     <div className="flex w-full space-x-4 border-b border-gray-300 text-xs font-medium text-black">
       <button
@@ -30,17 +34,19 @@ export const UploadFeatureTabs = ({
         Shapefile
       </button>
 
-      <button
-        type="button"
-        className={cn({
-          [BUTTON_COMMON_CLASSES]: true,
-          [BUTTON_ACTIVE_CLASSES]: mode === 'csv',
-          [BUTTON_INACTIVE_CLASSES]: mode !== 'csv',
-        })}
-        onClick={() => onChange('csv')}
-      >
-        CSV
-      </button>
+      {CSVUpload && (
+        <button
+          type="button"
+          className={cn({
+            [BUTTON_COMMON_CLASSES]: true,
+            [BUTTON_ACTIVE_CLASSES]: mode === 'csv',
+            [BUTTON_INACTIVE_CLASSES]: mode !== 'csv',
+          })}
+          onClick={() => onChange('csv')}
+        >
+          CSV
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Adds feature flag for CSV feature upload

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/e52c8502-19a2-498c-a826-6dd953d03065)

Hides CSV tab behind a feature flag until approved.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

- To enable the tab, add `CSVUpload` to your `NEXT_PUBLIC_FEATURE_FLAGS` variable.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-423

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file