### PR TITLE
feat(CostSurface): Adds CostSurface data to Scenario GET endpoints [MRXN23-110]

### DIFF
--- a/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios-crud.service.ts
@@ -72,6 +72,7 @@ export class ScenariosCrudService extends AppBaseService<
         'ranAtLeastOnce',
         'solutionsAreLocked',
         'projectScenarioId',
+        'costSurface',
       ],
       keyForAttribute: 'camelCase',
       project: {
@@ -87,6 +88,10 @@ export class ScenariosCrudService extends AppBaseService<
           'createdAt',
           'lastModifiedAt',
         ],
+      },
+      costSurface: {
+        ref: 'id',
+        attributes: ['name', 'isDefault'],
       },
       users: {
         ref: 'id',


### PR DESCRIPTION
Modifies the Scenarios serializer config to account the possible inclusion of costSurfaces on the GET responses (by using FetchSpecification's include in the GET request)

## Substitute this line for a meaningful title for your changes

### Overview

_Please write a description. If the PR is hard to understand, provide a quick explanation of the code._

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file