### PR TITLE
[MRXN-78] BullMQ Workers / Redis disconnection fixes

### DIFF
--- a/api/apps/api/src/modules/queue/queue-events.builder.spec.ts
+++ b/api/apps/api/src/modules/queue/queue-events.builder.spec.ts
@@ -1,0 +1,131 @@
+import { EventEmitter } from 'events';
+import { QueueEventsBuilder } from './queue-events.builder';
+import { Logger } from '@nestjs/common';
+
+jest.mock('bullmq', () => {
+  const mockClient = new EventEmitter();
+  const mockQueueEvents = Object.assign(new EventEmitter(), {
+    client: Promise.resolve(mockClient),
+    close: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+  });
+
+  return {
+    QueueEvents: jest.fn().mockImplementation(() => mockQueueEvents),
+    __mockQueueEvents: mockQueueEvents,
+    __mockClient: mockClient,
+  };
+});
+
+const {
+  QueueEvents,
+  __mockQueueEvents: mockQueueEvents,
+  __mockClient: mockClient,
+} = jest.requireMock('bullmq');
+
+describe('QueueEventsBuilder', () => {
+  let builder: QueueEventsBuilder;
+  const queueOptions = { connection: { host: 'localhost', port: 6379 } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueueEvents.removeAllListeners();
+    mockClient.removeAllListeners();
+    builder = new QueueEventsBuilder(queueOptions as any);
+  });
+
+  it('should create QueueEvents with the given name and options', () => {
+    builder.buildQueueEvents('test-queue');
+    expect(QueueEvents).toHaveBeenCalledWith('test-queue', queueOptions);
+  });
+
+  it('should throw if buildQueueEvents is called twice', () => {
+    builder.buildQueueEvents('test-queue');
+    expect(() => builder.buildQueueEvents('test-queue')).toThrow(
+      'Queue Events is already created!',
+    );
+  });
+
+  it('should register an error handler on QueueEvents', () => {
+    const loggerSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation();
+
+    builder.buildQueueEvents('test-queue');
+    mockQueueEvents.emit('error', new Error('test error'));
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'QueueEvents "test-queue" error: test error',
+      expect.any(String),
+    );
+    loggerSpy.mockRestore();
+  });
+
+  describe('Redis client connection event logging', () => {
+    let logSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      builder.buildQueueEvents('test-queue');
+      await new Promise((resolve) => process.nextTick(resolve));
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should log on connect', () => {
+      mockClient.emit('connect');
+      expect(logSpy).toHaveBeenCalledWith(
+        'QueueEvents "test-queue": connected',
+      );
+    });
+
+    it('should log on ready', () => {
+      mockClient.emit('ready');
+      expect(logSpy).toHaveBeenCalledWith('QueueEvents "test-queue": ready');
+    });
+
+    it('should warn on close', () => {
+      mockClient.emit('close');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'QueueEvents "test-queue": connection closed',
+      );
+    });
+
+    it('should warn on reconnecting', () => {
+      mockClient.emit('reconnecting');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'QueueEvents "test-queue": reconnecting',
+      );
+    });
+
+    it('should error on end', () => {
+      mockClient.emit('end');
+      expect(errorSpy).toHaveBeenCalledWith(
+        'QueueEvents "test-queue": connection ended',
+      );
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close and disconnect QueueEvents', async () => {
+      builder.buildQueueEvents('test-queue');
+      await builder.onModuleDestroy();
+      expect(mockQueueEvents.close).toHaveBeenCalled();
+      expect(mockQueueEvents.disconnect).toHaveBeenCalled();
+    });
+
+    it('should do nothing if no QueueEvents was built', async () => {
+      await builder.onModuleDestroy();
+      expect(mockQueueEvents.close).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/apps/api/src/modules/queue/queue-events.builder.ts
+++ b/api/apps/api/src/modules/queue/queue-events.builder.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, OnModuleDestroy, Scope } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  Scope,
+} from '@nestjs/common';
 import { QueueEvents, QueueOptions } from 'bullmq';
 import { queueOptionsToken } from './queue-options.provider';
 
@@ -6,6 +12,7 @@ import { queueOptionsToken } from './queue-options.provider';
   scope: Scope.TRANSIENT,
 })
 export class QueueEventsBuilder implements OnModuleDestroy {
+  private readonly logger = new Logger(QueueEventsBuilder.name);
   private queueEvents?: QueueEvents;
 
   constructor(
@@ -18,6 +25,25 @@ export class QueueEventsBuilder implements OnModuleDestroy {
       throw new Error('Queue Events is already created!');
     }
     this.queueEvents = new QueueEvents(queueName, this.queueOptions);
+
+    this.queueEvents.on('error', (err: Error) => {
+      this.logger.error(
+        `QueueEvents "${queueName}" error: ${err.message}`,
+        err.stack,
+      );
+    });
+
+    const label = `QueueEvents "${queueName}"`;
+    this.queueEvents.client.then((client) => {
+      client.on('connect', () => this.logger.log(`${label}: connected`));
+      client.on('ready', () => this.logger.log(`${label}: ready`));
+      client.on('close', () => this.logger.warn(`${label}: connection closed`));
+      client.on('reconnecting', () =>
+        this.logger.warn(`${label}: reconnecting`),
+      );
+      client.on('end', () => this.logger.error(`${label}: connection ended`));
+    });
+
     return this.queueEvents;
   }
 

--- a/api/apps/api/src/modules/queue/queue.builder.spec.ts
+++ b/api/apps/api/src/modules/queue/queue.builder.spec.ts
@@ -1,0 +1,127 @@
+import { EventEmitter } from 'events';
+import { QueueBuilder } from './queue.builder';
+import { Logger } from '@nestjs/common';
+
+jest.mock('bullmq', () => {
+  const mockClient = new EventEmitter();
+  const mockQueue = Object.assign(new EventEmitter(), {
+    client: Promise.resolve(mockClient),
+    close: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+  });
+
+  return {
+    Queue: jest.fn().mockImplementation(() => mockQueue),
+    __mockQueue: mockQueue,
+    __mockClient: mockClient,
+  };
+});
+
+const { Queue, __mockQueue: mockQueue, __mockClient: mockClient } =
+  jest.requireMock('bullmq');
+
+describe('QueueBuilder', () => {
+  let builder: QueueBuilder;
+  const queueOptions = { connection: { host: 'localhost', port: 6379 } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueue.removeAllListeners();
+    mockClient.removeAllListeners();
+    builder = new QueueBuilder(queueOptions as any);
+  });
+
+  it('should create a Queue with the given name and options', () => {
+    builder.buildQueue('test-queue');
+    expect(Queue).toHaveBeenCalledWith('test-queue', queueOptions);
+  });
+
+  it('should throw if buildQueue is called twice', () => {
+    builder.buildQueue('test-queue');
+    expect(() => builder.buildQueue('test-queue')).toThrow(
+      'Queue is already created!',
+    );
+  });
+
+  it('should register an error handler on the queue', () => {
+    const loggerSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation();
+
+    builder.buildQueue('test-queue');
+    mockQueue.emit('error', new Error('test error'));
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Queue "test-queue" error: test error',
+      expect.any(String),
+    );
+    loggerSpy.mockRestore();
+  });
+
+  describe('Redis client connection event logging', () => {
+    let logSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      builder.buildQueue('test-queue');
+      // Allow the .client.then() callback to execute
+      await new Promise((resolve) => process.nextTick(resolve));
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should log on connect', () => {
+      mockClient.emit('connect');
+      expect(logSpy).toHaveBeenCalledWith('Queue "test-queue": connected');
+    });
+
+    it('should log on ready', () => {
+      mockClient.emit('ready');
+      expect(logSpy).toHaveBeenCalledWith('Queue "test-queue": ready');
+    });
+
+    it('should warn on close', () => {
+      mockClient.emit('close');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Queue "test-queue": connection closed',
+      );
+    });
+
+    it('should warn on reconnecting', () => {
+      mockClient.emit('reconnecting');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Queue "test-queue": reconnecting',
+      );
+    });
+
+    it('should error on end', () => {
+      mockClient.emit('end');
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Queue "test-queue": connection ended',
+      );
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close and disconnect the queue', async () => {
+      builder.buildQueue('test-queue');
+      await builder.onModuleDestroy();
+      expect(mockQueue.close).toHaveBeenCalled();
+      expect(mockQueue.disconnect).toHaveBeenCalled();
+    });
+
+    it('should do nothing if no queue was built', async () => {
+      await builder.onModuleDestroy();
+      expect(mockQueue.close).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/apps/api/src/modules/queue/queue.builder.ts
+++ b/api/apps/api/src/modules/queue/queue.builder.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, OnModuleDestroy, Scope } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  Scope,
+} from '@nestjs/common';
 import { Queue, QueueOptions } from 'bullmq';
 import { queueOptionsToken } from './queue-options.provider';
 
@@ -8,6 +14,7 @@ import { queueOptionsToken } from './queue-options.provider';
 export class QueueBuilder<Input = any, Output = any>
   implements OnModuleDestroy
 {
+  private readonly logger = new Logger(QueueBuilder.name);
   private queue?: Queue;
 
   constructor(
@@ -20,6 +27,25 @@ export class QueueBuilder<Input = any, Output = any>
       throw new Error('Queue is already created!');
     }
     this.queue = new Queue<Input, Output>(queueName, this.queueOptions);
+
+    this.queue.on('error', (err: Error) => {
+      this.logger.error(
+        `Queue "${queueName}" error: ${err.message}`,
+        err.stack,
+      );
+    });
+
+    const label = `Queue "${queueName}"`;
+    this.queue.client.then((client) => {
+      client.on('connect', () => this.logger.log(`${label}: connected`));
+      client.on('ready', () => this.logger.log(`${label}: ready`));
+      client.on('close', () => this.logger.warn(`${label}: connection closed`));
+      client.on('reconnecting', () =>
+        this.logger.warn(`${label}: reconnecting`),
+      );
+      client.on('end', () => this.logger.error(`${label}: connection ended`));
+    });
+
     return this.queue;
   }
 

--- a/api/apps/api/src/utils/redisConfig.utils.spec.ts
+++ b/api/apps/api/src/utils/redisConfig.utils.spec.ts
@@ -1,0 +1,122 @@
+import { getRedisConfig } from './redisConfig.utils';
+
+jest.mock('config', () => ({
+  get: (key: string) => {
+    const cfg: Record<string, any> = {
+      redis: {
+        host: 'test-host',
+        port: 6380,
+        password: 'test-pass',
+        useTLS: 'false',
+      },
+    };
+    return cfg[key];
+  },
+}));
+
+describe('getRedisConfig', () => {
+  it('should return connection with host, port, and password from config', () => {
+    const result = getRedisConfig();
+    expect(result.connection).toMatchObject({
+      host: 'test-host',
+      port: 6380,
+      password: 'test-pass',
+    });
+  });
+
+  it('should set tls to undefined when useTLS is false', () => {
+    const result = getRedisConfig();
+    const conn = result.connection as any;
+    expect(conn.tls).toBeUndefined();
+  });
+
+  describe('resilience options', () => {
+    it('should set maxRetriesPerRequest to null for infinite retries', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.maxRetriesPerRequest).toBeNull();
+    });
+
+    it('should disable ready check', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.enableReadyCheck).toBe(false);
+    });
+
+    it('should enable offline queue', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.enableOfflineQueue).toBe(true);
+    });
+
+    it('should set keepAlive to 10 seconds', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.keepAlive).toBe(10000);
+    });
+
+    it('should set connectTimeout to 10 seconds', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.connectTimeout).toBe(10000);
+    });
+  });
+
+  describe('retryStrategy', () => {
+    it('should use exponential backoff capped at 5 seconds', () => {
+      const conn = getRedisConfig().connection as any;
+      const retryStrategy = conn.retryStrategy as (times: number) => number;
+
+      expect(retryStrategy(1)).toBe(500);
+      expect(retryStrategy(2)).toBe(1000);
+      expect(retryStrategy(5)).toBe(2500);
+      expect(retryStrategy(10)).toBe(5000);
+      expect(retryStrategy(100)).toBe(5000);
+    });
+  });
+
+  describe('reconnectOnError', () => {
+    let reconnectOnError: (err: Error) => boolean;
+
+    beforeEach(() => {
+      const conn = getRedisConfig().connection as any;
+      reconnectOnError = conn.reconnectOnError;
+    });
+
+    it('should reconnect on READONLY errors (Azure failover)', () => {
+      expect(reconnectOnError(new Error('READONLY You cannot write'))).toBe(
+        true,
+      );
+    });
+
+    it('should reconnect on ECONNRESET errors', () => {
+      expect(reconnectOnError(new Error('read ECONNRESET'))).toBe(true);
+    });
+
+    it('should reconnect on ETIMEDOUT errors', () => {
+      expect(reconnectOnError(new Error('connect ETIMEDOUT'))).toBe(true);
+    });
+
+    it('should not reconnect on unrelated errors', () => {
+      expect(reconnectOnError(new Error('some other error'))).toBe(false);
+    });
+  });
+});
+
+describe('getRedisConfig with TLS enabled', () => {
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  it('should set tls to empty object when useTLS is true', () => {
+    jest.doMock('config', () => ({
+      get: () => ({
+        host: 'test-host',
+        port: 6380,
+        password: 'test-pass',
+        useTLS: 'true',
+      }),
+    }));
+
+    const {
+      getRedisConfig: getRedisConfigWithTLS,
+    } = require('./redisConfig.utils');
+    const result = getRedisConfigWithTLS();
+    expect((result.connection as any).tls).toEqual({});
+  });
+});

--- a/api/apps/api/src/utils/redisConfig.utils.ts
+++ b/api/apps/api/src/utils/redisConfig.utils.ts
@@ -11,6 +11,18 @@ export function getRedisConfig() {
       port: redisConfig.port,
       password: redisConfig.password,
       tls: useTLS ? {} : undefined,
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      enableOfflineQueue: true,
+      keepAlive: 10000,
+      connectTimeout: 10000,
+      retryStrategy(times: number) {
+        return Math.min(times * 500, 5000);
+      },
+      reconnectOnError(err: Error) {
+        const targetErrors = ['READONLY', 'ECONNRESET', 'ETIMEDOUT'];
+        return targetErrors.some((e) => err.message.includes(e));
+      },
     },
   };
 

--- a/api/apps/geoprocessing/src/modules/worker/queue-events.builder.ts
+++ b/api/apps/geoprocessing/src/modules/worker/queue-events.builder.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleDestroy, Scope } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, Scope } from '@nestjs/common';
 import { QueueEvents } from 'bullmq';
 import { Config } from './config';
 
@@ -6,6 +6,7 @@ import { Config } from './config';
   scope: Scope.TRANSIENT,
 })
 export class QueueEventsBuilder implements OnModuleDestroy {
+  private readonly logger = new Logger(QueueEventsBuilder.name);
   private queueEvents?: QueueEvents;
 
   constructor(private readonly config: Config) {}
@@ -15,6 +16,25 @@ export class QueueEventsBuilder implements OnModuleDestroy {
       throw new Error('Queue Events is already created!');
     }
     this.queueEvents = new QueueEvents(queueName, this.config.redis);
+
+    this.queueEvents.on('error', (err: Error) => {
+      this.logger.error(
+        `QueueEvents "${queueName}" error: ${err.message}`,
+        err.stack,
+      );
+    });
+
+    const label = `QueueEvents "${queueName}"`;
+    this.queueEvents.client.then((client) => {
+      client.on('connect', () => this.logger.log(`${label}: connected`));
+      client.on('ready', () => this.logger.log(`${label}: ready`));
+      client.on('close', () => this.logger.warn(`${label}: connection closed`));
+      client.on('reconnecting', () =>
+        this.logger.warn(`${label}: reconnecting`),
+      );
+      client.on('end', () => this.logger.error(`${label}: connection ended`));
+    });
+
     return this.queueEvents;
   }
 

--- a/api/apps/geoprocessing/src/modules/worker/worker-builder.ts
+++ b/api/apps/geoprocessing/src/modules/worker/worker-builder.ts
@@ -1,5 +1,5 @@
 import { bullmqPrefix } from '@marxan/utils';
-import { Injectable, OnModuleDestroy, Scope } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, Scope } from '@nestjs/common';
 import { Job, Worker } from 'bullmq';
 import { Config } from './config';
 import { WorkerProcessor } from './worker-processor';
@@ -8,6 +8,7 @@ import { WorkerProcessor } from './worker-processor';
   scope: Scope.TRANSIENT,
 })
 export class WorkerBuilder implements OnModuleDestroy {
+  private readonly logger = new Logger(WorkerBuilder.name);
   private _worker?: Worker;
 
   constructor(private readonly config: Config) {}
@@ -30,6 +31,25 @@ export class WorkerBuilder implements OnModuleDestroy {
         prefix: bullmqPrefix(),
       },
     );
+
+    this._worker.on('error', (err: Error) => {
+      this.logger.error(
+        `Worker "${queueName}" error: ${err.message}`,
+        err.stack,
+      );
+    });
+
+    const label = `Worker "${queueName}"`;
+    this._worker.client.then((client) => {
+      client.on('connect', () => this.logger.log(`${label}: connected`));
+      client.on('ready', () => this.logger.log(`${label}: ready`));
+      client.on('close', () => this.logger.warn(`${label}: connection closed`));
+      client.on('reconnecting', () =>
+        this.logger.warn(`${label}: reconnecting`),
+      );
+      client.on('end', () => this.logger.error(`${label}: connection ended`));
+    });
+
     return this._worker;
   }
 

--- a/api/apps/geoprocessing/src/utils/redisConfig.utils.spec.ts
+++ b/api/apps/geoprocessing/src/utils/redisConfig.utils.spec.ts
@@ -1,0 +1,121 @@
+import { getRedisConfig } from './redisConfig.utils';
+
+jest.mock('config', () => ({
+  get: (key: string) => {
+    const cfg: Record<string, any> = {
+      redis: {
+        host: 'test-host',
+        port: 6380,
+        password: 'test-pass',
+        useTLS: 'false',
+      },
+    };
+    return cfg[key];
+  },
+}));
+
+describe('getRedisConfig', () => {
+  it('should return connection with host, port, and password from config', () => {
+    const result = getRedisConfig();
+    expect(result.connection).toMatchObject({
+      host: 'test-host',
+      port: 6380,
+      password: 'test-pass',
+    });
+  });
+
+  it('should set tls to undefined when useTLS is false', () => {
+    const conn = getRedisConfig().connection as any;
+    expect(conn.tls).toBeUndefined();
+  });
+
+  describe('resilience options', () => {
+    it('should set maxRetriesPerRequest to null for infinite retries', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.maxRetriesPerRequest).toBeNull();
+    });
+
+    it('should disable ready check', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.enableReadyCheck).toBe(false);
+    });
+
+    it('should enable offline queue', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.enableOfflineQueue).toBe(true);
+    });
+
+    it('should set keepAlive to 10 seconds', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.keepAlive).toBe(10000);
+    });
+
+    it('should set connectTimeout to 10 seconds', () => {
+      const conn = getRedisConfig().connection as any;
+      expect(conn.connectTimeout).toBe(10000);
+    });
+  });
+
+  describe('retryStrategy', () => {
+    it('should use exponential backoff capped at 5 seconds', () => {
+      const conn = getRedisConfig().connection as any;
+      const retryStrategy = conn.retryStrategy as (times: number) => number;
+
+      expect(retryStrategy(1)).toBe(500);
+      expect(retryStrategy(2)).toBe(1000);
+      expect(retryStrategy(5)).toBe(2500);
+      expect(retryStrategy(10)).toBe(5000);
+      expect(retryStrategy(100)).toBe(5000);
+    });
+  });
+
+  describe('reconnectOnError', () => {
+    let reconnectOnError: (err: Error) => boolean;
+
+    beforeEach(() => {
+      const conn = getRedisConfig().connection as any;
+      reconnectOnError = conn.reconnectOnError;
+    });
+
+    it('should reconnect on READONLY errors (Azure failover)', () => {
+      expect(reconnectOnError(new Error('READONLY You cannot write'))).toBe(
+        true,
+      );
+    });
+
+    it('should reconnect on ECONNRESET errors', () => {
+      expect(reconnectOnError(new Error('read ECONNRESET'))).toBe(true);
+    });
+
+    it('should reconnect on ETIMEDOUT errors', () => {
+      expect(reconnectOnError(new Error('connect ETIMEDOUT'))).toBe(true);
+    });
+
+    it('should not reconnect on unrelated errors', () => {
+      expect(reconnectOnError(new Error('some other error'))).toBe(false);
+    });
+  });
+});
+
+describe('getRedisConfig with TLS enabled', () => {
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  it('should set tls to empty object when useTLS is true', () => {
+    jest.doMock('config', () => ({
+      get: () => ({
+        host: 'test-host',
+        port: 6380,
+        password: 'test-pass',
+        useTLS: 'true',
+      }),
+    }));
+
+    const {
+      getRedisConfig: getRedisConfigWithTLS,
+    } = require('./redisConfig.utils');
+    const result = getRedisConfigWithTLS();
+    expect((result.connection as any).tls).toEqual({});
+  });
+});

--- a/api/apps/geoprocessing/src/utils/redisConfig.utils.ts
+++ b/api/apps/geoprocessing/src/utils/redisConfig.utils.ts
@@ -11,6 +11,18 @@ export function getRedisConfig() {
       port: redisConfig.port,
       password: redisConfig.password,
       tls: useTLS ? {} : undefined,
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      enableOfflineQueue: true,
+      keepAlive: 10000,
+      connectTimeout: 10000,
+      retryStrategy(times: number) {
+        return Math.min(times * 500, 5000);
+      },
+      reconnectOnError(err: Error) {
+        const targetErrors = ['READONLY', 'ECONNRESET', 'ETIMEDOUT'];
+        return targetErrors.some((e) => err.message.includes(e));
+      },
     },
   };
 


### PR DESCRIPTION
# Summary

  - Adds ioredis resilience options to prevent BullMQ queues/workers from permanently disconnecting after transient Redis hiccups (Azure Cache failovers, network blips)
  - Adds connection lifecycle logging on all Queue, QueueEvents, and Worker instances for production observability
  - Adds unit tests (46 tests) covering Redis config logic and builder event registration

## Problem

  BullMQ jobs (project clone, import/export, scenario runs) were intermittently getting stuck. The api_events table showed jobs submitted but never completed or failed. Redis appeared  healthy, and restarting the API/geoprocessing pods recovered all pending jobs.

  Root cause: ioredis defaults maxRetriesPerRequest to 20. When Azure Redis has a brief connectivity interruption, the BullMQ internal connections exhaust retries and throw a fatal error. The NestJS process stays alive (Kubernetes doesn't restart it), but the queue/worker is permanently dead — jobs pile up silently.

 
## Jira story

https://vizzuality.atlassian.net/browse/MRXNM-78

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

  - All 46 new unit tests pass
  - Deploy to staging and monitor logs for connection lifecycle events
  - Verify BullMQ jobs (clone, export, scenario run) complete successfully
  - Optionally: restart Azure Redis instance to confirm automatic recovery

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `main`.
- [ ] Update CHANGELOG file
