### PR TITLE
use table locks to prevent stale reads from trigger [MRXN23-572]

### DIFF
--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
@@ -124,6 +124,13 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
         if (scenarioCloning) {
           await this.updateScenario(em, scenarioId, metadata, input.ownerId);
         } else {
+          /**
+            * Aggressive locking on the table is used here in order to ensure that by the time
+            * the trigger function that is executed on insert will not get stale data from
+            * concurrent transactions. Inserting in serializable mode seems not to be enough,
+            * from checks done when this lock was added.
+            */
+          await em.query('lock table scenarios');
           await this.createScenario(
             em,
             scenarioId,


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Adding aggressive table locks to prevent stale reads from trigger that executes when inserting new `scenarios` rows.

### Designs

N/A

### Testing instructions

Create a project with 20ish scenarios. It should almost consistently _fail_ to clone without this change, and it should _always_ clone successfully with this change.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-572

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file