### PR TITLE
export and import lockStatusSetByUser flag [MRXN23-600]

### DIFF
--- a/api/apps/api/src/modules/analysis/providers/shared/__mocks__/scenario-planning-unit-geo.data.ts
+++ b/api/apps/api/src/modules/analysis/providers/shared/__mocks__/scenario-planning-unit-geo.data.ts
@@ -8,8 +8,9 @@ export const validDataWithGivenPuIds = (
   puids: string[],
   scenarioId = 'scenario-0000-fake-uuid',
 ): ScenariosPlanningUnitGeoEntity[] =>
-  puids.map((id, index) => ({
+  puids.map((id, _index) => ({
     lockStatus: LockStatus.Available,
+    lockStatusSetByUser: true,
     protectedByDefault: false,
     scenarioId,
     projectPuId: v4(),

--- a/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.serializer.ts
+++ b/api/apps/api/src/modules/scenarios/dto/scenario-planning-unit.serializer.ts
@@ -19,7 +19,7 @@ export class ScenarioPlanningUnitSerializer {
         defaultStatus: unit.protectedByDefault
           ? LockStatus.LockedIn
           : LockStatus.Available,
-        setByUser: unit.setByUser,
+        setByUser: unit.lockStatusSetByUser,
       })),
     );
   }

--- a/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
+++ b/api/apps/api/src/modules/scenarios/planning-units/scenario-planning-units.service.ts
@@ -36,7 +36,7 @@ export class ScenarioPlanningUnitsService {
       where: {
         scenarioId,
         lockStatus,
-        setByUser: true,
+        lockStatusSetByUser: true,
       },
     });
   }
@@ -63,7 +63,7 @@ export class ScenarioPlanningUnitsService {
         },
         {
           lockStatus: LockStatus.Available,
-          setByUser: false,
+          lockStatusSetByUser: false,
         },
       );
 
@@ -75,7 +75,7 @@ export class ScenarioPlanningUnitsService {
         },
         {
           lockStatus: LockStatus.LockedIn,
-          setByUser: false,
+          lockStatusSetByUser: false,
         },
       );
     });

--- a/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
+++ b/api/apps/api/test/scenario-input-files/scenario-cost-surface/scenario-cost-surface.fixtures.ts
@@ -123,7 +123,7 @@ export const getFixtures = async () => {
             projectPuId: pu.id,
             scenarioId,
             lockStatus: lockStatuses[index] ?? null,
-            setByUser: [1, 2].includes(index) ? true : false,
+            lockStatusSetByUser: [1, 2].includes(index) ? true : false,
           }),
         ),
       );

--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-cost-surfaces.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-cost-surfaces.piece-exporter.ts
@@ -87,16 +87,23 @@ export class ProjectCostSurfacesPieceExporter implements ExportPieceProcessor {
     projectPusMap = await this.getProjectPusMap(input.resourceId);
 
     const fileContent: ProjectCostSurfacesContent = {
-      costSurfaces: costSurfaces.map(({ id, ...costSurface }) => ({
+      costSurfaces: costSurfaces.map((costSurface) => ({
         ...costSurface,
         data: costSurfaceData
           .filter(
-            (data: CostSurfaceDataSelectResult) => data.cost_surface_id === id,
+            (data: CostSurfaceDataSelectResult) =>
+              data.cost_surface_id === costSurface.id,
           )
-          .map(({ cost_surface_id, projects_pu_id, ...data }) => {
-            const puid = projectPusMap[projects_pu_id];
-            return { puid, ...data };
-          }),
+          .map(
+            ({
+              cost_surface_id: _cost_surface_id,
+              projects_pu_id,
+              ...data
+            }) => {
+              const puid = projectPusMap[projects_pu_id];
+              return { puid, ...data };
+            },
+          ),
       })),
     };
 

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-planning-units-data.piece-exporter.ts
@@ -15,7 +15,8 @@ import {
 } from '../pieces/export-piece-processor';
 
 type SelectResult = {
-  lockin_status?: 1 | 2;
+  lockin_status?: 0 | 1 | 2;
+  lock_status_set_by_user?: boolean;
   xloc?: number;
   yloc?: number;
   protected_area?: number;
@@ -74,6 +75,7 @@ export class ScenarioPlanningUnitsDataPieceExporter
         protectedByDefault: row.protected_by_default,
         puid: row.puid,
         lockinStatus: row.lockin_status,
+        lockStatusSetByUser: row.lock_status_set_by_user,
         xloc: row.xloc,
         yloc: row.yloc,
       })),

--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-planning-units-data.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-planning-units-data.piece-importer.ts
@@ -92,6 +92,7 @@ export class ScenarioPlanningUnitsDataPieceImporter
                     featureList: puData.featureList,
                     projectPuId: projectPuIdByPuid[puData.puid],
                     lockStatus: toLockEnum[puData.lockinStatus ?? 0],
+                    lockStatusSetByUser: puData.lockStatusSetByUser,
                     protectedArea: puData.protectedArea,
                     protectedByDefault: puData.protectedByDefault,
                     xloc: puData.xloc,

--- a/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-planning-units-inclusion/scenario-planning-units-inclusion-processor.ts
@@ -195,7 +195,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.Available,
-        setByUser: false,
+        lockStatusSetByUser: false,
       },
     );
 
@@ -207,7 +207,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.LockedIn,
-        setByUser: false,
+        lockStatusSetByUser: false,
       },
     );
 
@@ -219,7 +219,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.LockedIn,
-        setByUser: true,
+        lockStatusSetByUser: true,
       },
     );
 
@@ -231,7 +231,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.LockedOut,
-        setByUser: true,
+        lockStatusSetByUser: true,
       },
     );
 
@@ -243,7 +243,7 @@ export class ScenarioPlanningUnitsInclusionProcessor
       },
       {
         lockStatus: LockStatus.Available,
-        setByUser: true,
+        lockStatusSetByUser: true,
       },
     );
   }

--- a/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
+++ b/api/apps/geoprocessing/test/integration/planning-unit-inclusion/world.ts
@@ -239,7 +239,7 @@ export const createWorld = async (app: INestApplication) => {
           where: {
             scenarioId,
             lockStatus: LockStatus.LockedIn,
-            setByUser: true,
+            lockStatusSetByUser: true,
           },
         })
       )
@@ -252,7 +252,7 @@ export const createWorld = async (app: INestApplication) => {
             scenarioId,
             lockStatus: LockStatus.LockedIn,
             protectedByDefault: true,
-            setByUser: false,
+            lockStatusSetByUser: false,
           },
         })
       )

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/scenario-planning-units-data.ts
@@ -3,7 +3,8 @@ export const scenarioPlanningUnitsDataRelativePath = `scenario-pu-data.json`;
 type PlanningUnitData = {
   puid: number;
   cost: number;
-  lockinStatus?: 1 | 2;
+  lockinStatus?: 0 | 1 | 2;
+  lockStatusSetByUser?: boolean;
   xloc?: number;
   yloc?: number;
   protectedArea?: number;

--- a/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
+++ b/api/libs/scenarios-planning-unit/src/scenarios-planning-unit.geo.entity.ts
@@ -20,9 +20,6 @@ export class ScenariosPlanningUnitGeoEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  /**
-   * missing FK
-   */
   @PrimaryColumn({
     type: 'uuid',
     name: 'project_pu_id',
@@ -30,7 +27,7 @@ export class ScenariosPlanningUnitGeoEntity {
   projectPuId!: string;
 
   /**
-   * missing FK
+   * Matches (apidb)scenarios.id
    */
   @Column({
     type: 'uuid',
@@ -57,12 +54,12 @@ export class ScenariosPlanningUnitGeoEntity {
     name: 'lockin_status',
     transformer: {
       from(value: number | null): LockStatus {
-        if (value !== null && (value === 1 || value === 2)) {
+        if (value !== null && (value === 0 || value === 1 || value === 2)) {
           return toLockEnum[value];
         }
         return LockStatus.Available;
       },
-      to(value: LockStatus): null | 1 | 2 {
+      to(value: LockStatus): null | 0 | 1 | 2 {
         return fromLockEnum[value];
       },
     },
@@ -80,7 +77,7 @@ export class ScenariosPlanningUnitGeoEntity {
     default: false,
     name: `lock_status_set_by_user`,
   })
-  setByUser!: boolean;
+  lockStatusSetByUser!: boolean;
 
   @Column({
     type: 'float8',


### PR DESCRIPTION
The `lockStatusSetByUser` scenario PU flag had not been added to piece exporters and importers, leading to loss of this data when cloning scenarios. This change fixes this.

### Testing instructions

Set some PUs to excluded, some to available and some to included for a scenario.

Clone the scenario (or its whole parent project). The new copy of the scenario must preserve the statuses set manually in the source scenario.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-600

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file