### PR TITLE
[N/A]: refetches scenarios list on focus

### DIFF
--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -179,7 +179,7 @@ export function useScenariosStatusOnce({
   };
 
   return useMutation(saveScenarioLock, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
@@ -286,7 +286,7 @@ export function useSaveScenarioLock({
   };
 
   return useMutation(saveScenarioLock, {
-    onSuccess: (data: any, variables) => {
+    onSuccess: (data, variables) => {
       const { sid } = variables;
       queryClient.invalidateQueries('project-locks');
       queryClient.invalidateQueries(['scenario-lock', sid]);
@@ -317,7 +317,7 @@ export function useDeleteScenarioLock({
   };
 
   return useMutation(deleteScenarioLock, {
-    onSuccess: (data: any, variables) => {
+    onSuccess: (data, variables) => {
       const { sid } = variables;
       queryClient.invalidateQueries('project-locks');
       queryClient.invalidateQueries(['scenario-lock', sid]);
@@ -578,7 +578,7 @@ export function useUploadScenarioPU({
   };
 
   return useMutation(uploadScenarioPUShapefile, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
@@ -669,7 +669,7 @@ export function useUploadCostSurface({
   };
 
   return useMutation(uploadScenarioCostSurface, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
@@ -760,7 +760,7 @@ export function useSaveScenarioPU({
   };
 
   return useMutation(saveScenario, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Success', data, variables, context);
       const { id } = variables;
       queryClient.invalidateQueries(['scenarios-pu', id]);
@@ -791,8 +791,8 @@ export function useDuplicateScenario({
   };
 
   return useMutation(duplicateScenario, {
-    onSuccess: (data: any, variables, context) => {
-      queryClient.invalidateQueries(['scenarios']);
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries(['scenarios']);
       console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
@@ -825,6 +825,7 @@ export function useRunScenario({
   return useMutation(runScenario, {
     onSuccess: async (data, variables) => {
       const { id } = variables;
+      await queryClient.invalidateQueries(['scenarios']);
       await queryClient.invalidateQueries(['scenario', id]);
     },
     onError: (error, variables, context) => {
@@ -852,7 +853,7 @@ export function useCancelRunScenario({
   };
 
   return useMutation(duplicateScenario, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Success', data, variables, context);
     },
     onError: (error, variables, context) => {
@@ -997,7 +998,7 @@ export function useSaveScenarioCalibrationRange({
   };
 
   return useMutation(saveScenarioCalibrationRange, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Succcess', data, variables, context);
       const { sid: scenarioId } = variables;
       queryClient.invalidateQueries(['scenario-calibration', scenarioId]);
@@ -1034,7 +1035,7 @@ export function useDownloadScenarioReport({
   };
 
   return useMutation(downloadScenarioReport, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       const { data: blob } = data;
       const url = window.URL.createObjectURL(new Blob([blob]));
       const link = document.createElement('a');
@@ -1072,7 +1073,7 @@ export function useDeletePUScenaro() {
   };
 
   return useMutation(deletePUScenario, {
-    onSuccess: (data: any, variables, context) => {
+    onSuccess: (data, variables, context) => {
       console.info('Success', data, variables, context);
       // const { id } = variables;
       // queryClient.invalidateQueries(['scenarios-pu', id]);

--- a/app/hooks/scenarios/index.ts
+++ b/app/hooks/scenarios/index.ts
@@ -374,6 +374,7 @@ export function useScenarios(pId, options: UseScenariosOptionsProps = {}) {
   const query = useInfiniteQuery(['scenarios', pId, JSON.stringify(options)], fetchScenarios, {
     retry: false,
     keepPreviousData: true,
+    refetchOnWindowFocus: true,
     getNextPageParam: (lastPage) => {
       const {
         data: { meta },

--- a/app/layout/project/navigation/hooks.tsx
+++ b/app/layout/project/navigation/hooks.tsx
@@ -50,7 +50,7 @@ export const useInventoryItems = (): SubMenuItem[] => {
 export const useGridSetupItems = (): SubMenuItem[] => {
   const { query, route } = useRouter();
   const { pid, sid, tab } = query as { pid: string; sid: string; tab: string };
-  const isScenarioRoute = route.startsWith(SCENARIO_ROUTE);
+  const isScenarioRoute = route.startsWith(SCENARIO_ROUTE) && !route.endsWith('/new');
 
   return [
     {
@@ -91,7 +91,7 @@ export const useGridSetupItems = (): SubMenuItem[] => {
 export const useSolutionItems = (): SubMenuItem[] => {
   const { query, route } = useRouter();
   const { pid, sid, tab } = query as { pid: string; sid: string; tab: string };
-  const isScenarioRoute = route.startsWith(SCENARIO_ROUTE);
+  const isScenarioRoute = route.startsWith(SCENARIO_ROUTE) && !route.endsWith('/new');
 
   return [
     {
@@ -112,7 +112,7 @@ export const useSolutionItems = (): SubMenuItem[] => {
 export const useAdvancedSettingsItems = (): SubMenuItem[] => {
   const { query, route } = useRouter();
   const { pid, sid, tab } = query as { pid: string; sid: string; tab: string };
-  const isScenarioRoute = route.startsWith(SCENARIO_ROUTE);
+  const isScenarioRoute = route.startsWith(SCENARIO_ROUTE) && !route.endsWith('/new');
 
   return [
     {

--- a/app/layout/project/navigation/index.tsx
+++ b/app/layout/project/navigation/index.tsx
@@ -63,8 +63,8 @@ export const Navigation = (): JSX.Element => {
   const { query, route } = useRouter();
   const { pid, sid, tab } = query as { pid: string; sid: string; tab: string };
 
-  const isProjectRoute = route === '/projects/[pid]';
-  const isScenarioRoute = route.startsWith('/projects/[pid]/scenarios/');
+  const isProjectRoute = route.startsWith('/projects/[pid]');
+  const isScenarioRoute = route.startsWith('/projects/[pid]/scenarios/') && !route.endsWith('/new');
 
   const { addToast } = useToasts();
   const plausible = usePlausible();
@@ -149,7 +149,7 @@ export const Navigation = (): JSX.Element => {
         },
       }
     );
-  }, [addToast, runScenarioMutation, sid]);
+  }, [addToast, runScenarioMutation, sid, plausible, user]);
 
   const isSolutionsSectionEnabled = scenarioQuery.data?.ranAtLeastOnce ?? false;
 

--- a/app/layout/project/sidebar/scenario/header/index.tsx
+++ b/app/layout/project/sidebar/scenario/header/index.tsx
@@ -31,7 +31,9 @@ export const ScenarioHeader = (): JSX.Element => {
     [saveScenarioMutation, sid]
   );
 
-  return <Title title={name} description={description} onEditTitle={onEditScenarioName} />;
+  return (
+    <>{sid && <Title title={name} description={description} onEditTitle={onEditScenarioName} />}</>
+  );
 };
 
 export default ScenarioHeader;


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

- The scenario list is now refetched on focus (ie: changing to the tab).
- Minor adjustment to navigation routes to avoid displaying the scenario title in the scenario creation screen.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file