### PR TITLE
[api] Cost surfaces tiles endpoint [MRXN23-118]

### DIFF
--- a/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
@@ -222,6 +222,28 @@ export class CostSurfaceService {
     }
   }
 
+  async checkProjectCostSurfaceVisibility(
+    userId: string,
+    projectId: string,
+    costSurfaceId: string,
+  ): Promise<
+    Either<
+      typeof costSurfaceNotFoundForProject | typeof projectNotVisible,
+      CostSurface
+    >
+  > {
+    const costSurface = await this.costSurfaceRepository.findOne({
+      where: { id: costSurfaceId, projectId },
+    });
+    if (!costSurface) {
+      return left(costSurfaceNotFoundForProject);
+    }
+    if (!(await this.projectAclService.canViewProject(userId, projectId))) {
+      return left(projectNotVisible);
+    }
+
+    return right(costSurface);
+  }
   async getCostSurface(
     userId: string,
     projectId: string,
@@ -294,4 +316,5 @@ export class CostSurfaceService {
   static defaultCostSurfaceName(): string {
     return `Default Cost Surface`;
   }
+
 }

--- a/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/api/src/modules/cost-surface/cost-surface.service.ts
@@ -316,5 +316,4 @@ export class CostSurfaceService {
   static defaultCostSurfaceName(): string {
     return `Default Cost Surface`;
   }
-
 }

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -261,7 +261,6 @@ export class ProjectCostSurfaceController {
 
   @ImplementsAcl()
   @UseGuards(JwtAuthGuard)
-  @TilesOpenApi()
   @ApiOperation({
     description: 'Get cost surface tiles.',
   })

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -293,6 +293,10 @@ export class ProjectCostSurfaceController {
       throw new ForbiddenException();
     }
 
+    req.url = req.url.replace(`projects/${projectId}/cost-surface/`, `cost-surfaces/`)
+
+    console.log(req.url)
+
     return await this.proxyService.proxyTileRequest(req, response);
   }
 }

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -293,9 +293,10 @@ export class ProjectCostSurfaceController {
       throw new ForbiddenException();
     }
 
-    req.url = req.url.replace(`projects/${projectId}/cost-surface/`, `cost-surfaces/`)
-
-    console.log(req.url)
+    req.url = req.url.replace(
+      `projects/${projectId}/cost-surface/`,
+      `cost-surfaces/`,
+    );
 
     return await this.proxyService.proxyTileRequest(req, response);
   }

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -49,7 +49,6 @@ import {
 import { ensureShapefileHasRequiredFiles } from '@marxan-api/utils/file-uploads.utils';
 import { UpdateCostSurfaceDto } from '@marxan-api/modules/cost-surface/dto/update-cost-surface.dto';
 import { CostSurfaceSerializer } from '@marxan-api/modules/cost-surface/dto/cost-surface.serializer';
-import { JSONAPICostSurface } from '@marxan-api/modules/cost-surface/cost-surface.api.entity';
 import { TilesOpenApi } from '@marxan/tiles';
 import { Response } from 'express';
 import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -6,15 +6,16 @@ import {
   forwardRef,
   Get,
   Inject,
-  Param, ParseIntPipe,
+  Param,
+  ParseIntPipe,
   ParseUUIDPipe,
   Patch,
   Post,
   Req,
   Res,
   UploadedFile,
-  UseGuards
-} from "@nestjs/common";
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiForbiddenResponse,
   ApiOkResponse,

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -7,7 +7,6 @@ import {
   Get,
   Inject,
   Param,
-  ParseIntPipe,
   ParseUUIDPipe,
   Patch,
   Post,
@@ -49,7 +48,6 @@ import {
 import { ensureShapefileHasRequiredFiles } from '@marxan-api/utils/file-uploads.utils';
 import { UpdateCostSurfaceDto } from '@marxan-api/modules/cost-surface/dto/update-cost-surface.dto';
 import { CostSurfaceSerializer } from '@marxan-api/modules/cost-surface/dto/cost-surface.serializer';
-import { TilesOpenApi } from '@marxan/tiles';
 import { Response } from 'express';
 import { ProxyService } from '@marxan-api/modules/proxy/proxy.service';
 import {
@@ -273,15 +271,30 @@ export class ProjectCostSurfaceController {
     name: 'projectId',
     description: 'The id of the Project that the Cost Surface is associated to',
   })
-  @Get(':projectId/cost-surface/:costSurfaceId/preview/tiles/:z/:x/:y.mvt')
+  @ApiParam({
+    name: 'z',
+    description: 'The zoom level ranging from 0 - 20',
+    type: Number,
+    required: true,
+  })
+  @ApiParam({
+    name: 'x',
+    description: 'The tile x offset on Mercator Projection',
+    type: Number,
+    required: true,
+  })
+  @ApiParam({
+    name: 'y',
+    description: 'The tile y offset on Mercator Projection',
+    type: Number,
+    required: true,
+  })
+  @Get(':projectId/cost-surfaces/:costSurfaceId/preview/tiles/:z/:x/:y.mvt')
   async proxyCostSurfaceTile(
     @Req() req: RequestWithAuthenticatedUser,
     @Res() response: Response,
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('costSurfaceId', ParseUUIDPipe) costSurfaceId: string,
-    @Param('z', ParseIntPipe) z: number,
-    @Param('x', ParseIntPipe) x: number,
-    @Param('y', ParseIntPipe) y: number,
   ): Promise<void> {
     const checkCostSurfaceForProject = await this.costSurfaceService.checkProjectCostSurfaceVisibility(
       req.user.id,
@@ -293,8 +306,8 @@ export class ProjectCostSurfaceController {
     }
 
     req.url = req.url.replace(
-      `projects/${projectId}/cost-surface/`,
-      `cost-surfaces/`,
+      `projects/${projectId}/`,
+      ``,
     );
 
     return await this.proxyService.proxyTileRequest(req, response);

--- a/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
+++ b/api/apps/api/src/modules/projects/project-cost-surface.controller.ts
@@ -260,6 +260,7 @@ export class ProjectCostSurfaceController {
   }
 
   @ImplementsAcl()
+  @UseGuards(JwtAuthGuard)
   @TilesOpenApi()
   @ApiOperation({
     description: 'Get cost surface tiles.',

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
@@ -18,7 +18,10 @@ import { BBox } from 'geojson';
 
 import { Response } from 'express';
 import { setTileResponseHeadersForSuccessfulRequests } from '@marxan/tiles';
-import { CostSurfaceService, CostSurfaceTileRequest } from "@marxan-geoprocessing/modules/cost-surface/cost-surface.service";
+import {
+  CostSurfaceService,
+  CostSurfaceTileRequest,
+} from '@marxan-geoprocessing/modules/cost-surface/cost-surface.service';
 
 @Controller(`${apiGlobalPrefixes.v1}/cost-surfaces`)
 export class FeaturesController {
@@ -66,9 +69,7 @@ export class FeaturesController {
     @Param() TileSpecification: CostSurfaceTileRequest,
     @Res() response: Response,
   ): Promise<Response> {
-    const tile: Buffer = await this.service.findTile(
-      TileSpecification
-    );
+    const tile: Buffer = await this.service.findTile(TileSpecification);
     setTileResponseHeadersForSuccessfulRequests(response);
     return response.send(tile);
   }

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
@@ -1,20 +1,15 @@
 import {
   Controller,
   Get,
-  Header,
   Logger,
   Param,
-  Query,
   Res,
 } from '@nestjs/common';
 import { apiGlobalPrefixes } from '@marxan-geoprocessing/api.config';
 import {
   ApiBadRequestResponse,
   ApiOperation,
-  ApiParam,
-  ApiQuery,
 } from '@nestjs/swagger';
-import { BBox } from 'geojson';
 
 import { Response } from 'express';
 import { setTileResponseHeadersForSuccessfulRequests } from '@marxan/tiles';
@@ -31,37 +26,6 @@ export class CostSurfaceController {
 
   @ApiOperation({
     description: 'Get tile for a cost surface by id.',
-  })
-  @ApiParam({
-    name: 'z',
-    description: 'The zoom level ranging from 0 - 20',
-    type: Number,
-    required: true,
-  })
-  @ApiParam({
-    name: 'x',
-    description: 'The tile x offset on Mercator Projection',
-    type: Number,
-    required: true,
-  })
-  @ApiParam({
-    name: 'y',
-    description: 'The tile y offset on Mercator Projection',
-    type: Number,
-    required: true,
-  })
-  @ApiParam({
-    name: 'id',
-    description: 'Specific id of the cost surface',
-    type: String,
-    required: true,
-  })
-  @ApiQuery({
-    name: 'bbox',
-    description: 'Bounding box of the project',
-    type: [Number],
-    required: false,
-    example: [-1, 40, 1, 42],
   })
   @Get(':costSurfaceId/preview/tiles/:z/:x/:y.mvt')
   @ApiBadRequestResponse()

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Header,
+  Logger,
+  Param,
+  Query,
+  Res,
+} from '@nestjs/common';
+import { apiGlobalPrefixes } from '@marxan-geoprocessing/api.config';
+import {
+  ApiBadRequestResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { BBox } from 'geojson';
+
+import { Response } from 'express';
+import { setTileResponseHeadersForSuccessfulRequests } from '@marxan/tiles';
+import { CostSurfaceService, CostSurfaceTileRequest } from "@marxan-geoprocessing/modules/cost-surface/cost-surface.service";
+
+@Controller(`${apiGlobalPrefixes.v1}/cost-surfaces`)
+export class FeaturesController {
+  private readonly logger: Logger = new Logger(FeaturesController.name);
+
+  constructor(public service: CostSurfaceService) {}
+
+  @ApiOperation({
+    description: 'Get tile for a cost surface by id.',
+  })
+  @ApiParam({
+    name: 'z',
+    description: 'The zoom level ranging from 0 - 20',
+    type: Number,
+    required: true,
+  })
+  @ApiParam({
+    name: 'x',
+    description: 'The tile x offset on Mercator Projection',
+    type: Number,
+    required: true,
+  })
+  @ApiParam({
+    name: 'y',
+    description: 'The tile y offset on Mercator Projection',
+    type: Number,
+    required: true,
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Specific id of the cost surface',
+    type: String,
+    required: true,
+  })
+  @ApiQuery({
+    name: 'bbox',
+    description: 'Bounding box of the project',
+    type: [Number],
+    required: false,
+    example: [-1, 40, 1, 42],
+  })
+  @Get(':projectId/cost-surface/:costSurfaceId/preview/tiles/:z/:x/:y.mvt')
+  @ApiBadRequestResponse()
+  async getTile(
+    @Param() TileSpecification: CostSurfaceTileRequest,
+    @Res() response: Response,
+  ): Promise<Response> {
+    const tile: Buffer = await this.service.findTile(
+      TileSpecification
+    );
+    setTileResponseHeadersForSuccessfulRequests(response);
+    return response.send(tile);
+  }
+}

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.controller.ts
@@ -24,8 +24,8 @@ import {
 } from '@marxan-geoprocessing/modules/cost-surface/cost-surface.service';
 
 @Controller(`${apiGlobalPrefixes.v1}/cost-surfaces`)
-export class FeaturesController {
-  private readonly logger: Logger = new Logger(FeaturesController.name);
+export class CostSurfaceController {
+  private readonly logger: Logger = new Logger(CostSurfaceController.name);
 
   constructor(public service: CostSurfaceService) {}
 
@@ -63,7 +63,7 @@ export class FeaturesController {
     required: false,
     example: [-1, 40, 1, 42],
   })
-  @Get(':projectId/cost-surface/:costSurfaceId/preview/tiles/:z/:x/:y.mvt')
+  @Get(':costSurfaceId/preview/tiles/:z/:x/:y.mvt')
   @ApiBadRequestResponse()
   async getTile(
     @Param() TileSpecification: CostSurfaceTileRequest,

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.module.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.module.ts
@@ -19,9 +19,9 @@ import { PuCostExtractor } from './adapters/pu-cost-extractor';
 import { AvailablePlanningUnitsRepository } from './adapters/available-planning-units-repository';
 import { ScenariosPuCostDataGeo } from '@marxan/scenarios-planning-unit';
 import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
-import { CostSurfaceService } from "@marxan-geoprocessing/modules/cost-surface/cost-surface.service";
-import { CostSurfaceController } from "@marxan-geoprocessing/modules/cost-surface/cost-surface.controller";
-import { TileService } from "@marxan-geoprocessing/modules/tile/tile.service";
+import { CostSurfaceService } from '@marxan-geoprocessing/modules/cost-surface/cost-surface.service';
+import { CostSurfaceController } from '@marxan-geoprocessing/modules/cost-surface/cost-surface.controller';
+import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
 
 @Module({
   imports: [

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.module.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.module.ts
@@ -19,6 +19,9 @@ import { PuCostExtractor } from './adapters/pu-cost-extractor';
 import { AvailablePlanningUnitsRepository } from './adapters/available-planning-units-repository';
 import { ScenariosPuCostDataGeo } from '@marxan/scenarios-planning-unit';
 import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
+import { CostSurfaceService } from "@marxan-geoprocessing/modules/cost-surface/cost-surface.service";
+import { CostSurfaceController } from "@marxan-geoprocessing/modules/cost-surface/cost-surface.controller";
+import { TileService } from "@marxan-geoprocessing/modules/tile/tile.service";
 
 @Module({
   imports: [
@@ -34,6 +37,8 @@ import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
   providers: [
     CostSurfaceWorker,
     CostSurfaceProcessor,
+    CostSurfaceService,
+    TileService,
     {
       provide: CostSurfacePersistencePort,
       useClass: TypeormCostSurface,
@@ -51,5 +56,6 @@ import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
       useClass: ShapefileConverter,
     },
   ],
+  controllers: [CostSurfaceController],
 })
 export class CostSurfaceModule {}

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Brackets, Repository } from "typeorm";
+import { GeoFeatureGeometry } from '@marxan/geofeatures';
+import { IsArray, IsNumber, IsString, IsOptional, IsDefined } from "class-validator";
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { BBox } from 'geojson';
+import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo';
+
+import { TileRequest } from '@marxan/tiles';
+import { ProtectedAreaTileRequest } from "@marxan-geoprocessing/modules/protected-areas/protected-area-tile-request";
+import { QueryResult } from "pg";
+import { TileSpecification } from "@marxan-geoprocessing/modules/features/features.service";
+import { CostSurfacePuDataEntity } from "@marxan/cost-surfaces";
+export class CostSurfaceTileRequest extends TileRequest {
+  @ApiProperty()
+  @IsString()
+  projectId!: string;
+
+  @ApiProperty()
+  @IsString()
+  costSurfaceId!: string;
+}
+
+export class CostSurfaceFilters {
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @Transform((value: string): BBox => JSON.parse(value))
+  bbox?: BBox;
+}
+
+
+@Injectable()
+export class CostSurfaceService {
+  private readonly logger: Logger = new Logger(CostSurfaceService.name);
+
+  constructor(
+    @InjectRepository(GeoFeatureGeometry)
+    private readonly costSurfaceDataRepository: Repository<CostSurfacePuDataEntity>,
+    private readonly tileService: TileService,
+  ) {}
+
+
+  buildFeaturesWhereQuery(id: string, bbox?: BBox): string {
+    let whereQuery = `cost_surface_id = '${id}'`;
+
+    if (bbox) {
+      const { westBbox, eastBbox } = antimeridianBbox(nominatim2bbox(bbox));
+      whereQuery += `AND
+      (st_intersects(
+        st_intersection(st_makeenvelope(${eastBbox}, 4326),
+        ST_MakeEnvelope(0, -90, 180, 90, 4326)),
+      the_geom
+      ) or st_intersects(
+      st_intersection(st_makeenvelope(${westBbox}, 4326),
+      ST_MakeEnvelope(-180, -90, 0, 90, 4326)),
+      the_geom
+      ))`;
+    }
+    return whereQuery;
+  }
+
+  public findTile(
+    tileSpecification: CostSurfaceTileRequest,
+    bbox?: BBox,
+  ): Promise<Buffer> {
+    const { z, x, y, costSurfaceId } = tileSpecification;
+    const simplificationLevel = 360 / (Math.pow(2, z + 1) * 100);
+    const attributes = 'cost_surface_id, properties';
+    const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, ${simplificationLevel}) as the_geom,
+                          (coalesce(properties,'{}'::jsonb) || jsonb_build_object('cost', cost)) as properties,
+                          cost_surface_id
+                          from "${this.costSurfaceDataRepository.metadata.tableName}")
+                          inner join projects_pu on project_pu.id = cost_surface_pu_dat.projects_pu_id`;
+
+    const customQuery = this.buildFeaturesWhereQuery(costSurfaceId, bbox);
+    return this.tileService.getTile({
+      z,
+      x,
+      y,
+      table,
+      customQuery,
+      attributes,
+    });
+  }
+}

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
@@ -1,13 +1,10 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { IsArray, IsNumber, IsString, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { BBox } from 'geojson';
 import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo';
-
 import { TileRequest } from '@marxan/tiles';
 
 import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
@@ -34,8 +31,6 @@ export class CostSurfaceService {
   private readonly logger: Logger = new Logger(CostSurfaceService.name);
 
   constructor(
-    @InjectRepository(CostSurfacePuDataEntity)
-    private readonly costSurfaceDataRepository: Repository<CostSurfacePuDataEntity>,
     private readonly tileService: TileService,
   ) {}
 

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
@@ -69,12 +69,13 @@ export class CostSurfaceService {
   ): Promise<Buffer> {
     const { z, x, y, costSurfaceId } = tileSpecification;
     const simplificationLevel = 360 / (Math.pow(2, z + 1) * 100);
-    const attributes = 'cost_surface_id, properties';
+    const attributes = 'cost_surface_id, cost';
     const table = `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, ${simplificationLevel}) as the_geom,
-                          (coalesce(properties,'{}'::jsonb) || jsonb_build_object('cost', cost)) as properties,
+                          cost,
                           cost_surface_id
-                          from "${this.costSurfaceDataRepository.metadata.tableName}")
-                          inner join projects_pu on project_pu.id = cost_surface_pu_data.projects_pu_id`;
+                          from cost_surface_pu_data
+                          inner join projects_pu ppu on ppu.id=cost_surface_pu_data.projects_pu_id
+                          inner join planning_units_geom pug on pug.id=ppu.geom_id)`;
 
     const customQuery = this.buildCostSurfacesWhereQuery(costSurfaceId, bbox);
     return this.tileService.getTile({

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
@@ -74,7 +74,7 @@ export class CostSurfaceService {
                           (coalesce(properties,'{}'::jsonb) || jsonb_build_object('cost', cost)) as properties,
                           cost_surface_id
                           from "${this.costSurfaceDataRepository.metadata.tableName}")
-                          inner join projects_pu on project_pu.id = cost_surface_pu_dat.projects_pu_id`;
+                          inner join projects_pu on project_pu.id = cost_surface_pu_data.projects_pu_id`;
 
     const customQuery = this.buildCostSurfacesWhereQuery(costSurfaceId, bbox);
     return this.tileService.getTile({

--- a/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
+++ b/api/apps/geoprocessing/src/modules/cost-surface/cost-surface.service.ts
@@ -1,19 +1,21 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { TileService } from '@marxan-geoprocessing/modules/tile/tile.service';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Brackets, Repository } from "typeorm";
-import { GeoFeatureGeometry } from '@marxan/geofeatures';
-import { IsArray, IsNumber, IsString, IsOptional, IsDefined } from "class-validator";
+import { Repository } from 'typeorm';
+import {
+  IsArray,
+  IsNumber,
+  IsString,
+  IsOptional,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { BBox } from 'geojson';
 import { antimeridianBbox, nominatim2bbox } from '@marxan/utils/geo';
 
 import { TileRequest } from '@marxan/tiles';
-import { ProtectedAreaTileRequest } from "@marxan-geoprocessing/modules/protected-areas/protected-area-tile-request";
-import { QueryResult } from "pg";
-import { TileSpecification } from "@marxan-geoprocessing/modules/features/features.service";
-import { CostSurfacePuDataEntity } from "@marxan/cost-surfaces";
+
+import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
 export class CostSurfaceTileRequest extends TileRequest {
   @ApiProperty()
   @IsString()
@@ -32,19 +34,17 @@ export class CostSurfaceFilters {
   bbox?: BBox;
 }
 
-
 @Injectable()
 export class CostSurfaceService {
   private readonly logger: Logger = new Logger(CostSurfaceService.name);
 
   constructor(
-    @InjectRepository(GeoFeatureGeometry)
+    @InjectRepository(CostSurfacePuDataEntity)
     private readonly costSurfaceDataRepository: Repository<CostSurfacePuDataEntity>,
     private readonly tileService: TileService,
   ) {}
 
-
-  buildFeaturesWhereQuery(id: string, bbox?: BBox): string {
+  buildCostSurfacesWhereQuery(id: string, bbox?: BBox): string {
     let whereQuery = `cost_surface_id = '${id}'`;
 
     if (bbox) {
@@ -76,7 +76,7 @@ export class CostSurfaceService {
                           from "${this.costSurfaceDataRepository.metadata.tableName}")
                           inner join projects_pu on project_pu.id = cost_surface_pu_dat.projects_pu_id`;
 
-    const customQuery = this.buildFeaturesWhereQuery(costSurfaceId, bbox);
+    const customQuery = this.buildCostSurfacesWhereQuery(costSurfaceId, bbox);
     return this.tileService.getTile({
       z,
       x,


### PR DESCRIPTION
##  Add Cost surfaces tiles endpoint 

### Overview

New endpoint in ProjectCostSurfaceController to retrieve Cost Surface tiles.
Implementation is similar to the endpoint for tiles for Geo Features

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file