### PR TITLE
[api] Update endpoint for getting project cost surface min and max values [MRXN23-320]

### DIFF
--- a/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
@@ -4,7 +4,7 @@ import { CostSurface } from '@marxan-api/modules/cost-surface/cost-surface.api.e
 import { Repository } from 'typeorm';
 import { ProjectAclService } from '@marxan-api/modules/access-control/projects-acl/project-acl.service';
 import { Either, left, right } from 'fp-ts/lib/Either';
-import { projectNotEditable } from '@marxan-api/modules/projects/projects.service';
+import { projectNotEditable, projectNotVisible } from "@marxan-api/modules/projects/projects.service";
 import { UploadCostSurfaceShapefileDto } from '@marxan-api/modules/cost-surface/dto/upload-cost-surface-shapefile.dto';
 import { UpdateCostSurfaceDto } from '@marxan-api/modules/cost-surface/dto/update-cost-surface.dto';
 import { CostSurfaceCalculationPort } from '@marxan-api/modules/cost-surface/ports/project/cost-surface-calculation.port';
@@ -145,17 +145,17 @@ export class CostSurfaceService {
     userId: string,
   ): Promise<
     Either<
-      typeof costSurfaceNotFoundForProject | typeof projectNotEditable,
+      typeof costSurfaceNotFoundForProject | typeof projectNotVisible,
       CostRange
     >
   > {
     if (
-      !(await this.projectAclService.canEditCostSurfaceInProject(
+      !(await this.projectAclService.canViewProject(
         userId,
         projectId,
       ))
     ) {
-      return left(projectNotEditable);
+      return left(projectNotVisible);
     }
     const costRange = await this.costSurfaceRepository.findOne({
       select: ['min', 'max'],

--- a/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
@@ -8,8 +8,6 @@ import { projectNotEditable } from '@marxan-api/modules/projects/projects.servic
 import { UploadCostSurfaceShapefileDto } from '@marxan-api/modules/cost-surface/dto/upload-cost-surface-shapefile.dto';
 import { UpdateCostSurfaceDto } from '@marxan-api/modules/cost-surface/dto/update-cost-surface.dto';
 import { CostSurfaceCalculationPort } from '@marxan-api/modules/cost-surface/ports/project/cost-surface-calculation.port';
-import { forbiddenError } from '@marxan-api/modules/access-control';
-
 export const costSurfaceNotEditableWithinProject = Symbol(
   `cost surface not editable within project`,
 );

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  ForbiddenException,
   forwardRef,
   Get,
   Inject,

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   forwardRef,
   Get,
   Inject,
@@ -131,23 +132,35 @@ export class ProjectCostSurfaceController {
 
   @ImplementsAcl()
   @UseGuards(JwtAuthGuard)
+  @ApiParam({
+    name: 'costSurfaceId',
+    description: 'The id of the Cost Surface to be updated',
+  })
+  @ApiParam({
+    name: 'projectId',
+    description: 'The id of the Project that the Cost Surface is associated to',
+  })
   @Get(`:projectId/cost-surface/:costSurfaceId/cost-range`)
   @ApiOkResponse({ type: CostRangeDto })
   async getCostRange(
-    @Param('projectId') scenarioId: string,
+    @Param('projectId') projectId: string,
+    @Param('costSurfaceId') costSurfaceId: string,
     @Req() req: RequestWithAuthenticatedUser,
   ): Promise<CostRangeDto> {
-    const result = await this.scenarioService.getCostRange(
-      scenarioId,
+    const result = await this.costSurfaceService.getCostSurfaceRange(
+      costSurfaceId,
+      projectId,
       req.user.id,
     );
+
     if (isLeft(result)) {
       throw mapAclDomainToHttpError(result.left, {
-        scenarioId,
+        projectId,
+        costSurfaceId,
         userId: req.user.id,
-        resourceType: scenarioResource.name.plural,
       });
     }
+
     return plainToClass<CostRangeDto, CostRangeDto>(CostRangeDto, result.right);
   }
 }

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -133,7 +133,7 @@ export class ProjectCostSurfaceController {
   @UseGuards(JwtAuthGuard)
   @ApiParam({
     name: 'costSurfaceId',
-    description: 'The id of the Cost Surface to be updated',
+    description: 'The id of the Cost Surface for which to retrieve [min,max] cost range',
   })
   @ApiParam({
     name: 'projectId',

--- a/api/apps/api/src/modules/scenarios/protected-area/getter/selection-get.service.ts
+++ b/api/apps/api/src/modules/scenarios/protected-area/getter/selection-get.service.ts
@@ -69,7 +69,7 @@ export class SelectionGetService {
 
     return [
       ...categories.map((category) => ({
-        name: 'IUCN '+ category,
+        name: 'IUCN ' + category,
         id: category,
         isCustom: false,
       })),

--- a/api/apps/api/test/project/project-cost-surface.e2e-spec.ts
+++ b/api/apps/api/test/project/project-cost-surface.e2e-spec.ts
@@ -8,6 +8,11 @@ describe('Cost Surface', () => {
   beforeEach(async () => {
     fixtures = await getProjectCostSurfaceFixtures();
   });
+
+  afterEach(async () => {
+    await fixtures.cleanup();
+  });
+
   describe('Default Cost Surface', () => {
     it(`should create a default Cost Surface`, async () => {
       const { projectId } = await fixtures.WhenCreatingAProject(
@@ -132,6 +137,26 @@ describe('Cost Surface', () => {
         costSurface2.id,
       );
       await fixtures.ThenCostSurfaceAPIEntityWasNotUpdated(costSurface2);
+    });
+  });
+
+  describe('Get Cost Surface Range', () => {
+    it(`should return the range of the cost surface`, async () => {
+      // ARRANGE
+      const projectId = await fixtures.GivenProject('someProject');
+      const costSurface = await fixtures.GivenCostSurfaceMetadataForProject(
+        projectId,
+        'costSurfaceName',
+      );
+
+      // ACT
+      const response = await fixtures.WhenGettingCostSurfaceRange(
+        costSurface.id,
+        projectId,
+      );
+
+      // ASSERT
+      await fixtures.ThenCostSurfaceRangeWasReturned(response);
     });
   });
 });

--- a/api/apps/api/test/project/project-cost-surface.fixtures.ts
+++ b/api/apps/api/test/project/project-cost-surface.fixtures.ts
@@ -151,6 +151,18 @@ export const getProjectCostSurfaceFixtures = async () => {
         .send({ name: costSurfaceName });
     },
 
+    WhenGettingCostSurfaceRange: async (
+      costSurfaceId: string,
+      projectId: string,
+    ) => {
+      return request(app.getHttpServer())
+        .get(
+          `/api/v1/projects/${projectId}/cost-surface/${costSurfaceId}/cost-range`,
+        )
+        .set('Authorization', `Bearer ${token}`)
+        .send();
+    },
+
     ThenCostSurfaceAPIEntityWasProperlySaved: async (name: string) => {
       const savedCostSurface = await costSurfaceRepo.findOne({
         where: { name },
@@ -229,6 +241,11 @@ export const getProjectCostSurfaceFixtures = async () => {
       });
 
       expect(costSurface).toBeDefined();
+    },
+
+    ThenCostSurfaceRangeWasReturned: async (response: any) => {
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body).toEqual({ min: 0, max: 0 });
     },
   };
 };


### PR DESCRIPTION
## Endpoint for getting project cost surface min and max values

### Overview

The endpoint has already been part of ProjectCostSurfaceController and was using ScenariosService  to get min and max values from `cost_surface_pu_data`. This PR implements Cost Surface service to retrieve min and max data from `(api)cost_surfaces table` and adds test.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file