### PR TITLE
[FE](fix): recover zero on cost surface map legend [MRXN23-527] 

### DIFF
--- a/app/components/map/legend/types/gradient/index.tsx
+++ b/app/components/map/legend/types/gradient/index.tsx
@@ -41,19 +41,17 @@ export const LegendTypeGradient: React.FC<LegendTypeGradientProps> = ({
       />
 
       <ul className="mt-1 flex w-full justify-between">
-        {items
-          .filter(({ value }) => !!value)
-          .map(({ value }) => (
-            <li
-              key={`${value}`}
-              className={cn({
-                'flex-shrink-0 text-xs': true,
-                [className.labels]: className.labels,
-              })}
-            >
-              {format(+parseInt(value, 10))}
-            </li>
-          ))}
+        {items.map(({ value }) => (
+          <li
+            key={`${value}`}
+            className={cn({
+              'flex-shrink-0 text-xs': true,
+              [className.labels]: className.labels,
+            })}
+          >
+            {format(+parseInt(value, 10))}
+          </li>
+        ))}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Cost surface - The values in the color ramp seem to be inverted.

### Testing instructions
Need to test here [https://marxan23.vercel.app/projects/8b02401f-6952-467c-b31c-ef11c21c5536?tab=cost-surface](https://marxan23.vercel.app/projects/8b02401f-6952-467c-b31c-ef11c21c5536?tab=cost-surface)
or see sreenshoot below:
![Screenshot 2023-12-14 at 18 04 14](https://github.com/Vizzuality/marxan-cloud/assets/51995866/118a3d8b-eab4-460d-93f1-4081f8ab168e)

### Feature relevant tickets

[MRXN23-527](https://vizzuality.atlassian.net/browse/MRXN23-527)


[MRXN23-527]: https://vizzuality.atlassian.net/browse/MRXN23-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ