### PR TITLE
avoid inserting duplicate feature_amounts_per_planning_unit rows over and over [MRXN23-609]

### DIFF
--- a/api/apps/api/src/modules/geo-features/geo-features.service.ts
+++ b/api/apps/api/src/modules/geo-features/geo-features.service.ts
@@ -993,7 +993,7 @@ export class GeoFeaturesService extends AppBaseService<
       return left(featureDataCannotBeUploadedWithCsv);
     }
 
-    await this.featureAmountUploads.uploadFeatureFromCSVAsync(
+    await this.featureAmountUploads.uploadFeatureFromCsvAsync(
       fileBuffer,
       projectId,
       userId,

--- a/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
+++ b/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
@@ -49,7 +49,7 @@ export class FeatureAmountUploadService {
     private readonly geoFeaturesService: GeoFeaturesService,
   ) {}
 
-  uploadFeatureFromCSVAsync(
+  async uploadFeatureFromCsvAsync(
     fileBuffer: Buffer,
     projectId: string,
     userId: string,

--- a/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
+++ b/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
@@ -74,7 +74,7 @@ export class FeatureAmountUploadService {
   }): Promise<Left<any> | Right<GeoFeature[]>> {
     //Because feature CSV files are bound to be increasingly larger, this can cause problems when trying to save a big
     //JSONB value into postgres eventually crashing due to an memory error, so the CSV file is ignored for the api event
-    const { fileBuffer, ...apiEventData } = data;
+    const { fileBuffer: _fileBuffer, ...apiEventData } = data;
     await this.events.submittedEvent(data.projectId, apiEventData);
 
     const apiQueryRunner = this.apiDataSource.createQueryRunner();

--- a/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
+++ b/api/apps/api/src/modules/geo-features/import/features-amounts-upload.service.ts
@@ -398,18 +398,19 @@ export class FeatureAmountUploadService {
           `,
           parameters,
         );
-        await geoQueryRunner.manager.query(
-          ` INSERT INTO feature_amounts_per_planning_unit (project_id, feature_id, amount, project_pu_id)
-                  SELECT $1, $2, amount, project_pu_id
-                  FROM features_data where feature_id = $2`,
-          [projectId, newFeature.id],
-        );
         this.logger.log(
           `Chunk ${amountIndex}/${featuresChunks.length} saved to (geoDB).features_data`,
         );
       }
       this.logger.log(
         `All chunks of feature ${newFeature.feature_class_name} saved`,
+      );
+
+      await geoQueryRunner.manager.query(
+        `INSERT INTO feature_amounts_per_planning_unit (project_id, feature_id, amount, project_pu_id)
+                SELECT $1, $2, amount, project_pu_id
+                FROM features_data where feature_id = $2`,
+        [projectId, newFeature.id],
       );
     }
     this.logger.log(


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/MRXN23-609

This is only a fix for the bug. I recommend to add a migration that fixes existing duplicated data as a separate PR, to keep things manageable and fast-track this fix (if approved) to production.

There are no tests with this fix. It's going to be complicated to test this exhaustively within a limited development effort.