### PR TITLE
add canary migration for spike [MRXN23-453]

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1692255000000-CrossDbMigration.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1692255000000-CrossDbMigration.ts
@@ -1,0 +1,31 @@
+import { DataSource, MigrationInterface, QueryRunner } from 'typeorm';
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { Logger } from '@nestjs/common';
+
+export class CrossDbMigration1692255000000
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    
+    const apiMigrationDataSource: DataSource = await(new DataSource({
+      ...geoprocessingConnections.apiDB,
+      name: 'apiMigration',
+    })).initialize();
+
+    const apiQueryRunner = apiMigrationDataSource.createQueryRunner();
+    const apidbCanary = await apiQueryRunner.query(`
+      select name from migrations order by timestamp;
+    `);
+
+    const geodbCanary = await queryRunner.query(`
+      select name from migrations order by timestamp;
+    `);
+
+    Logger.debug('canary: apidb migrations');
+    Logger.debug(JSON.stringify(apidbCanary));
+    Logger.debug('canary: geodb migrations');
+    Logger.debug(JSON.stringify(geodbCanary));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+  }
+}


### PR DESCRIPTION
not to be merged - this is only a spike to validate the use of an ad-hoc `DataSource` to be able to drive `apidb` alongside `geodb` from within a TypeORM migration for the geoprocessing service, since we haven't used this setup ever so far.

This will be needed if porting the proposed Python data migration script for existing projects and scenario-specific cost surfaces (#1501).

What this spike wants to achieve is:

- validate that the use of an ad-hoc `DataSource` for `apidb` works as expected at runtime (this was validated in our Compose-based development setup)
- validate that the use of this ad-hoc `DataSource` works correctly in CI too (because I got lost in the multitude of ways we may run migrations, as part of standing up services, as steps of a script, etc. as well as the multiple ormconfig instances and flavours)
