### PR TITLE
[MRXN23-577] fixes overflow of row with long names

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/targets-spf-table/row-item/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/targets-spf-table/row-item/index.tsx
@@ -75,7 +75,7 @@ const RowItem = ({
       </td>
       <td
         className={cn({
-          'flex flex-col px-1 pb-2': true,
+          'break-anywhere flex max-w-[300px] flex-col px-1 pb-2': true,
           'w-52': type,
         })}
       >

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -164,6 +164,10 @@
   .preserve-3d {
     transform-style: preserve-3d;
   }
+
+  .break-anywhere {
+    overflow-wrap: anywhere;
+  }
 }
 
 /* PRINT */


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/5afc4f70-0761-413b-8a5e-0ec4c23f9b0b)


This was a visual glitch where rows with long names would grow further its container hiding other elements (like SPF input).

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-577

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file