### PR TITLE
makes default cost surface a regular option instead of a reset

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/cost-surface/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/cost-surface/index.tsx
@@ -8,7 +8,6 @@ import { useAppDispatch } from 'store/hooks';
 import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 
 import { motion } from 'framer-motion';
-import { sortBy } from 'lodash';
 import { HiOutlineArrowUpOnSquareStack } from 'react-icons/hi2';
 import { useEffectOnceWhen } from 'rooks';
 
@@ -58,11 +57,18 @@ export const GridSetupCostSurface = (): JSX.Element => {
     {},
     {
       select: (data) =>
-        sortBy(data, 'name')?.map(({ id, name, isDefault }) => ({
-          value: id,
-          label: name,
-          isDefault,
-        })),
+        data
+          ?.map(({ id, name, isDefault }) => ({
+            value: id,
+            label: isDefault ? 'Default cost surface' : name,
+            isDefault,
+          }))
+          .sort((a, b) => {
+            if (a.isDefault) return -1;
+            if (b.isDefault) return 1;
+
+            return a.label.localeCompare(b.label);
+          }),
     }
   );
   const scenarioQuery = useScenario(sid, {
@@ -287,10 +293,9 @@ export const GridSetupCostSurface = (): JSX.Element => {
                       size="base"
                       theme="dark"
                       selected={fprops.values.costSurfaceId}
-                      options={costSurfaceQuery.data?.filter(({ isDefault }) => !isDefault)}
-                      clearSelectionActive
+                      options={costSurfaceQuery.data}
                       onChange={onChangeCostSurface}
-                      clearSelectionLabel="Default cost surface"
+                      placeholder="Select a cost surface"
                     />
                   )}
                 </Field>


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Converts the default cost option as selectable instead of a reset.

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/1239a73b-9d5a-47dc-bfaa-02169efceac2)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file