### PR TITLE
[FE](fix): Avoid double click when adding feature to scenario [MRXN23-503]

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/features/add/add-modal/component.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/add/add-modal/component.tsx
@@ -60,7 +60,8 @@ export const ScenariosFeaturesAdd = (): JSX.Element => {
     const { value, onChange } = input;
     const selected = [...value];
 
-    const selectedIndex = selected.findIndex((f) => f === id);
+    const item = selected.find((f) => f === id);
+    const selectedIndex = selected.indexOf(item);
 
     if (selectedIndex !== -1) {
       selected.splice(selectedIndex, 1);


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview
When adding a feature to an scenario several times, we obtain above error, so we just changed the way to obtain the index of the `string[]`

![Screenshot 2023-12-14 at 15 02 42](https://github.com/Vizzuality/marxan-cloud/assets/51995866/f5db0a19-e905-4ca8-97f0-37635ff49a21)

### Testing instructions
To try to test, it is important to repeat the action of adding and removing a feature several times in a row in different scenarios.

### Feature relevant tickets
[MRXN23-503](https://vizzuality.atlassian.net/browse/MRXN23-503)



[MRXN23-503]: https://vizzuality.atlassian.net/browse/MRXN23-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ