### PR TITLE
infra(chore): update bastion host vm setup [MRXNM-52]

### DIFF
--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -39,6 +39,7 @@ module "bastion" {
   project_name            = var.project_name
   bastion_ssh_public_keys = var.bastion_ssh_public_keys
   bastion_subnet_id       = module.network.bastion_subnet_id
+  bastion_nsg_id          = module.network.bastion_nsg_id
   dns_zone                = module.dns.dns_zone
 }
 

--- a/infrastructure/base/modules/bastion/main.tf
+++ b/infrastructure/base/modules/bastion/main.tf
@@ -69,8 +69,8 @@ resource "azurerm_linux_virtual_machine" "bastion" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-focal"
-    sku       = "20_04-lts"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "minimal"
     version   = "latest"
   }
 

--- a/infrastructure/base/modules/bastion/main.tf
+++ b/infrastructure/base/modules/bastion/main.tf
@@ -23,6 +23,11 @@ resource "azurerm_network_interface" "bastion_nic" {
   }
 }
 
+resource "azurerm_network_interface_security_group_association" "bastion_nic_nsg_association" {
+  network_interface_id      = azurerm_network_interface.bastion_nic.id
+  network_security_group_id = var.bastion_nsg_id
+}
+
 resource "tls_private_key" "ssh_private_key" {
   algorithm = "RSA"
   rsa_bits  = 4096

--- a/infrastructure/base/modules/bastion/variables.tf
+++ b/infrastructure/base/modules/bastion/variables.tf
@@ -21,6 +21,10 @@ variable "bastion_subnet_id" {
   description = "The id of the subnet where the bastion host will be placed"
 }
 
+variable "bastion_nsg_id" {
+  description = "The id of the network security group for the bastion host"
+}
+
 variable "dns_zone" {
   description = "The Azure DNS zone where the bastion A record will be added"
 }

--- a/infrastructure/base/modules/network/outputs.tf
+++ b/infrastructure/base/modules/network/outputs.tf
@@ -26,6 +26,10 @@ output "bastion_subnet_id" {
   value = azurerm_subnet.bastion_subnet.id
 }
 
+output "bastion_nsg_id" {
+  value = azurerm_network_security_group.bastion_nsg.id
+}
+
 output "firewall_subnet_id" {
   value = azurerm_subnet.firewall_subnet.id
 }


### PR DESCRIPTION
- link bastion network security group (allows public ssh access on ipv4) to bastion host NIC
- add a small swapfile and enable it as swap when provisioning the bastion host VM
- use latest Ubuntu LTS base image

### Testing instructions

Re-creating the bastion host VM via Terraform should do all the above.

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/MRXNM-52

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist (`docs/deployment-checklist.md`)
- [ ] Update CHANGELOG file