### PR TITLE
Increase timeouts for scenario report generation [MRXN23-503]

### DIFF
--- a/app/layout/scenarios/reports/solutions/webshot-status/index.tsx
+++ b/app/layout/scenarios/reports/solutions/webshot-status/index.tsx
@@ -78,7 +78,7 @@ export const WebShotStatus = () => {
           ...globalThis.MARXAN,
           webshot_ready: true,
         };
-      }, 1000);
+      }, 10000);
     }
   }, [reportDataIsFetched]);
 

--- a/webshot/src/domain/solutions-report/solutions-report.ts
+++ b/webshot/src/domain/solutions-report/solutions-report.ts
@@ -75,8 +75,8 @@ export const generateSummaryReportForScenario = async (
 
   console.info(`Rendering ${pageUrl} as PDF`);
   await page.goto(pageUrl);
-  await page.waitForFunction(waitForReportReady, { timeout: 30e3 });
-  const pageAsPdf = await page.pdf({ ...pdfOptions, timeout: 30e3 });
+  await page.waitForFunction(waitForReportReady, { timeout: 60e3 });
+  const pageAsPdf = await page.pdf({ ...pdfOptions, timeout: 60e3 });
 
   await page.close();
   await browser.close();


### PR DESCRIPTION
## Increase timeouts for scenario report generation

### Overview

In some cases when generating pdf report for scenario some solutions maps are left empty.

This PR increases webshot timeout from 30 to 60 seconds and in FE increases timeout for setting MARXAN.webshot_ready to true to 10 seconds

### Designs

### Testing instructions
Manual testing done with Okavango project - before timeouts increase 3 out of 5 maps were empty, after the increase all 5 maps are printed correctly.
[project_okavango-scenario_new_scenario-run_after.pdf](https://github.com/Vizzuality/marxan-cloud/files/13673979/project_okavango-scenario_new_scenario-run_after.pdf)
[project_okavango-scenario_new_scenario-run_before.pdf](https://github.com/Vizzuality/marxan-cloud/files/13673980/project_okavango-scenario_new_scenario-run_before.pdf)

### Feature relevant tickets

[MRXN23-530](https://vizzuality.atlassian.net/browse/MRXN23-530)

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file

[MRXN23-530]: https://vizzuality.atlassian.net/browse/MRXN23-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ