### PR TITLE
emit correct api events when dealing with cost surface uploads [MRXN23-472]

### DIFF
--- a/api/apps/api/src/migrations/api/1645026803969-AddTokenIdColumnToLocks.ts
+++ b/api/apps/api/src/migrations/api/1645026803969-AddTokenIdColumnToLocks.ts
@@ -1,4 +1,3 @@
-
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddTokenIdColumnToLocks1645026803969

--- a/api/apps/api/src/migrations/api/1645449750000-SyncPuShapeEnumFromGeoprocessingToApi.ts
+++ b/api/apps/api/src/migrations/api/1645449750000-SyncPuShapeEnumFromGeoprocessingToApi.ts
@@ -1,7 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class SyncPuShapeEnumFromGeoprocessingToApi1645449750000
-  implements MigrationInterface {
+  implements MigrationInterface
+{
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       ALTER TYPE planning_unit_grid_shape ADD VALUE 'irregular';

--- a/api/apps/api/src/migrations/api/1696603545456-AddCostSurfaceLinkingNewEvents.ts
+++ b/api/apps/api/src/migrations/api/1696603545456-AddCostSurfaceLinkingNewEvents.ts
@@ -1,7 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddCostSurfaceLinkingNewEvents1696603545456
-  implements MigrationInterface {
+  implements MigrationInterface
+{
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       INSERT INTO api_event_kinds (id) values

--- a/api/apps/api/src/migrations/api/1697210673344-AddMinMaxAmountColumnsToFeatures.ts
+++ b/api/apps/api/src/migrations/api/1697210673344-AddMinMaxAmountColumnsToFeatures.ts
@@ -1,21 +1,21 @@
-import { MigrationInterface, QueryRunner } from "typeorm"
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddMinMaxAmountColumnsToFeatures1697210673344 implements MigrationInterface {
-
-    public async up(queryRunner: QueryRunner): Promise<void> {
-      await queryRunner.query(`
+export class AddMinMaxAmountColumnsToFeatures1697210673344
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
         ALTER TABLE features
             ADD COLUMN amount_min float8,
             ADD COLUMN amount_max float8;
     `);
-    }
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-      await queryRunner.query(`
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
         ALTER TABLE features
             DROP COLUMN amount_min float8,
             DROP COLUMN amount_max float8;
     `);
-    }
-
+  }
 }

--- a/api/apps/api/src/modules/cost-surface/adapters/scenario/scenario-cost-surface-api-events.ts
+++ b/api/apps/api/src/modules/cost-surface/adapters/scenario/scenario-cost-surface-api-events.ts
@@ -9,7 +9,8 @@ import {
 @Injectable()
 export class ScenarioCostSurfaceApiEvents
   extends ApiEventsService
-  implements ScenarioCostSurfaceEventsPort {
+  implements ScenarioCostSurfaceEventsPort
+{
   private readonly eventsMap: Record<
     ScenarioCostSurfaceState,
     API_EVENT_KINDS

--- a/api/apps/api/src/modules/cost-surface/application/scenario/link-cost-surface-to-scenario.handler.ts
+++ b/api/apps/api/src/modules/cost-surface/application/scenario/link-cost-surface-to-scenario.handler.ts
@@ -19,7 +19,8 @@ import { scenarioCostSurfaceQueueToken } from '@marxan-api/modules/cost-surface/
 
 @CommandHandler(LinkCostSurfaceToScenarioCommand)
 export class LinkCostSurfaceToScenarioHandler
-  implements IInferredCommandHandler<LinkCostSurfaceToScenarioCommand> {
+  implements IInferredCommandHandler<LinkCostSurfaceToScenarioCommand>
+{
   private readonly logger: Logger = new Logger(
     LinkCostSurfaceToScenarioHandler.name,
   );

--- a/api/apps/api/src/modules/cost-surface/infra/project/project-cost-surface-events.handler.ts
+++ b/api/apps/api/src/modules/cost-surface/infra/project/project-cost-surface-events.handler.ts
@@ -26,11 +26,11 @@ export class ProjectCostSurfaceEventsHandler
   // TODO!!! Create proper events
 
   private failEventsMapper: EventKind = {
-    event: API_EVENT_KINDS.scenario__costSurface__costUpdateFailed__v1_alpha1,
+    event: API_EVENT_KINDS.project__costSurface_shapefile_failed__v1alpha1,
   };
 
   private successEventsMapper: EventKind = {
-    event: API_EVENT_KINDS.scenario__costSurface__finished__v1_alpha1,
+    event: API_EVENT_KINDS.project__costSurface_shapefile_finished__v1alpha1,
   };
 
   constructor(

--- a/api/apps/api/src/modules/cost-surface/infra/project/project-cost-surface-events.handler.ts
+++ b/api/apps/api/src/modules/cost-surface/infra/project/project-cost-surface-events.handler.ts
@@ -23,8 +23,6 @@ export class ProjectCostSurfaceEventsHandler
 {
   private queueEvents: QueueEventsAdapter<ProjectCostSurfaceJobInput, true>;
 
-  // TODO!!! Create proper events
-
   private failEventsMapper: EventKind = {
     event: API_EVENT_KINDS.project__costSurface_shapefile_failed__v1alpha1,
   };

--- a/api/apps/api/src/modules/cost-surface/infra/scenario/scenario-cost-surface-events.handler.ts
+++ b/api/apps/api/src/modules/cost-surface/infra/scenario/scenario-cost-surface-events.handler.ts
@@ -19,7 +19,8 @@ type EventKind = { event: API_EVENT_KINDS };
 
 @Injectable()
 export class ScenarioCostSurfaceEventsHandler
-  implements EventFactory<ScenarioCostSurfaceJobInput, true> {
+  implements EventFactory<ScenarioCostSurfaceJobInput, true>
+{
   private queueEvents: QueueEventsAdapter<ScenarioCostSurfaceJobInput, true>;
 
   private failEventsMapper: EventKind = {

--- a/api/apps/api/src/modules/cost-surface/infra/scenario/scenario-cost-surface-queue.provider.ts
+++ b/api/apps/api/src/modules/cost-surface/infra/scenario/scenario-cost-surface-queue.provider.ts
@@ -27,13 +27,14 @@ export const scenarioCostSurfaceQueueProvider: FactoryProvider<
   },
   inject: [QueueBuilder],
 };
-export const scenarioCostSurfaceQueueEventsProvider: FactoryProvider<QueueEvents> = {
-  provide: scenarioCostSurfaceEventsToken,
-  useFactory: (eventsBuilder: QueueEventsBuilder) => {
-    return eventsBuilder.buildQueueEvents(scenarioCostSurfaceQueueName);
-  },
-  inject: [QueueEventsBuilder],
-};
+export const scenarioCostSurfaceQueueEventsProvider: FactoryProvider<QueueEvents> =
+  {
+    provide: scenarioCostSurfaceEventsToken,
+    useFactory: (eventsBuilder: QueueEventsBuilder) => {
+      return eventsBuilder.buildQueueEvents(scenarioCostSurfaceQueueName);
+    },
+    inject: [QueueEventsBuilder],
+  };
 
 export const scenarioCostSurfaceEventsFactoryProvider: FactoryProvider<
   CreateWithEventFactory<ScenarioCostSurfaceJobInput>

--- a/api/apps/api/src/modules/geo-features/geo-features.controller.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.controller.ts
@@ -74,9 +74,8 @@ export class GeoFeaturesController {
   async findAll(
     @ProcessFetchSpecification() fetchSpecification: FetchSpecification,
   ): Promise<GeoFeatureResult> {
-    const results = await this.geoFeatureService.findAllPaginated(
-      fetchSpecification,
-    );
+    const results =
+      await this.geoFeatureService.findAllPaginated(fetchSpecification);
     return this.geoFeatureService.serialize(results.data, results.metadata);
   }
 

--- a/api/apps/api/src/modules/planning-areas/planning-areas.service.ts
+++ b/api/apps/api/src/modules/planning-areas/planning-areas.service.ts
@@ -9,17 +9,18 @@ export class PlanningAreasService {
     private readonly allPlanningAreaService: AllPlanningAreasService,
   ) {}
 
-  savePlanningAreaFromShapefile = this.uploader.savePlanningAreaFromShapefile.bind(
-    this.uploader,
-  );
+  savePlanningAreaFromShapefile =
+    this.uploader.savePlanningAreaFromShapefile.bind(this.uploader);
 
-  locatePlanningAreaEntity = this.allPlanningAreaService.locatePlanningAreaEntity.bind(
-    this.allPlanningAreaService,
-  );
+  locatePlanningAreaEntity =
+    this.allPlanningAreaService.locatePlanningAreaEntity.bind(
+      this.allPlanningAreaService,
+    );
 
-  getPlanningAreaIdAndName = this.allPlanningAreaService.getPlanningAreaIdAndName.bind(
-    this.allPlanningAreaService,
-  );
+  getPlanningAreaIdAndName =
+    this.allPlanningAreaService.getPlanningAreaIdAndName.bind(
+      this.allPlanningAreaService,
+    );
 
   getPlanningAreaBBox = this.allPlanningAreaService.getPlanningAreaBBox.bind(
     this.allPlanningAreaService,

--- a/api/apps/api/src/modules/projects/projects-crud.service.ts
+++ b/api/apps/api/src/modules/projects/projects-crud.service.ts
@@ -41,7 +41,7 @@ const projectFilterKeyNames = [
 ] as const;
 type ProjectFilterKeys = keyof Pick<
   Project,
-  typeof projectFilterKeyNames[number]
+  (typeof projectFilterKeyNames)[number]
 >;
 type ProjectFilters = Record<ProjectFilterKeys, string[]>;
 
@@ -241,9 +241,8 @@ export class ProjectsCrudService extends AppBaseService<
     _info?: ProjectsRequest,
   ): Promise<Project> {
     const ids: MultiplePlanningAreaIds = entity;
-    const idAndName = await this.planningAreasService.getPlanningAreaIdAndName(
-      ids,
-    );
+    const idAndName =
+      await this.planningAreasService.getPlanningAreaIdAndName(ids);
     if (isDefined(idAndName)) {
       entity.planningAreaId = idAndName.planningAreaId;
       entity.planningAreaName = idAndName.planningAreaName;
@@ -361,7 +360,8 @@ export class ProjectsCrudService extends AppBaseService<
     return [await Promise.all(extendedEntities), entitiesAndCount[1]];
   }
 
-  locatePlanningAreaEntity = this.planningAreasService.locatePlanningAreaEntity.bind(
-    this.planningAreasService,
-  );
+  locatePlanningAreaEntity =
+    this.planningAreasService.locatePlanningAreaEntity.bind(
+      this.planningAreasService,
+    );
 }

--- a/api/apps/api/src/modules/projects/projects.project-features.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.project-features.controller.ts
@@ -158,11 +158,12 @@ export class ProjectFeaturesController {
       throw new BadRequestException(`Only FeatureCollection is supported.`);
     }
 
-    const newFeatureOrError = await this.geoFeatureService.createFeaturesForShapefile(
-      projectId,
-      body,
-      data.features,
-    );
+    const newFeatureOrError =
+      await this.geoFeatureService.createFeaturesForShapefile(
+        projectId,
+        body,
+        data.features,
+      );
 
     if (isLeft(newFeatureOrError)) {
       // @debt Use mapDomainToHttpException() instead
@@ -480,11 +481,12 @@ export class ProjectFeaturesController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('featureId', ParseUUIDPipe) featureId: string,
   ): Promise<void> {
-    const checkCostSurfaceForProject = await this.geoFeatureService.checkProjectFeatureVisibility(
-      req.user.id,
-      projectId,
-      featureId,
-    );
+    const checkCostSurfaceForProject =
+      await this.geoFeatureService.checkProjectFeatureVisibility(
+        req.user.id,
+        projectId,
+        featureId,
+      );
     if (isLeft(checkCostSurfaceForProject)) {
       throw mapAclDomainToHttpError(checkCostSurfaceForProject.left);
     }

--- a/api/apps/api/src/modules/scenarios/scenarios.service.ts
+++ b/api/apps/api/src/modules/scenarios/scenarios.service.ts
@@ -89,9 +89,7 @@ import {
 } from '@marxan-api/modules/blm/values/blm-repos';
 
 import { ExportScenario } from '../clone/export/application/export-scenario.command';
-import {
-  SetInitialCostSurfaceError,
-} from '@marxan-api/modules/cost-surface/application/set-initial-cost-surface.command';
+import { SetInitialCostSurfaceError } from '@marxan-api/modules/cost-surface/application/set-initial-cost-surface.command';
 import { UpdateCostSurface } from '@marxan-api/modules/cost-surface/application/update-cost-surface.command';
 import { DeleteScenario } from '@marxan-api/modules/cost-surface/infra/delete-scenario.command';
 import {
@@ -121,9 +119,7 @@ import { lastValueFrom } from 'rxjs';
 import { AdjustPlanningUnitsInput } from '@marxan-api/modules/analysis/entry-points/adjust-planning-units-input';
 import { submissionFailed } from '@marxan-api/modules/projects/protected-area/add-protected-area.service';
 import { CostSurface } from '@marxan-api/modules/cost-surface/cost-surface.api.entity';
-import {
-  costSurfaceNotFound,
-} from '@marxan-api/modules/cost-surface/cost-surface.service';
+import { costSurfaceNotFound } from '@marxan-api/modules/cost-surface/cost-surface.service';
 import {
   LinkCostSurfaceToScenarioCommand,
   linkCostSurfaceToScenarioFailed,

--- a/api/apps/api/test/projects/cost-surfaces/project-cost-surface.controller.acl.e2e-spec.ts
+++ b/api/apps/api/test/projects/cost-surfaces/project-cost-surface.controller.acl.e2e-spec.ts
@@ -46,9 +46,8 @@ describe('Get Project Cost Surface', () => {
     await fixtures.GivenScenario(projectId, costSurface2.id);
     await fixtures.GivenScenario(projectId, costSurface2.id);
     // ACT
-    const response = await fixtures.WhenGettingCostSurfacesForProject(
-      projectId,
-    );
+    const response =
+      await fixtures.WhenGettingCostSurfacesForProject(projectId);
 
     // ASSERT
     await fixtures.ThenProjectNotViewableErrorWasReturned(response);
@@ -89,9 +88,8 @@ describe('Link Cost Surface To Scenario', () => {
   it(`should not update CostSurface API entity if the user doesn't have permissions to edit the project`, async () => {
     // ARRANGE
     const projectId = await fixtures.GivenProject('someProject');
-    const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-      projectId,
-    );
+    const defaultCostSurface =
+      await fixtures.GivenDefaultCostSurfaceForProject(projectId);
     const costSurface = await fixtures.GivenCostSurfaceMetadataForProject(
       projectId,
       'someName',

--- a/api/apps/api/test/projects/cost-surfaces/project-cost-surface.e2e-spec.ts
+++ b/api/apps/api/test/projects/cost-surfaces/project-cost-surface.e2e-spec.ts
@@ -15,9 +15,8 @@ describe('Cost Surface', () => {
 
   describe('Default Cost Surface', () => {
     it(`should create a default Cost Surface`, async () => {
-      const { projectId } = await fixtures.WhenCreatingAProject(
-        'my awesome project',
-      );
+      const { projectId } =
+        await fixtures.WhenCreatingAProject('my awesome project');
       await fixtures.ThenADefaultCostSurfaceWasCreated(projectId);
     });
   });
@@ -73,12 +72,10 @@ describe('Cost Surface', () => {
       // ARRANGE
       const projectId1 = await fixtures.GivenProject('someProject 1');
       const projectId2 = await fixtures.GivenProject('the REAL project');
-      const default1 = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId1,
-      );
-      const default2 = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId2,
-      );
+      const default1 =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId1);
+      const default2 =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId2);
       const costSurface11 = await fixtures.GivenCostSurfaceMetadataForProject(
         projectId1,
         'costSurface 1 1',
@@ -140,12 +137,10 @@ describe('Cost Surface', () => {
       ];
 
       // ACT
-      const response1 = await fixtures.WhenGettingCostSurfacesForProject(
-        projectId1,
-      );
-      const response2 = await fixtures.WhenGettingCostSurfacesForProject(
-        projectId2,
-      );
+      const response1 =
+        await fixtures.WhenGettingCostSurfacesForProject(projectId1);
+      const response2 =
+        await fixtures.WhenGettingCostSurfacesForProject(projectId2);
 
       // ASSERT
       await fixtures.ThenReponseHasCostSurfaceList(
@@ -182,11 +177,12 @@ describe('Cost Surface', () => {
       const shapefilePath = fixtures.GivenMockCostSurfaceShapefile();
 
       // ACT
-      const response = await fixtures.WhenUploadingCostSurfaceShapefileForProject(
-        projectId,
-        '',
-        shapefilePath,
-      );
+      const response =
+        await fixtures.WhenUploadingCostSurfaceShapefileForProject(
+          projectId,
+          '',
+          shapefilePath,
+        );
 
       // ASSERT
       fixtures.ThenEmptyErrorWasReturned(response);
@@ -281,9 +277,8 @@ describe('Cost Surface', () => {
     it(`should link properly`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const scenario = await fixtures.GivenScenario(
         projectId,
         defaultCostSurface.id,
@@ -318,9 +313,8 @@ describe('Cost Surface', () => {
     it(`should link back to the scenario's project default cost surface when unlinkind`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const costSurface = await fixtures.GivenCostSurfaceMetadataForProject(
         projectId,
         'someCostSurface',
@@ -353,9 +347,8 @@ describe('Cost Surface', () => {
     it(`should return error when the Scenario was not found`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const nonExistentScenarioId = v4();
 
       // ACT
@@ -374,9 +367,8 @@ describe('Cost Surface', () => {
     it(`should return error when the Cost Surface was not found`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const scenario = await fixtures.GivenScenario(
         projectId,
         defaultCostSurface.id,
@@ -400,19 +392,19 @@ describe('Cost Surface', () => {
     it(`should return error when the Cost Surface being linked is from a different Project from the Scenario's`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const scenario = await fixtures.GivenScenario(
         projectId,
         defaultCostSurface.id,
         'someName',
       );
       const projectId2 = await fixtures.GivenProject('someProject2');
-      const otherProjectCostSurface = await fixtures.GivenCostSurfaceMetadataForProject(
-        projectId2,
-        'someCostSurface',
-      );
+      const otherProjectCostSurface =
+        await fixtures.GivenCostSurfaceMetadataForProject(
+          projectId2,
+          'someCostSurface',
+        );
 
       // ACT
       const response = await fixtures.WhenLinkingCostSurfaceToScenario(
@@ -430,9 +422,8 @@ describe('Cost Surface', () => {
     it(`should return true and do nothing when the Cost Surface is already linked to the Scenario`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const scenario = await fixtures.GivenScenario(
         projectId,
         defaultCostSurface.id,
@@ -460,9 +451,8 @@ describe('Cost Surface', () => {
     it(`should return error when the Cost Surface could not be linked (error at Command handler) `, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const defaultCostSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const defaultCostSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
       const scenario = await fixtures.GivenScenario(
         projectId,
         defaultCostSurface.id,
@@ -552,9 +542,8 @@ describe('Cost Surface', () => {
     it(`should return error if the CostSurface is the Project's default`, async () => {
       // ARRANGE
       const projectId = await fixtures.GivenProject('someProject');
-      const costSurface = await fixtures.GivenDefaultCostSurfaceForProject(
-        projectId,
-      );
+      const costSurface =
+        await fixtures.GivenDefaultCostSurfaceForProject(projectId);
 
       // ACT
       const response = await fixtures.WhenDeletingCostSurface(

--- a/api/apps/api/test/projects/cost-surfaces/project-cost-surface.e2e-spec.ts
+++ b/api/apps/api/test/projects/cost-surfaces/project-cost-surface.e2e-spec.ts
@@ -189,7 +189,7 @@ describe('Cost Surface', () => {
       );
 
       // ASSERT
-      await fixtures.ThenEmptyErrorWasReturned(response);
+      fixtures.ThenEmptyErrorWasReturned(response);
     });
   });
   describe('Update Cost Surface', () => {

--- a/api/apps/api/test/projects/cost-surfaces/project-cost-surface.fixtures.ts
+++ b/api/apps/api/test/projects/cost-surfaces/project-cost-surface.fixtures.ts
@@ -249,19 +249,13 @@ export const getProjectCostSurfaceFixtures = async () => {
       costSurfaceId: string,
     ) => {
       return request(app.getHttpServer())
-        .post(
-          `/api/v1/scenarios/${scenarioId}/cost-surface/${costSurfaceId}`,
-        )
+        .post(`/api/v1/scenarios/${scenarioId}/cost-surface/${costSurfaceId}`)
         .set('Authorization', `Bearer ${token}`)
         .send();
     },
-    WhenUnlinkingCostSurfaceToScenario: async (
-      scenarioId: string,
-    ) => {
+    WhenUnlinkingCostSurfaceToScenario: async (scenarioId: string) => {
       return request(app.getHttpServer())
-        .delete(
-          `/api/v1/scenarios/${scenarioId}/cost-surface/`,
-        )
+        .delete(`/api/v1/scenarios/${scenarioId}/cost-surface/`)
         .set('Authorization', `Bearer ${token}`)
         .send();
     },
@@ -327,8 +321,7 @@ export const getProjectCostSurfaceFixtures = async () => {
         async () =>
           await apiEventService.getLatestEventForTopic({
             topic: scenarioId,
-            kind:
-              API_EVENT_KINDS.scenario__costSurface__link__submitted__v1_alpha1,
+            kind: API_EVENT_KINDS.scenario__costSurface__link__submitted__v1_alpha1,
           }),
       ).rejects.toThrow(NotFoundException);
     },
@@ -446,9 +439,8 @@ export const getProjectCostSurfaceFixtures = async () => {
       expect(costSurface).not.toBeNull();
     },
     ThenCostSurfaceDeletedEventWasEmitted: async (costSurfaceId: string) => {
-      const event = await eventBusTestUtils.waitUntilEventIsPublished(
-        CostSurfaceDeleted,
-      );
+      const event =
+        await eventBusTestUtils.waitUntilEventIsPublished(CostSurfaceDeleted);
 
       expect(event).toMatchObject({ costSurfaceId });
     },

--- a/api/apps/api/test/projects/crud/project-get.e2e-spec.ts
+++ b/api/apps/api/test/projects/crud/project-get.e2e-spec.ts
@@ -27,8 +27,7 @@ test(`getting non-public project as logged-in owner`, async () => {
 
 test(`getting a project where the user is not in project`, async () => {
   const projectId = await fixtures.GivenPrivateProjectWasCreated();
-  const response = await fixtures.WhenGettingProjectAsNotIncludedUser(
-    projectId,
-  );
+  const response =
+    await fixtures.WhenGettingProjectAsNotIncludedUser(projectId);
   fixtures.ThenForbiddenIsReturned(response);
 });

--- a/api/apps/api/test/projects/projects.fixtures.ts
+++ b/api/apps/api/test/projects/projects.fixtures.ts
@@ -195,9 +195,7 @@ export const getFixtures = async () => {
             adminAreaLevel1Id: null,
             adminAreaLevel2Id: null,
             bbox: [
-              25.25670051574707,
-              11.735139846801758,
-              -16.959890365600586,
+              25.25670051574707, 11.735139846801758, -16.959890365600586,
               -28.969440460205078,
             ],
             countryId: 'NAM',

--- a/api/apps/geoprocessing/test/integration/cost-surface/planning-unit-fixtures.ts
+++ b/api/apps/geoprocessing/test/integration/cost-surface/planning-unit-fixtures.ts
@@ -17,9 +17,8 @@ export const getFixtures = async (app: INestApplication) => {
   const projectId = v4();
   const scenarioId = v4();
   const entityManager = app.get(getEntityManagerToken());
-  const projectsPuRepo: Repository<ProjectsPuEntity> = entityManager.getRepository(
-    ProjectsPuEntity,
-  );
+  const projectsPuRepo: Repository<ProjectsPuEntity> =
+    entityManager.getRepository(ProjectsPuEntity);
   const planningUnitsGeomRepo: Repository<PlanningUnitsGeom> = app.get(
     getRepositoryToken(PlanningUnitsGeom),
   );

--- a/api/apps/geoprocessing/test/integration/cost-surface/steps/world.ts
+++ b/api/apps/geoprocessing/test/integration/cost-surface/steps/world.ts
@@ -14,7 +14,8 @@ import { getFixtures } from '../planning-unit-fixtures';
 import { CostSurfaceShapefileRecord } from '@marxan-geoprocessing/modules/cost-surface/ports/cost-surface-shapefile-record';
 import {
   FromProjectShapefileJobInput,
-  LinkCostSurfaceToScenarioJobInput, LinkCostSurfaceToScenarioMode,
+  LinkCostSurfaceToScenarioJobInput,
+  LinkCostSurfaceToScenarioMode,
   ProjectCostSurfaceJobInput,
 } from '@marxan/artifact-cache/surface-cost-job-input';
 import { CostSurfacePuDataEntity } from '@marxan/cost-surfaces';
@@ -42,31 +43,31 @@ export const createWorld = async (app: INestApplication) => {
     GivenScenarioPuDataExists: fixtures.GivenScenarioPuDataExists,
     GivenCostSurfacePuDataExists: fixtures.GivenCostSurfacePuDataExists,
     getShapefileForScenarioWithCost: () =>
-      (({
+      ({
         data: {
           scenarioId: fixtures.scenarioId,
           shapefile,
         },
         id: 'test-job',
-      } as unknown) as Job<FromShapefileJobInput>),
+      }) as unknown as Job<FromShapefileJobInput>,
     getShapefileForProjectWithCost: (
       projectId: string,
       costSurfaceId: string,
     ) =>
-      (({
+      ({
         data: {
           projectId,
           costSurfaceId,
           shapefile,
         },
         id: 'test-job',
-      } as unknown) as Job<FromProjectShapefileJobInput>),
+      }) as unknown as Job<FromProjectShapefileJobInput>,
     getLinkCostSurfaceToScenarioJob: (
       scenarioId: string,
       costSurfaceId: string,
-      mode: LinkCostSurfaceToScenarioMode
+      mode: LinkCostSurfaceToScenarioMode,
     ) =>
-      (({
+      ({
         data: {
           type: 'LinkCostSurfaceToScenarioJobInput',
           projectId: v4(),
@@ -76,7 +77,7 @@ export const createWorld = async (app: INestApplication) => {
           mode: mode,
         },
         id: 'test-job',
-      } as unknown) as Job<LinkCostSurfaceToScenarioJobInput>),
+      }) as unknown as Job<LinkCostSurfaceToScenarioJobInput>,
     ThenCostIsUpdated: async () => {
       const newCost = await fixtures.GetPuCostsData(fixtures.scenarioId);
       expect(newCost).toEqual(

--- a/api/libs/api-events/src/api-event-kinds.enum.ts
+++ b/api/libs/api-events/src/api-event-kinds.enum.ts
@@ -124,4 +124,5 @@ export type ScenarioGeofeatureEvents = Pick<
   typeof API_EVENT_KINDS,
   ScenarioGeoFeatureEventKeys
 >;
-export type ScenarioGeofeatureEventValues = ValuesType<ScenarioGeofeatureEvents>;
+export type ScenarioGeofeatureEventValues =
+  ValuesType<ScenarioGeofeatureEvents>;


### PR DESCRIPTION
when uploading a cost surface to a project, a `project.costSurface.shapefile.finished/v1alpha1` API event should be emitted rather than a `scenario.costSurface.finished/v1alpha1`

https://vizzuality.atlassian.net/browse/MRXN23-472