### PR TITLE
added coalesce to avoid issue when property does not exist

### DIFF
--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -74,7 +74,7 @@ export class FeatureService {
     const { z, x, y, id } = tileSpecification;
     const simplificationLevel = 360/(Math.pow(2, z+1)*100);
     const attributes = 'feature_id, properties';
-    const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, ${simplificationLevel}) as the_geom, (properties || jsonb_build_object('amount', amount)) as properties, feature_id from "${this.featuresRepository.metadata.tableName}")`;
+    const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, ${simplificationLevel}) as the_geom, (coalesce(properties,'{}'::jsonb) || jsonb_build_object('amount', amount)) as properties, feature_id from "${this.featuresRepository.metadata.tableName}")`;
     const customQuery = this.buildFeaturesWhereQuery(id, bbox);
     return this.tileService.getTile({
       z,


### PR DESCRIPTION
Hotfix that adds a coalesce to prevent a side effect of concatenating a null value with a json. 