### PR TITLE
[MRXN23-624] targets: sync local with remotes changes in targets

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/index.tsx
@@ -26,7 +26,7 @@ const SplitFeaturesBulkActionMenu = ({
 }: {
   features: (Feature & { name: string; marxanSettings: { prop?: number; fpf?: number } })[];
   selectedFeatureIds: Feature['id'][];
-  onDone: () => void;
+  onDone: (res?: unknown) => void;
 }): JSX.Element => {
   const { query } = useRouter();
   const { pid, sid } = query as { pid: string; sid: string };

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/delete/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/delete/index.tsx
@@ -19,7 +19,7 @@ const DeleteModal = ({
   features: any[];
   selectedFeaturesIds: Feature['id'][];
   onDismiss?: ModalProps['onDismiss'];
-  onDone?: () => void;
+  onDone?: (res?: unknown) => void;
 }): JSX.Element => {
   const queryClient = useQueryClient();
   const { query } = useRouter();

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
@@ -28,7 +28,7 @@ const EditModal = ({
 }: {
   selectedFeatures: (Feature & { name: string; marxanSettings: { prop?: number; fpf?: number } })[];
   handleModal: (modalKey: 'split' | 'edit' | 'delete', isVisible: boolean) => void;
-  onDone?: () => void;
+  onDone?: (res?: unknown) => void;
 }): JSX.Element => {
   const { addToast } = useToasts();
   const { query } = useRouter();
@@ -136,8 +136,8 @@ const EditModal = ({
           data,
         },
         {
-          onSuccess: () => {
-            onDone?.();
+          onSuccess: (res) => {
+            onDone?.(res);
             handleModal('edit', false);
 
             addToast(

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ComponentProps, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, ComponentProps, useCallback, useMemo, useState } from 'react';
 
 import { useQueryClient } from 'react-query';
 
@@ -415,23 +415,25 @@ const TargetAndSPFFeatures = (): JSX.Element => {
     [selectedFeaturesQuery.data, queryClient, sid, selectedFeaturesMutation]
   );
 
-  const displayBulkActions = selectedFeatureIds.length > 0;
-  const displaySaveButton = selectedFeaturesQuery.data?.length > 0;
+  const onDoneEditing = useCallback((res: { data: { features: any[] } }) => {
+    setSelectedFeatureIds([]);
+    const { features } = res?.data || {};
 
-  useEffect(() => {
-    setFeatureValues((prevValues) => ({
-      ...prevValues,
-      ...selectedFeaturesQuery.data?.reduce((acc, { id, marxanSettings }) => {
+    setFeatureValues(() => ({
+      ...features?.reduce((acc, { featureId, marxanSettings }) => {
         return {
           ...acc,
-          [id]: {
+          [featureId]: {
             target: marxanSettings?.prop * 100,
             spf: marxanSettings?.fpf,
           },
         };
       }, {}),
     }));
-  }, [selectedFeaturesQuery.data]);
+  }, []);
+
+  const displayBulkActions = selectedFeatureIds.length > 0;
+  const displaySaveButton = selectedFeaturesQuery.data?.length > 0;
 
   return (
     <>
@@ -524,9 +526,7 @@ const TargetAndSPFFeatures = (): JSX.Element => {
           <FeaturesBulkActionMenu
             features={targetedFeatures}
             selectedFeatureIds={selectedFeatureIds}
-            onDone={() => {
-              setSelectedFeatureIds([]);
-            }}
+            onDone={onDoneEditing}
           />
         )}
       </Section>


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR removes a side effect triggered when the user searched for some targets and the edited values were reverted to app's defaults after rendering the filtered results.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXN23-624

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file