### PR TITLE
[MRXN23-431]: renames advanced settings section

### DIFF
--- a/app/layout/project/navigation/constants.ts
+++ b/app/layout/project/navigation/constants.ts
@@ -31,7 +31,7 @@ export const NAVIGATION_TREE = {
     TABS['scenario-features-targets-spf'],
     TABS['scenario-gap-analysis'],
   ],
-  advancedSettings: [TABS['scenario-advanced-settings'], TABS['scenario-blm-calibration']],
+  marxanSettings: [TABS['scenario-advanced-settings'], TABS['scenario-blm-calibration']],
   solutions: [TABS['scenario-solutions'], TABS['scenario-target-achievement']],
 } satisfies { [key in NavigationTreeCategories]: string[] };
 

--- a/app/layout/project/navigation/hooks.tsx
+++ b/app/layout/project/navigation/hooks.tsx
@@ -17,11 +17,10 @@ import type { SubMenuItem } from './submenu';
 const SCENARIO_ROUTE = '/projects/[pid]/scenarios/';
 
 export const useInventoryItems = (): SubMenuItem[] => {
+  const { showPA, showCS } = useFeatureFlags();
   const { query, route } = useRouter();
   const { pid, tab } = query as { pid: string; tab: string };
   const isProjectRoute = route.startsWith('/projects/[pid]');
-
-  const { showPA, showCS } = useFeatureFlags();
 
   return [
     ...(showPA
@@ -122,7 +121,7 @@ export const useAdvancedSettingsItems = (): SubMenuItem[] => {
 
   return [
     {
-      name: 'Overview',
+      name: 'Advanced Settings',
       route: `/projects/${pid}/scenarios/${sid}/edit?tab=${TABS['scenario-advanced-settings']}`,
       icon: OVERVIEW_SVG,
       selected: isScenarioRoute && tab === TABS['scenario-advanced-settings'],

--- a/app/layout/project/navigation/index.tsx
+++ b/app/layout/project/navigation/index.tsx
@@ -70,7 +70,7 @@ export const Navigation = (): JSX.Element => {
     inventory: NAVIGATION_TREE.inventory.includes(tab),
     gridSetup: isScenarioRoute && NAVIGATION_TREE.gridSetup.includes(tab),
     solutions: isScenarioRoute && NAVIGATION_TREE.solutions.includes(tab),
-    advancedSettings: isScenarioRoute && NAVIGATION_TREE.advancedSettings.includes(tab),
+    marxanSettings: isScenarioRoute && NAVIGATION_TREE.marxanSettings.includes(tab),
   });
 
   const inventoryItems = useInventoryItems();
@@ -145,8 +145,8 @@ export const Navigation = (): JSX.Element => {
     if (isProjectRoute && NAVIGATION_TREE.inventory.includes(tab)) toggleSubmenu('inventory');
     if (isScenarioRoute && NAVIGATION_TREE.gridSetup.includes(tab)) toggleSubmenu('gridSetup');
     if (isScenarioRoute && NAVIGATION_TREE.solutions.includes(tab)) toggleSubmenu('solutions');
-    if (isScenarioRoute && NAVIGATION_TREE.advancedSettings.includes(tab))
-      toggleSubmenu('advancedSettings');
+    if (isScenarioRoute && NAVIGATION_TREE.marxanSettings.includes(tab))
+      toggleSubmenu('marxanSettings');
   }, [tab, isProjectRoute, isScenarioRoute, toggleSubmenu]);
 
   const runJob = JOBS.find(({ kind }) => kind === 'run');
@@ -292,24 +292,24 @@ export const Navigation = (): JSX.Element => {
                 className={cn({
                   [MENU_ITEM_COMMON_CLASSES]: true,
                   [MENU_ITEM_ACTIVE_CLASSES]:
-                    isScenarioRoute && NAVIGATION_TREE.advancedSettings.includes(tab),
+                    isScenarioRoute && NAVIGATION_TREE.marxanSettings.includes(tab),
                 })}
               >
                 <Tooltip
                   placement="right"
                   offset={TOOLTIP_OFFSET}
-                  content={<MenuTooltip>Advanced settings</MenuTooltip>}
+                  content={<MenuTooltip>Marxan Settings</MenuTooltip>}
                 >
                   <button
                     type="button"
                     className={MENU_ITEM_BUTTON_COMMON_CLASSES}
-                    onClick={() => toggleSubmenu('advancedSettings')}
+                    onClick={() => toggleSubmenu('marxanSettings')}
                   >
                     <Icon className={ICON_COMMON_CLASSES} icon={ADVANCED_SETTINGS_SVG} />
                   </button>
                 </Tooltip>
               </li>
-              {submenuState.advancedSettings && (
+              {submenuState.marxanSettings && (
                 <li>
                   <SubMenu items={advancedSettingsItems} />
                 </li>

--- a/app/layout/project/navigation/types.ts
+++ b/app/layout/project/navigation/types.ts
@@ -3,6 +3,6 @@ export type NavigationTreeCategories =
   | 'inventory'
   | 'gridSetup'
   | 'solutions'
-  | 'advancedSettings';
+  | 'marxanSettings';
 
 export type NavigationInventoryTabs = 'protected-areas' | 'cost-surface' | 'features';


### PR DESCRIPTION
## Renames advanced settings section

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/01accc7f-8cb9-4b80-94c9-f54b7a633bcb)
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/097f1f26-4dcb-4843-866c-4893caf18b67)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-431

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file