### PR TITLE
[MRXN23-523]: represents cost surfaces with flat ranges with basic colors

### DIFF
--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -354,28 +354,53 @@ export const LEGEND_LAYERS = {
   }) => {
     const { items, onChangeVisibility } = options;
 
-    return items?.map(({ id, name, min = 1, max = 100 }) => ({
-      id,
-      name,
-      type: 'gradient' as LegendItemType,
-      settingsManager: {
-        opacity: true,
-        visibility: true,
-      },
-      items: [
-        {
-          color: COLORS.cost[0],
-          value: `${min === max ? 0 : min}`,
+    return items?.map(({ id, name, min = 1, max = 100 }) => {
+      // ? if the cost surface has a flat range, a gradient makes no sense
+      if (min === max) {
+        return {
+          id,
+          name,
+          type: 'basic' as LegendItemType,
+          icon: (
+            <FaSquare
+              className="h-3 w-3"
+              style={{ color: COLORS.cost[1], minWidth: 12, minHeight: 12 }}
+            />
+          ),
+          items: [],
+          settingsManager: {
+            opacity: true,
+            visibility: true,
+          },
+          onChangeVisibility: () => {
+            onChangeVisibility?.(id);
+          },
+        };
+      }
+
+      return {
+        id,
+        name,
+        type: 'gradient' as LegendItemType,
+        settingsManager: {
+          opacity: true,
+          visibility: true,
         },
-        {
-          color: COLORS.cost[1],
-          value: `${max}`,
+        items: [
+          {
+            color: COLORS.cost[0],
+            value: min,
+          },
+          {
+            color: COLORS.cost[1],
+            value: `${max}`,
+          },
+        ],
+        onChangeVisibility: () => {
+          onChangeVisibility?.(id);
         },
-      ],
-      onChangeVisibility: () => {
-        onChangeVisibility?.(id);
-      },
-    }));
+      };
+    });
   },
   'lock-available': (options) => {
     const { puAvailableValue, onChangeVisibility } = options;

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -217,7 +217,7 @@ export function useCostSurfaceLayer({
                 layerSettings.max,
                 COLORS.cost[1],
               ],
-              'fill-opacity': 0.75 * (layerSettings.opacity || 1),
+              'fill-opacity': 0.75 * (layerSettings.opacity ?? 1),
             },
           },
         ],


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/32d95c3c-19e3-4d5a-96f7-2796ccda993f)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-523

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file