### PR TITLE
[MRXN23-521]: displays default cost-surface when user clears selection

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -87,6 +87,7 @@
     "react-redux": "8.1.2",
     "react-resize-detector": "^6.7.3",
     "react-table": "^7.7.0",
+    "rooks": "7.14.1",
     "tailwind-merge": "1.13.2",
     "tailwindcss": "3.3.1",
     "use-debounce": "^6.0.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4194,6 +4194,7 @@ __metadata:
     react-redux: 8.1.2
     react-resize-detector: ^6.7.3
     react-table: ^7.7.0
+    rooks: 7.14.1
     svg-sprite-loader: 6.0.11
     svgo: 3.0.2
     svgo-loader: 4.0.0
@@ -9724,6 +9725,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"performance-now@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "performance-now@npm:2.1.0"
+  checksum: 534e641aa8f7cba160f0afec0599b6cecefbb516a2e837b512be0adbe6c1da5550e89c78059c7fabc5c9ffdf6627edabe23eb7c518c4500067a898fa65c2b550
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -10252,6 +10260,15 @@ __metadata:
   version: 2.0.0
   resolution: "quickselect@npm:2.0.0"
   checksum: ed2e78431050d223fb75da20ee98011aef1a03f7cb04e1a32ee893402e640be3cfb76d72e9dbe01edf3bb457ff6a62e5c2d85748424d1aa531f6ba50daef098c
+  languageName: node
+  linkType: hard
+
+"raf@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "raf@npm:3.4.1"
+  dependencies:
+    performance-now: ^2.1.0
+  checksum: 50ba284e481c8185dbcf45fc4618ba3aec580bb50c9121385d5698cb6012fe516d2015b1df6dd407a7b7c58d44be8086108236affbce1861edd6b44637c8cd52
   languageName: node
   linkType: hard
 
@@ -10878,6 +10895,21 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 87f4164e396f0171b0a3386cc1877a817f572148ee13a7e113b238e48e8a9f2f31d009a92ec38a591ff1567d9662c6b67fd8818a2dbbaed74bc26a87a2a4a9a0
+  languageName: node
+  linkType: hard
+
+"rooks@npm:7.14.1":
+  version: 7.14.1
+  resolution: "rooks@npm:7.14.1"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+    lodash.debounce: ^4.0.8
+    raf: ^3.4.1
+    use-sync-external-store: ^1.2.0
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+  checksum: b88dc3d7451b017503b11be995fba2ccc260ac18a386922e490ef3d328a796cfd677c4425454efd2de4e2c936eb879febe2f9f8a939be4f22aa2a66329567895
   languageName: node
   linkType: hard
 
@@ -12083,7 +12115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.0.0":
+"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/5c9c9550-65b5-4f59-a8d7-fd991c860ead)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-521

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file