### PR TITLE
disable autoAttachChildProcesses in the recommended vscode launch.json config

### DIFF
--- a/docs/developers/editors/vscode/configs/launch.json
+++ b/docs/developers/editors/vscode/configs/launch.json
@@ -16,7 +16,9 @@
             "outFiles": [
                 "!**/node_modules/**"
             ],
-            "sourceMaps": true
+            "sourceMaps": true,
+            "autoAttachChildProcesses": false // avoids issues with node child
+              // processes such as those exec'ed by Mapshaper's runCommandsXL()
         },
         {
             "name": "Marxan Geoprocessing service",
@@ -30,7 +32,9 @@
             "outFiles": [
                 "!**/node_modules/**"
             ],
-            "sourceMaps": true
+            "sourceMaps": true,
+            "autoAttachChildProcesses": false // avoids issues with node child
+              // processes such as those exec'ed by Mapshaper's runCommandsXL()
         }
     ]
 }


### PR DESCRIPTION
Auto attach would cause things such as Mapshaper's runCommandsXL() to fail, when running in OCI containers, as VSCode would try to attach to exec'ed child processes.

See: https://github.com/microsoft/vscode-js-debug/issues/374
