### PR TITLE
update GH Actions dependencies for which a version that uses Node v20 is available from upstream maintainers [MRXN23-586]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -68,6 +68,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/deploy-to-kubernetes.yml
+++ b/.github/workflows/deploy-to-kubernetes.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login via Azure CLI
         uses: azure/login@v1

--- a/.github/workflows/e2e-client.yml
+++ b/.github/workflows/e2e-client.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: app
     steps:
     - name: checkout pull
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Node setup
       uses: actions/setup-node@v3

--- a/.github/workflows/publish-marxan-docker-images.yml
+++ b/.github/workflows/publish-marxan-docker-images.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login via Azure CLI
         uses: azure/login@v1
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login via Azure CLI
         uses: azure/login@v1

--- a/.github/workflows/publish-webshot-docker-images.yml
+++ b/.github/workflows/publish-webshot-docker-images.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login via Azure CLI
         uses: azure/login@v1

--- a/.github/workflows/tests-api-e2e.yml
+++ b/.github/workflows/tests-api-e2e.yml
@@ -57,6 +57,6 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run CI tests via make task
         run: TEST_SUITE_PATH="${{ matrix.test-suite }}" make test-e2e-api environment=ci

--- a/.github/workflows/tests-api-unit.yml
+++ b/.github/workflows/tests-api-unit.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run API unit Tests
         run: make test-unit-api

--- a/.github/workflows/tests-backend-build-oci-images.yml
+++ b/.github/workflows/tests-backend-build-oci-images.yml
@@ -45,17 +45,17 @@ jobs:
       REPOSITORY: marxan-api
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare ids
         shell: bash
@@ -66,7 +66,7 @@ jobs:
         id: extract_branch
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         env:
           IMAGE_TAG: ${{ steps.extract_branch.outputs.shortsha }}
           REGISTRY_NAMESPACE: ${{ steps.extract_branch.outputs.registry_namespace }}
@@ -84,17 +84,17 @@ jobs:
       REPOSITORY: marxan-geoprocessing
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare ids
         shell: bash
@@ -105,7 +105,7 @@ jobs:
         id: extract_branch
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         env:
           IMAGE_TAG: ${{ steps.extract_branch.outputs.shortsha }}
           REGISTRY_NAMESPACE: ${{ steps.extract_branch.outputs.registry_namespace }}
@@ -123,17 +123,17 @@ jobs:
       REPOSITORY: marxan-postgresql-api
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare ids
         shell: bash
@@ -144,7 +144,7 @@ jobs:
         id: extract_branch
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         env:
           IMAGE_TAG: ${{ steps.extract_branch.outputs.shortsha }}
           REGISTRY_NAMESPACE: ${{ steps.extract_branch.outputs.registry_namespace }}
@@ -162,17 +162,17 @@ jobs:
       REPOSITORY: marxan-postgresql-geo-api
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare ids
         shell: bash
@@ -183,7 +183,7 @@ jobs:
         id: extract_branch
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         env:
           IMAGE_TAG: ${{ steps.extract_branch.outputs.shortsha }}
           REGISTRY_NAMESPACE: ${{ steps.extract_branch.outputs.registry_namespace }}
@@ -201,17 +201,17 @@ jobs:
       REPOSITORY: marxan-redis
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare ids
         shell: bash
@@ -222,7 +222,7 @@ jobs:
         id: extract_branch
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         env:
           IMAGE_TAG: ${{ steps.extract_branch.outputs.shortsha }}
           REGISTRY_NAMESPACE: ${{ steps.extract_branch.outputs.registry_namespace }}
@@ -239,17 +239,17 @@ jobs:
       REPOSITORY: marxan-webshot
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Prepare ids
         shell: bash
@@ -260,7 +260,7 @@ jobs:
         id: extract_branch
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         env:
           IMAGE_TAG: ${{ steps.extract_branch.outputs.shortsha }}
           REGISTRY_NAMESPACE: ${{ steps.extract_branch.outputs.registry_namespace }}

--- a/.github/workflows/tests-geoprocessing-e2e.yml
+++ b/.github/workflows/tests-geoprocessing-e2e.yml
@@ -32,6 +32,6 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run CI tests via make task
         run: TEST_SUITE_PATH="${{ matrix.test-suite }}" make test-e2e-geoprocessing environment=ci

--- a/.github/workflows/tests-geoprocessing-unit.yml
+++ b/.github/workflows/tests-geoprocessing-unit.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Geoprocessing Unit Tests
         run: make test-unit-geo

--- a/.github/workflows/webshot-build.yml
+++ b/.github/workflows/webshot-build.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build webshot service
       run: docker compose -f docker-compose-build-webshot.yml build webshot
 


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MRXN23-586

Exceptions so far: Azure's own actions, and (most of) GitHub's own actions, which haven't released versions that use Node v20 yet (some of these have PRs being reviewed 🤞🏼)