### PR TITLE
delete dangling feature_amounts_per_planning_unit data straight away when deleting a feature [MRXN23-518]

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -741,7 +741,7 @@ export class GeoFeaturesService extends AppBaseService<
         featureClassName: data.name,
         description: data.description,
         projectId,
-        creationStatus: JobStatus.done,
+        creationStatus: JobStatus.created,
       }),
     );
   }

--- a/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
+++ b/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
@@ -232,7 +232,7 @@ export class FeatureAmountUploadService {
       return {
         featureClassName: feature.feature_name,
         projectId: projectId,
-        creationStatus: JobStatus.done,
+        creationStatus: JobStatus.created,
         isLegacy: true,
       };
     });

--- a/api/apps/api/src/modules/scenarios/input-files/input-params/input-parameter-file.provider.spec.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/input-params/input-parameter-file.provider.spec.ts
@@ -272,7 +272,7 @@ async function getFixtures() {
           setIsPublicProperty: jest.fn(),
           sources: ProjectSourcesEnum.legacyImport,
         },
-        status: JobStatus.done,
+        status: JobStatus.created,
         type: ScenarioType.marxanWithZones,
         users: [],
         ranAtLeastOnce: false,

--- a/api/apps/api/test/projects/crud/delete-project.e2e-spec.ts
+++ b/api/apps/api/test/projects/crud/delete-project.e2e-spec.ts
@@ -22,5 +22,5 @@ test(`deleting a project does not work if user is not in project`, async () => {
 
   const request = await fixtures.WhenProjectIsDeletedAsNotIncludedUser();
 
-  await fixtures.ThenForbiddenIsReturned(request);
+  fixtures.ThenForbiddenIsReturned(request);
 });

--- a/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
@@ -37,6 +37,7 @@ test(`if tagging info is included in DTO but invalid, then error is returned and
     name,
     description,
     invalidTag1,
+    { skipWaitingForFeatureToBeReady: true }, // needed as this feature will never be actually created
   );
   expect(result1.status).toBe(HttpStatus.BAD_REQUEST);
   fixtures.ThenInvalidTagErrorWasReturned(result1);
@@ -46,6 +47,7 @@ test(`if tagging info is included in DTO but invalid, then error is returned and
     name,
     description,
     invalidTag2,
+    { skipWaitingForFeatureToBeReady: true }, // needed as this feature will never be actually created
   );
   expect(result2.status).toBe(HttpStatus.BAD_REQUEST);
   fixtures.ThenMaxLengthErrorWasReturned(result2);
@@ -132,10 +134,9 @@ test('should delete feature_amounts_per_planning_unit data related to a feature 
 
   const result = await fixtures.WhenUploadingCustomFeature(name, description);
 
-  await fixtures.ThenGeoFeaturesAreCreated(result, name, description);
   await fixtures.ThenFeatureAmountsFromShapefileAreCreated(name);
   await fixtures.WhenDeletingFeatureForProject(name);
   await fixtures.ThenFeatureAmountsPerPlanningUnitDataIsDeletedForFeatureWithGivenId(
-    name,
+    result.body.id,
   );
 });

--- a/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.e2e-spec.ts
@@ -124,3 +124,18 @@ test(`if there is already an existing feature with a tag that has equivalent cap
   await fixtures.ThenGeoFeatureTagIsCreated(name, equivalentTag);
   // TODO Check for update of last_modified_at for all affected tag rows for project when implemented
 });
+
+test('should delete feature_amounts_per_planning_unit data related to a feature when this is deleted', async () => {
+  const name = 'someFeature';
+  const description = 'someDescrip';
+  await fixtures.GivenProjectPusWithGeometryForProject();
+
+  const result = await fixtures.WhenUploadingCustomFeature(name, description);
+
+  await fixtures.ThenGeoFeaturesAreCreated(result, name, description);
+  await fixtures.ThenFeatureAmountsFromShapefileAreCreated(name);
+  await fixtures.WhenDeletingFeatureForProject(name);
+  await fixtures.ThenFeatureAmountsPerPlanningUnitDataIsDeletedForFeatureWithGivenId(
+    name,
+  );
+});

--- a/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
+++ b/api/apps/api/test/upload-feature/upload-feature.fixtures.ts
@@ -228,7 +228,6 @@ export const getFixtures = async () => {
           description: customFeatureDesc,
         });
     },
-
     WhenUploadingCsvWithPuidsNotPresentITheProject: async () => {
       await GivenProjectsPuExists(geoEntityManager, projectId);
       return request(app.getHttpServer())
@@ -243,7 +242,15 @@ export const getFixtures = async () => {
           description: customFeatureDesc,
         });
     },
-
+    WhenDeletingFeatureForProject: async (featureClassName: string) => {
+      const feature = await featuresRepository.findOneOrFail({
+        where: { featureClassName },
+      });
+      await request(app.getHttpServer())
+        .delete(`/api/v1/projects/${projectId}/features/${feature?.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send();
+    },
     // ASSERT
     ThenMaxLengthErrorWasReturned: (response: request.Response) => {
       const error: any =
@@ -426,6 +433,22 @@ export const getFixtures = async () => {
       expect(feature2Amounts[0].amount).toBe(0);
       expect(feature2Amounts[1].amount).toBe(0);
       expect(feature2Amounts[2].amount).toBe(0);
+    },
+    ThenFeatureAmountsPerPlanningUnitDataIsDeletedForFeatureWithGivenId: async (
+      featureClassName: string,
+    ) => {
+      const featureId = await featuresRepository
+        .findOneOrFail({
+          where: { featureClassName },
+        })
+        .then((result) => result.id);
+      const featureAmountsPerPlanningUnitForFeature =
+        await featureAmountsPerPlanningUnitRepo.find({
+          where: {
+            featureId,
+          },
+        });
+      expect(featureAmountsPerPlanningUnitForFeature.length).toBe(0);
     },
     ThenFeatureUploadRegistryIsCleared: async () => {
       const featureImportRegistryRecord = await featureImportRegistry.findOne({

--- a/api/apps/api/test/utils/wait-for-feature-to-be-ready.utils.ts
+++ b/api/apps/api/test/utils/wait-for-feature-to-be-ready.utils.ts
@@ -1,0 +1,31 @@
+import { JobStatus } from '@marxan-api/modules/scenarios/scenario.api.entity';
+import { GeoFeature } from '@marxan-api/modules/geo-features/geo-feature.api.entity';
+import { Repository } from 'typeorm';
+import { waitFor } from './wait-for.utils';
+
+export const waitForFeatureToBeReady = async (
+  geoFeaturesApiRepo: Repository<GeoFeature>,
+  featureId: string,
+) => {
+  const checkFn = async () => {
+    return await geoFeaturesApiRepo
+      .findOne({
+        where: {
+          id: featureId,
+          creationStatus: JobStatus.created,
+        },
+      })
+      .then((result) => result !== undefined);
+  };
+
+  await waitFor(
+    {
+      description: 'feature to be ready',
+      fn: checkFn,
+    },
+    {
+      maxTries: 10,
+      intervalMs: 2000,
+    },
+  );
+};

--- a/api/apps/api/test/utils/wait-for.utils.ts
+++ b/api/apps/api/test/utils/wait-for.utils.ts
@@ -1,0 +1,46 @@
+import { Logger } from '@nestjs/common';
+
+type msTime = number;
+
+interface RetryOptions {
+  delayMs?: msTime;
+  intervalMs: msTime;
+  maxTries: number;
+}
+
+const sleep = (seconds: number) => {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+};
+
+export const waitFor = async (
+  retryOp: {
+    description: string;
+    fn: ((...args: unknown[]) => Promise<boolean>) | (() => boolean);
+  },
+  retryOptions: RetryOptions,
+): Promise<boolean> => {
+  Logger.debug(`Polling for ${retryOp.description} until complete...`);
+
+  if (retryOptions?.delayMs) {
+    const delay = retryOptions.delayMs ?? '0';
+    Logger.debug(
+      `Waiting for ${delay / 1e3}s before starting to poll status...`,
+    );
+    await sleep(delay / 1e3);
+  }
+
+  const interval = retryOptions.intervalMs;
+
+  for (const i of [...Array(retryOptions.maxTries).keys()]) {
+    Logger.debug(`Retry ${i} of ${retryOptions.maxTries}...`);
+    const success = await retryOp.fn();
+    if (success) {
+      Logger.debug(`Callback function succeeded.`);
+      return true;
+    }
+    Logger.debug(`Waiting for ${interval / 1e3}s`);
+    await sleep(interval / 1e3);
+  }
+
+  return false;
+};

--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-metadata.piece-importer.ts
@@ -125,11 +125,11 @@ export class ScenarioMetadataPieceImporter implements ImportPieceProcessor {
           await this.updateScenario(em, scenarioId, metadata, input.ownerId);
         } else {
           /**
-            * Aggressive locking on the table is used here in order to ensure that by the time
-            * the trigger function that is executed on insert will not get stale data from
-            * concurrent transactions. Inserting in serializable mode seems not to be enough,
-            * from checks done when this lock was added.
-            */
+           * Aggressive locking on the table is used here in order to ensure that by the time
+           * the trigger function that is executed on insert will not get stale data from
+           * concurrent transactions. Inserting in serializable mode seems not to be enough,
+           * from checks done when this lock was added.
+           */
           await em.query('lock table scenarios');
           await this.createScenario(
             em,

--- a/api/apps/geoprocessing/src/modules/cleanup-tasks/cleanup-tasks.service.ts
+++ b/api/apps/geoprocessing/src/modules/cleanup-tasks/cleanup-tasks.service.ts
@@ -473,6 +473,13 @@ export class CleanupTasksService implements CleanupTasks {
         SELECT df.feature_id FROM dangling_features df
       );`,
     );
+
+    await this.geoEntityManager.query(
+      `DELETE FROM feature_amounts_per_planning_unit fappu
+      WHERE fappu.feature_id IN (
+        SELECT df.feature_id FROM dangling_features df
+      );`,
+    );
   }
 
   async deleteDanglingCostSurfacesIdsInGeoDb() {


### PR DESCRIPTION
Complements the original fix to MRXN23-518, adding deletion of dangling `feature_amounts_per_planning_unit` rows while deleting a feature.

https://vizzuality.atlassian.net/browse/MRXN23-518

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file