### PR TITLE
[MRXN23-531]: invalidates cost-surface fetch a second later of creation

### DIFF
--- a/app/hooks/projects/index.ts
+++ b/app/hooks/projects/index.ts
@@ -189,8 +189,8 @@ export function useSaveProject({
   };
 
   return useMutation(saveProject, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('projects');
+    onSuccess: async () => {
+      await queryClient.invalidateQueries('projects');
     },
     onError: (error, variables, context) => {
       // An error happened!


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR delays the query invalidation of cost surfaces up to one second so it avoids falling in limbo when the API processes the cost surface between the POST callback and the first `/status` polling. If the API takes more than that second into processing the cost-surface, the `/status` will in charge of telling the application when the query invalidation should occur.

For future reference:

![Screenshot 2024-02-20 at 16-56-43 Excalidraw — Collaborative whiteboarding made easy](https://github.com/Vizzuality/marxan-cloud/assets/47385021/869e384b-09e8-4a35-97f8-802a0311b2e0)

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-531

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file