### PR TITLE
FE (fix): protected areas name consistency [MRXN23-461]

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/protected-areas/categories/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/protected-areas/categories/index.tsx
@@ -145,7 +145,7 @@ export const WDPACategories = ({ onContinue }): JSX.Element => {
     if (!wdpaData) return [];
 
     return wdpaData.map((w) => ({
-      label: w.kind === 'global' ? `IUCN ${w.name}` : `${w.name}`,
+      label: w.name,
       value: w.id,
       kind: w.kind,
       selected: w.selected,

--- a/app/layout/project/sidebar/scenario/grid-setup/protected-areas/threshold/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/protected-areas/threshold/index.tsx
@@ -75,7 +75,7 @@ export const WDPAThreshold = ({ onGoBack }): JSX.Element => {
     if (!wdpaData) return [];
 
     return wdpaData.map((w) => ({
-      label: w.kind === 'global' ? `IUCN ${w.name}` : `${w.name}`,
+      label: w.name,
       value: w.id,
       kind: w.kind,
       selected: w.selected,


### PR DESCRIPTION
## Global Protected areas name consistency

### Overview

Now we are reading complete global protected areas name from API both on Inventory Panel and scenarios detail

### Feature relevant tickets

[MRXN23-461](https://vizzuality.atlassian.net/browse/MRXN23-461)


[MRXN23-461]: https://vizzuality.atlassian.net/browse/MRXN23-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ