### PR TITLE
[MRXN23-475]: disables scenario export without run scenarios

### DIFF
--- a/app/components/toast/component.tsx
+++ b/app/components/toast/component.tsx
@@ -32,8 +32,8 @@ const THEME: ToastTheme = {
   },
   error: {
     icon: ERROR_SVG,
-    bg: 'from-red-1000 to-red-800',
-    hoverBg: 'from-red-200 to-red-1000',
+    bg: 'from-red-500 to-red-800',
+    hoverBg: 'from-red-200 to-red-900',
   },
 };
 

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -20,7 +20,6 @@ import { useMe } from 'hooks/me';
 import { useProjectUsers } from 'hooks/project-users';
 
 import { ItemProps } from 'components/scenarios/item/component';
-import { CostSurface } from 'types/api/cost-surface';
 import { Job } from 'types/api/job';
 import { Project } from 'types/api/project';
 import { Scenario } from 'types/api/scenario';

--- a/app/layout/help/documentation/component.tsx
+++ b/app/layout/help/documentation/component.tsx
@@ -23,7 +23,7 @@ export const DocumentationLink = () => {
         />
       </div>
       {isHover && (
-        <div className="z-60 absolute right-12 top-2 rounded-xl bg-white px-2 py-px text-black">
+        <div className="absolute right-12 top-2 z-50 rounded-xl bg-white px-2 py-px text-black">
           <p className="whitespace-nowrap font-sans text-sm">Marxan&apos;s documentation</p>
         </div>
       )}

--- a/app/layout/loading/component.tsx
+++ b/app/layout/loading/component.tsx
@@ -22,7 +22,7 @@ export const Loading: React.FC<LoadingProps> = ({ loading }: LoadingProps) => {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className={cn({
-            'z-60 fixed h-full w-full': true,
+            'fixed z-50 h-full w-full': true,
           })}
         >
           <div

--- a/app/layout/project/sidebar/scenario/grid-setup/features/targets/list/component.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/targets/list/component.tsx
@@ -265,9 +265,9 @@ export const ScenariosFeaturesTargets = ({ onGoBack }: { onGoBack: () => void })
             iconClassName="w-10 h-10 text-white"
           />
 
-          {(!targetedFeaturesData || !targetedFeaturesData.length) && <NoResults />}
+          {!targetedFeaturesData?.length && <NoResults />}
 
-          {!!targetedFeaturesData && !!targetedFeaturesData.length && (
+          {!!targetedFeaturesData.length && (
             <div className="relative flex flex-grow flex-col overflow-hidden">
               <div className="pointer-events-none absolute left-0 top-0 z-10 h-6 w-full bg-gradient-to-b from-gray-800 via-gray-800" />
               <div className="relative h-full overflow-y-auto overflow-x-visible px-0.5">
@@ -346,7 +346,7 @@ export const ScenariosFeaturesTargets = ({ onGoBack }: { onGoBack: () => void })
             </div>
           )}
 
-          {!!targetedFeaturesData && !!targetedFeaturesData.length && (
+          {!!targetedFeaturesData?.length && (
             <div className="flex flex-shrink-0 justify-center space-x-3">
               <Button
                 className="w-full"

--- a/app/layout/projects/show/map/index.tsx
+++ b/app/layout/projects/show/map/index.tsx
@@ -417,7 +417,7 @@ export const ProjectMap = (): JSX.Element => {
       {id && (
         <motion.div
           key="project-map"
-          className="relative col-span-5 h-full w-full overflow-hidden"
+          className="relative h-full w-full overflow-hidden"
           initial={{ y: -10, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           exit={{ y: -10, opacity: 0 }}

--- a/app/layout/scenarios/edit/map/component.tsx
+++ b/app/layout/scenarios/edit/map/component.tsx
@@ -259,7 +259,7 @@ export const ScenariosEditMap = (): JSX.Element => {
   const TargetedPreviewLayers = useTargetedPreviewLayers({
     features: targetedFeaturesData,
     cache,
-    active: targetedFeaturesData.length > 0,
+    active: targetedFeaturesData?.length > 0,
     bbox,
     options: {
       featuresRecipe,

--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -130,10 +130,10 @@ export const useFeatureAbundanceLegend = () => {
 
   const { layerSettings } = useAppSelector((state) => state[`/scenarios/${sid}/edit`]);
 
-  const totalItems = features.length || 0;
+  const totalItems = features?.length || 0;
 
   const items =
-    features.map(({ id, name, amountRange = { min: 5000, max: 100000 } }, index) => {
+    features?.map(({ id, name, amountRange = { min: 5000, max: 100000 } }, index) => {
       const color =
         totalItems > COLORS['features-preview'].ramp.length
           ? chroma.scale(COLORS['features-preview'].ramp).colors(totalItems)[index]
@@ -178,10 +178,10 @@ export const useFeaturesLegend = () => {
     (state) => state[`/scenarios/${sid}/edit`]
   );
 
-  const totalItems = features.length || 0;
+  const totalItems = features?.length || 0;
 
   const items =
-    features.map(({ id, name }, index) => {
+    features?.map(({ id, name }, index) => {
       const color =
         totalItems > COLORS['features-preview'].ramp.length
           ? chroma.scale(COLORS['features-preview'].ramp).colors(totalItems)[index]

--- a/app/layout/toast/component.tsx
+++ b/app/layout/toast/component.tsx
@@ -5,7 +5,7 @@ import { ToastContainerProps } from 'hooks/toast/types';
 
 export const ToastContainer = ({ placement, ...props }: ToastContainerProps) => (
   <div
-    className="z-60 pointer-events-none fixed max-h-full w-full max-w-full p-5"
+    className="pointer-events-none fixed z-50 max-h-full w-full max-w-full p-5"
     style={{
       ...PLACEMENTS[placement],
       maxWidth: 400,


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Now it's not possible asking for the scenario summary unless there is, at least, one scenario run previously.

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/c299e567-a9fc-4cdb-8c4a-2d907a7d07a6)
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/460e3d7a-cb98-4f1d-95d0-fdb69a6c8333)
![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/b6832b59-8ad8-4b50-ba51-8ad2de89dbe5)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-475

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file