### PR TITLE
link scenarios correctly to cost surfaces after cloning [MRXN23-606]

### DIFF
--- a/api/apps/api/src/migrations/api/1710069730000-AddStableIdsToCostSurfaces.ts
+++ b/api/apps/api/src/migrations/api/1710069730000-AddStableIdsToCostSurfaces.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStableIdsToCostSurfaces1710069730000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+ALTER TABLE cost_surfaces
+ADD COLUMN stable_id uuid;
+
+CREATE INDEX cost_surfaces_stable_id__idx ON cost_surfaces(stable_id);
+
+CREATE UNIQUE INDEX cost_surfaces_unique_stable_ids_within_project__idx ON cost_surfaces(project_id, stable_id);
+      `);
+
+    await queryRunner.query(`
+UPDATE cost_surfaces
+SET stable_id = id;
+      `);
+
+    await queryRunner.query(`
+ALTER TABLE cost_surfaces
+ALTER COLUMN stable_id SET NOT NULL;
+
+ALTER TABLE cost_surfaces
+ALTER COLUMN stable_id SET DEFAULT gen_random_uuid();
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+ALTER TABLE cost_surfaces
+DROP COLUMN stable_id;
+      `);
+  }
+}

--- a/api/apps/api/src/modules/cost-surface/cost-surface.api.entity.ts
+++ b/api/apps/api/src/modules/cost-surface/cost-surface.api.entity.ts
@@ -33,6 +33,9 @@ export class CostSurface {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
+  @Column({ name: 'stable_id' })
+  stableId!: string;
+
   @ApiProperty({ type: () => Project })
   @ManyToOne((_type) => Project, (project) => project.costSurfaces)
   @JoinColumn({

--- a/api/apps/api/src/modules/scenarios/input-files/input-params/input-parameter-file.provider.spec.ts
+++ b/api/apps/api/src/modules/scenarios/input-files/input-params/input-parameter-file.provider.spec.ts
@@ -225,6 +225,7 @@ async function getFixtures() {
         costSurfaceId: '',
         costSurface: {
           id: '',
+          stableId: '',
           name: 'some cost surface',
           projectId: '',
           isDefault: false,

--- a/api/apps/geoprocessing/src/import/pieces-importers/project-cost-surfaces.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/project-cost-surfaces.piece-importer.ts
@@ -123,7 +123,7 @@ export class ProjectCostSurfacesPieceImporter implements ImportPieceProcessor {
               .createQueryBuilder()
               .insert()
               .into('cost_surfaces')
-              .values(omit(costSurfaceData, ['origin_id']))
+              .values(costSurfaceData)
               .execute(),
           ),
         );

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-cost-surface.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/project-cost-surface.piece-exporter.e2e-spec.ts
@@ -1,7 +1,6 @@
 import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
 import { ClonePiece, ExportJobInput } from '@marxan/cloning';
 import { ResourceKind } from '@marxan/cloning/domain';
-import { ProjectCustomFeaturesContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-custom-features';
 import { CloningFilesRepository } from '@marxan/cloning-files-repository';
 import { GeoFeatureGeometry } from '@marxan/geofeatures';
 import { FixtureType } from '@marxan/utils/tests/fixture-type';
@@ -9,14 +8,12 @@ import { Test } from '@nestjs/testing';
 import { getEntityManagerToken, TypeOrmModule } from '@nestjs/typeorm';
 import { isLeft, Right } from 'fp-ts/lib/Either';
 import { Readable } from 'stream';
-import { EntityManager, In } from 'typeorm';
+import { EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
 import {
   DeleteProjectAndOrganization,
   GivenCostSurfaceData,
   GivenCostSurfaces,
-  GivenFeatures,
-  GivenFeaturesData,
   GivenProjectExists,
   readSavedFile,
 } from '../fixtures';

--- a/api/libs/cloning/src/infrastructure/clone-piece-data/project-cost-surfaces.ts
+++ b/api/libs/cloning/src/infrastructure/clone-piece-data/project-cost-surfaces.ts
@@ -6,6 +6,16 @@ export type CostSurfaceData = {
 };
 
 export type ProjectCostSurface = {
+  /**
+   * The stable_id of the cost surface in the original project is stored as part
+   * of the export, so that it can be used to port over as part of cloned
+   * projects any links between scenarios and cost surfaces (since the former
+   * are imported with a cost_surface_id matching the stable_id stored here, but
+   * the corresponding cost surfaces are created with a new unique id in the
+   * cloned project).
+   */
+  id: string;
+  stable_id: string;
   name: string;
   min: number;
   max: number;


### PR DESCRIPTION
Allow scenarios to be linked correctly to copies of cost surfaces within cloned projects.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-606

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file