### PR TITLE
[api] Add Project Feature tiles endpoint [MRXN23-477]

### DIFF
--- a/api/apps/geoprocessing/src/modules/features/features.controller.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.controller.ts
@@ -73,6 +73,23 @@ export class FeaturesController {
   ): Promise<Response> {
     const tile: Buffer = await this.service.findTile(
       TileSpecification,
+      false,
+      query.bbox as BBox,
+    );
+    setTileResponseHeadersForSuccessfulRequests(response);
+    return response.send(tile);
+  }
+
+  @Get('project-feature/:id/preview/tiles/:z/:x/:y.mvt')
+  @ApiBadRequestResponse()
+  async getTileForProjectFeature(
+    @Param() TileSpecification: TileSpecification,
+    @Query() query: FeaturesFilters,
+    @Res() response: Response,
+  ): Promise<Response> {
+    const tile: Buffer = await this.service.findTile(
+      TileSpecification,
+      true,
       query.bbox as BBox,
     );
     setTileResponseHeadersForSuccessfulRequests(response);


### PR DESCRIPTION
## Add endpoint for Project Feature tiles with amounts from puvspr_calculations

### Overview

New endpoint in ProjectFeaturesController:
- checks if feature belongs to projects + acl
- gets tiles for feature with amounts retrieved from (`geoDB).puvspr_calculations `by `featureId` and `project_pu_id`

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file