### PR TITLE
add index to improve performance when updating cost_surface_pu_data [MRXN23-483]

### DIFF
--- a/api/apps/geoprocessing/src/migrations/geoprocessing/1697102188000-AddProjectsPuIdIndexOnCostSurfacePuData.ts
+++ b/api/apps/geoprocessing/src/migrations/geoprocessing/1697102188000-AddProjectsPuIdIndexOnCostSurfacePuData.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectsPuIdIndexOnCostSurfacePuData1697102188000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+create index cost_surface_pu_data_projects_pu_id on cost_surface_pu_data (projects_pu_id);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+drop index cost_surface_pu_data_projects_pu_id;
+        );
+   `);
+  }
+}


### PR DESCRIPTION
This will help with the query that does a `UPDATE "cost_surface_pu_data" SET "cost_surface_id" = $1 WHERE "projects_pu_id" = $2` while linking rows of a project's default cost surface to a newly-created project.

context: https://vizzuality.atlassian.net/browse/MRXN23-483