### PR TITLE
[MRXN23-604] fixes target/spf values after editing one of them

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/all-targets/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/all-targets/index.tsx
@@ -34,13 +34,16 @@ const AllTargetsSelector = ({
             type="number"
             min={0}
             max={100}
+            step={0.01}
             defaultValue={values.target}
             value={values.target}
-            // disabled={!editable}
             onChange={({ target: { value: inputValue } }) => {
+              const numericValue = Number(inputValue);
+              if (numericValue < 0 || numericValue > 100) return;
+
               setValues((prevValues) => ({
                 ...prevValues,
-                target: Number(inputValue),
+                target: numericValue,
               }));
             }}
             onKeyDownCapture={(event) => {
@@ -75,12 +78,15 @@ const AllTargetsSelector = ({
             mode="dashed"
             type="number"
             defaultValue={values.spf}
-            // value={inputFPFValue}
-            // disabled={!editable}
+            step={0.01}
+            min={0}
             onChange={({ target: { value: inputValue } }) => {
+              const numericValue = Number(inputValue);
+              if (numericValue <= 0) return;
+
               setValues((prevValues) => ({
                 ...prevValues,
-                spf: Number(inputValue),
+                spf: numericValue,
               }));
             }}
             onKeyDownCapture={(event) => {

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/index.tsx
@@ -24,7 +24,7 @@ const SplitFeaturesBulkActionMenu = ({
   selectedFeatureIds,
   onDone,
 }: {
-  features: (Feature & { name: string })[];
+  features: (Feature & { name: string; marxanSettings: { prop?: number; fpf?: number } })[];
   selectedFeatureIds: Feature['id'][];
   onDone: () => void;
 }): JSX.Element => {

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
@@ -18,6 +18,9 @@ export type FormValues = {
   spf: number;
 };
 
+const INPUT_CLASSES =
+  'h-10 w-full rounded-md border border-gray-400 px-3 text-gray-900 focus:border-none focus:outline-none focus:ring-1 focus:ring-blue-600';
+
 const EditModal = ({
   selectedFeatures,
   handleModal,
@@ -206,10 +209,11 @@ const EditModal = ({
                       <input
                         {...fprops.input}
                         type="number"
-                        className="h-10 w-full rounded-md border border-gray-400 px-3 text-gray-900 focus:border-none focus:outline-none focus:ring-1 focus:ring-blue-600"
+                        className={INPUT_CLASSES}
                         defaultValue={fprops.input.value}
                         min={0}
                         max={100}
+                        step={0.01}
                       />
                     </Field>
                   )}
@@ -228,11 +232,10 @@ const EditModal = ({
                       <input
                         {...fprops.input}
                         type="number"
-                        className="h-10 w-full rounded-md border border-gray-400 px-3 text-gray-900 focus:border-none focus:outline-none focus:ring-1 focus:ring-blue-600"
+                        className={INPUT_CLASSES}
                         defaultValue={fprops.input.value}
-                        min={0}
-                        max={1}
-                        step="0.01"
+                        min={1}
+                        step={0.01}
                       />
                     </Field>
                   )}

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
@@ -23,7 +23,7 @@ const EditModal = ({
   handleModal,
   onDone,
 }: {
-  selectedFeatures: (Feature & { name: string })[];
+  selectedFeatures: (Feature & { name: string; marxanSettings: { prop?: number; fpf?: number } })[];
   handleModal: (modalKey: 'split' | 'edit' | 'delete', isVisible: boolean) => void;
   onDone?: () => void;
 }): JSX.Element => {
@@ -178,8 +178,9 @@ const EditModal = ({
   return (
     <FormRFF<FormValues>
       initialValues={{
-        target: 50,
-        spf: 1,
+        target:
+          (selectedFeatures?.length === 1 && selectedFeatures?.[0]?.marxanSettings?.prop) || 50,
+        spf: (selectedFeatures?.length === 1 && selectedFeatures?.[0]?.marxanSettings?.fpf) || 1,
       }}
       ref={formRef}
       onSubmit={onEditSubmit}

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ComponentProps, useCallback, useMemo, useState } from 'react';
+import { ChangeEvent, ComponentProps, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useQueryClient } from 'react-query';
 
@@ -417,6 +417,21 @@ const TargetAndSPFFeatures = (): JSX.Element => {
 
   const displayBulkActions = selectedFeatureIds.length > 0;
   const displaySaveButton = selectedFeaturesQuery.data?.length > 0;
+
+  useEffect(() => {
+    setFeatureValues((prevValues) => ({
+      ...prevValues,
+      ...selectedFeaturesQuery.data?.reduce((acc, { id, marxanSettings }) => {
+        return {
+          ...acc,
+          [id]: {
+            target: marxanSettings?.prop * 100,
+            spf: marxanSettings?.fpf,
+          },
+        };
+      }, {}),
+    }));
+  }, [selectedFeaturesQuery.data]);
 
   return (
     <>

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/targets-spf-table/row-item/details/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/targets-spf-table/row-item/details/index.tsx
@@ -6,6 +6,8 @@ import { useCanEditScenario } from 'hooks/permissions';
 
 import Input from 'components/forms/input';
 
+const INPUT_CLASES = 'w-[55px] rounded-md border-solid border-gray-600 px-0 py-1 text-center';
+
 export const RowDetails = ({ item, onChange }): JSX.Element => {
   const { query } = useRouter();
   const { pid, sid } = query as { pid: string; sid: string };
@@ -28,20 +30,26 @@ export const RowDetails = ({ item, onChange }): JSX.Element => {
       <div className="flex items-center space-x-2">
         <span>Target</span>
         <Input
-          className="w-[55px] rounded-md border-solid border-gray-600 py-1 text-center"
+          className={INPUT_CLASES}
           theme="dark"
           mode="dashed"
           type="number"
+          min={0}
+          max={100}
+          step={0.01}
           defaultValue={values.target}
           value={values.target}
           disabled={!editable}
           onChange={({ target: { value: inputValue } }) => {
+            const numericValue = Number(inputValue);
+            if (numericValue < 0 || numericValue > 100) return;
+
             setValues((prevValues) => ({
               ...prevValues,
-              target: Number(inputValue),
+              target: numericValue,
             }));
 
-            onChange(id, { target: Number(inputValue) });
+            onChange(id, { target: numericValue });
           }}
         />
         <span className="text-xs">%</span>
@@ -49,20 +57,25 @@ export const RowDetails = ({ item, onChange }): JSX.Element => {
       <div className="flex items-center space-x-2">
         <span>SPF</span>
         <Input
-          className="w-[55px] rounded border border-solid py-1 "
+          className={INPUT_CLASES}
           theme="dark"
           mode="dashed"
           type="number"
+          step={0.01}
+          min={0}
           defaultValue={values.spf}
           value={values.spf}
           disabled={!editable}
           onChange={({ target: { value: inputValue } }) => {
+            const numericValue = Number(inputValue);
+            if (numericValue <= 0) return;
+
             setValues((prevValues) => ({
               ...prevValues,
-              spf: Number(inputValue),
+              spf: numericValue,
             }));
 
-            onChange(id, { spf: Number(inputValue) });
+            onChange(id, { spf: numericValue });
           }}
         />
       </div>


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR fixes an issue were the features listed were defaulted to the app's default values (for target and spf) when one of the features was edited by selecting it (through the checkbox) and clicking on the edit button in the floating menu.

The PR also displays the current values for target and spf when the user edits their values instead of defaulting to the app's default values. If more than one features are selected to edit, then the app's default values will display though.

![image](https://github.com/Vizzuality/marxan-cloud/assets/999124/21cea19e-37be-4d97-91dd-37cc42f36ea1)


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-604

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file