### PR TITLE
[MRXN23-618] cost surface layer: ensures interpolation is possible

### DIFF
--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -213,7 +213,7 @@ export function useCostSurfaceLayer({
                 ['get', 'cost'],
                 layerSettings.min === layerSettings.max ? 0 : layerSettings.min,
                 COLORS.cost[0],
-                layerSettings.max,
+                layerSettings.min === layerSettings.max ? layerSettings.max + 1 : layerSettings.max,
                 COLORS.cost[1],
               ],
               'fill-opacity': 0.75 * (layerSettings.opacity ?? 1),


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR ensure if possible to interpolate values when the `min` and `max` values of the cost-surface layer are equal by adding 1 to the `max` value.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-618

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file