### PR TITLE
[MRXN23-427]: moves PU section right after PA

### DIFF
--- a/app/layout/project/navigation/hooks.tsx
+++ b/app/layout/project/navigation/hooks.tsx
@@ -66,16 +66,16 @@ export const useGridSetupItems = (): SubMenuItem[] => {
       selected: isScenarioRoute && tab === TABS['scenario-protected-areas'],
     },
     {
-      name: 'Cost Surface',
-      route: `/projects/${pid}/scenarios/${sid}/edit?tab=${TABS['scenario-cost-surface']}`,
-      icon: COST_SURFACE_SVG,
-      selected: isScenarioRoute && tab === TABS['scenario-cost-surface'],
-    },
-    {
       name: 'Planning Unit Status',
       route: `/projects/${pid}/scenarios/${sid}/edit?tab=${TABS['scenario-planning-unit-status']}`,
       icon: PLANNING_UNITS_SVG,
       selected: isScenarioRoute && tab === TABS['scenario-planning-unit-status'],
+    },
+    {
+      name: 'Cost Surface',
+      route: `/projects/${pid}/scenarios/${sid}/edit?tab=${TABS['scenario-cost-surface']}`,
+      icon: COST_SURFACE_SVG,
+      selected: isScenarioRoute && tab === TABS['scenario-cost-surface'],
     },
     {
       name: 'Features',

--- a/app/layout/project/navigation/index.tsx
+++ b/app/layout/project/navigation/index.tsx
@@ -250,7 +250,7 @@ export const Navigation = (): JSX.Element => {
                 <Tooltip
                   placement="right"
                   offset={TOOLTIP_OFFSET}
-                  content={<MenuTooltip>Scenario</MenuTooltip>}
+                  content={<MenuTooltip>Scenarios</MenuTooltip>}
                 >
                   <Link href={`/projects/${pid}`} className={MENU_ITEM_BUTTON_COMMON_CLASSES}>
                     <Icon className={ICON_COMMON_CLASSES} icon={SCENARIO_LIST_SVG} />


### PR DESCRIPTION
## Moves Planning Units section right after Protected Areas

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/e3ef81a8-0cee-4fc8-9edf-a5200492e699)

Moves Planning Units section right after Protected Areas.

### Designs

–

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-427

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file