### PR TITLE
fix(infra): switch CI image push to ACR token-based auth [MRXNM-55]

### DIFF
--- a/.github/workflows/publish-marxan-docker-images.yml
+++ b/.github/workflows/publish-marxan-docker-images.yml
@@ -1,7 +1,6 @@
 name: Publish Marxan Docker images
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -57,19 +56,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: "Login via Azure CLI"
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Build and push image
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.REGISTRY_LOGIN_SERVER }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ vars.REGISTRY_TOKEN_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN_PASSWORD }}
 
       - run: |
           docker build ./api -f api/api.Dockerfile \
@@ -85,19 +77,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Login via Azure CLI
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Build and push image
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.REGISTRY_LOGIN_SERVER }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ vars.REGISTRY_TOKEN_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN_PASSWORD }}
 
       - run: |
           docker build ./api -f api/geo.Dockerfile \
@@ -114,19 +99,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Login via Azure CLI
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Build and push image
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.REGISTRY_LOGIN_SERVER }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ vars.REGISTRY_TOKEN_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN_PASSWORD }}
 
       - run: |
           docker build ./app \

--- a/.github/workflows/publish-webshot-docker-images.yml
+++ b/.github/workflows/publish-webshot-docker-images.yml
@@ -1,7 +1,6 @@
 name: Publish Webshot Docker image
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -24,19 +23,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Login via Azure CLI
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Build and push image
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.REGISTRY_LOGIN_SERVER }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ vars.REGISTRY_TOKEN_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN_PASSWORD }}
 
       - run: |
           docker build ./webshot \

--- a/.github/workflows/test-acr-token-login.yml
+++ b/.github/workflows/test-acr-token-login.yml
@@ -1,0 +1,22 @@
+name: Test ACR login via token
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test_acr_token_login:
+    name: Test ACR token login
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Log in to ACR via token
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.REGISTRY_LOGIN_SERVER }}
+          username: ${{ vars.REGISTRY_TOKEN_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN_PASSWORD }}
+
+      - name: Verify - pull an existing image
+        run: docker pull ${{ vars.REGISTRY_LOGIN_SERVER }}/marxan-api:staging || echo "Pull failed or image not found"

--- a/README.md
+++ b/README.md
@@ -453,9 +453,16 @@ and [variables](https://docs.github.com/en/actions/learn-github-actions/variable
 
 **For pushing Docker images to ACR (using ACR token-based auth):**
 
+Docker images are pushed to the Azure Container Registry using an ACR scope-map
+token (`_repositories_push`), which provides a cloud-agnostic username/password
+for `docker login` without depending on Azure AD service principal credentials.
+
 - `REGISTRY_LOGIN_SERVER` (variable): Obtain from Terraform's `azurerm_container_registry_login_server` output
 - `REGISTRY_TOKEN_USERNAME` (variable): Obtain from Terraform's `registry_token_username` output
 - `REGISTRY_TOKEN_PASSWORD` (secret): Obtain from Terraform's `registry_token_password` output
+
+> **Note:** the token password is currently set to not expire. A possible
+> improvement is to research how to get a rotating password mechanism working.
 
 **For deploying to Kubernetes (using OIDC federated credentials):**
 

--- a/README.md
+++ b/README.md
@@ -448,15 +448,20 @@ For code merged to key branches (currently `main` and `develop`), once tests run
 successfully, [Docker](https://www.docker.com/) images are built and pushed to a 
 private [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/).
 
-The GitHub Actions workflows currently configured requires a few [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-to be set on GitHub in order to work properly:
+The GitHub Actions workflows currently configured require a few [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+and [variables](https://docs.github.com/en/actions/learn-github-actions/variables) to be set on GitHub in order to work properly:
 
-- `AZURE_CLIENT_ID`: Obtain from Terraform's `azure_client_id` output
-- `AZURE_TENANT_ID`: Obtain from Terraform's `azure_tenant_id` output
-- `AZURE_SUBSCRIPTION_ID`: Obtain from Terraform's `azure_subscription_id` output
-- `REGISTRY_LOGIN_SERVER`: Obtain from Terraform's `azurerm_container_registry_login_server` output
-- `REGISTRY_USERNAME`: Obtain from Terraform's `azure_client_id` output
-- `REGISTRY_PASSWORD`: Obtain from Terraform's `azuread_application_password` output
+**For pushing Docker images to ACR (using ACR token-based auth):**
+
+- `REGISTRY_LOGIN_SERVER` (variable): Obtain from Terraform's `azurerm_container_registry_login_server` output
+- `REGISTRY_TOKEN_USERNAME` (variable): Obtain from Terraform's `registry_token_username` output
+- `REGISTRY_TOKEN_PASSWORD` (secret): Obtain from Terraform's `registry_token_password` output
+
+**For deploying to Kubernetes (using OIDC federated credentials):**
+
+- `AZURE_CLIENT_ID` (secret): Obtain from Terraform's `azure_client_id` output
+- `AZURE_TENANT_ID` (secret): Obtain from Terraform's `azure_tenant_id` output
+- `AZURE_SUBSCRIPTION_ID` (secret): Obtain from Terraform's `azure_subscription_id` output
 
 Some of these values are obtained from Terraform output values, which will be documented
 in more detail in the [Infrastructure](#infrastructure) docs.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -99,7 +99,13 @@ the services on kubernetes, which is done by this plan.
 
 As part of this infrastructure, Github Actions are used to automatically build
 and push Docker images to Azure ACR, and to redeploy Kubernetes pods once that
-happens. Said Github Actions depend on specific Github Secrets and Variables,
+happens. Docker image push uses ACR token-based authentication (scope-map token
+with `_repositories_push` permissions), which provides a cloud-agnostic
+username/password for `docker login` without depending on Azure AD service
+principal credentials. Kubernetes deployments use OIDC federated credentials
+for Azure CLI login.
+
+Said Github Actions depend on specific Github Secrets and Variables,
 that are listed below for reference.
 
 Secrets and variables listed below are automatically created by the `base`
@@ -130,6 +136,12 @@ creation of an AKS cluster.
 - `BASTION_USER`: By default this will be `ubuntu` if using the initial user created on bastion host instantiation. It is configurable in case infrastructure admins wish to configure a different user on the bastion host or the default distro user is renamed.
 - `REGISTRY_LOGIN_SERVER`: The hostname for the Azure ACR. Get from `Base`'s `container_registry_hostname`
 - `REGISTRY_TOKEN_USERNAME`: The ACR token username for pushing Docker images. Get from `Base`'s `registry_token_username`
+
+> **Note:** the ACR token password is currently set to not expire. A possible
+> improvement is to research how to get a rotating password mechanism working.
+> Legacy secrets `REGISTRY_PASSWORD` and `REGISTRY_USERNAME` (based on Azure AD
+> service principal credentials) are still present but no longer used by CI
+> workflows and are pending removal.
 
 Additional Github Actions Secrets are needed, as required by the [frontend application](../app/README.md#env-variables)
 and used by the corresponding [Github workflow](../.github/workflows/publish-marxan-docker-images.yml) that builds

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -115,11 +115,11 @@ creation of an AKS cluster.
 
 ##### Secrets
 
-- `AZURE_CLIENT_ID`: The hostname for the Azure ACT. Get from `Base`'s `container_registry_client_id`
+- `AZURE_CLIENT_ID`: The client ID of the Azure AD application used for OIDC login to Azure (for K8s deployments). Get from `Base`'s `container_registry_client_id`
 - `AZURE_SUBSCRIPTION_ID`: The Azure Subscription Id. Get from `Base`'s `azure_subscription_id`
 - `AZURE_TENANT_ID`: The Azure Tenant Id. Get from `Base`'s `azure_tenant_id`
 - `BASTION_SSH_PRIVATE_KEY`: The ssh private key to access the bastion host. Get it by connection to the bastion host using SSH, and generating a new public/private SSH key pair.
-- `REGISTRY_PASSWORD`: The password to access the Azure. Get from `Base`'s `container_registry_password`
+- `REGISTRY_TOKEN_PASSWORD`: The ACR token password for pushing Docker images. Get from `Base`'s `registry_token_password`
 
 ##### Variables
 
@@ -129,7 +129,7 @@ creation of an AKS cluster.
 - `BASTION_HOST`: The hostname for the bastion machine. Get from `Base`'s `bastion_hostname`
 - `BASTION_USER`: By default this will be `ubuntu` if using the initial user created on bastion host instantiation. It is configurable in case infrastructure admins wish to configure a different user on the bastion host or the default distro user is renamed.
 - `REGISTRY_LOGIN_SERVER`: The hostname for the Azure ACR. Get from `Base`'s `container_registry_hostname`
-- `REGISTRY_USERNAME`: The username for the Azure ACR. Get from `Base`'s `container_registry_client_id`
+- `REGISTRY_TOKEN_USERNAME`: The ACR token username for pushing Docker images. Get from `Base`'s `registry_token_username`
 
 Additional Github Actions Secrets are needed, as required by the [frontend application](../app/README.md#env-variables)
 and used by the corresponding [Github workflow](../.github/workflows/publish-marxan-docker-images.yml) that builds

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -107,8 +107,8 @@ module "github_secrets" {
   bastion_user            = module.bastion.bastion_user
   client_id               = module.container_registry.azure_client_id
   registry_login_server   = module.container_registry.azurerm_container_registry_login_server
-  registry_password       = module.container_registry.azuread_application_password
-  registry_username       = module.container_registry.azure_client_id
+  registry_password       = module.container_registry.azuread_application_password  # TODO: remove once the ACR token login is approved and integrated
+  registry_username       = module.container_registry.azure_client_id              # TODO: remove once the ACR token login is approved and integrated
   repo_name               = var.github_repo
   resource_group_name     = data.azurerm_resource_group.resource_group.name
   subscription_id         = data.azurerm_subscription.subscription.subscription_id
@@ -116,6 +116,9 @@ module "github_secrets" {
   mapbox_api_token        = var.mapbox_api_token
   domain                  = var.domain
   support_email           = var.support_email
+  registry_name           = module.container_registry.azurerm_container_registry_name
+  registry_token_username = module.container_registry.registry_token_username
+  registry_token_password = module.container_registry.registry_token_password
 }
 
 module "log_analytics_workspace" {

--- a/infrastructure/base/modules/container-registry/main.tf
+++ b/infrastructure/base/modules/container-registry/main.tf
@@ -58,10 +58,12 @@ resource "azurerm_role_assignment" "resource-group-contributor" {
   principal_id         = azuread_service_principal.github-actions-access.object_id
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 resource "azuread_application_password" "github-actions-access" {
   application_object_id = azuread_application.github-actions-access.object_id
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 resource "azurerm_role_assignment" "acr-push" {
   scope                = azurerm_container_registry.acr.id
   role_definition_name = "AcrPush"
@@ -84,4 +86,24 @@ resource "azuread_application_federated_identity_credential" "github-actions-acc
   audiences             = ["api://AzureADTokenExchange"]
   issuer                = "https://token.actions.githubusercontent.com"
   subject               = "repo:${var.github_org}/${var.github_repo}:ref:refs/heads/${var.github_production_branch}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ACR token-based authentication for CI image push
+#
+# This provides a cloud-agnostic username/password for docker login, independent
+# of the Azure AD service principal above. Uses the built-in _repositories_push
+# scope map (read + write on all repositories).
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "azurerm_container_registry_token" "ci_push" {
+  name                    = "ci-push"
+  container_registry_name = azurerm_container_registry.acr.name
+  resource_group_name     = var.resource_group.name
+  scope_map_id            = "${azurerm_container_registry.acr.id}/scopeMaps/_repositories_push"
+}
+
+resource "azurerm_container_registry_token_password" "ci_push" {
+  container_registry_token_id = azurerm_container_registry_token.ci_push.id
+  password1 {}
 }

--- a/infrastructure/base/modules/container-registry/main.tf
+++ b/infrastructure/base/modules/container-registry/main.tf
@@ -103,6 +103,8 @@ resource "azurerm_container_registry_token" "ci_push" {
   scope_map_id            = "${azurerm_container_registry.acr.id}/scopeMaps/_repositories_push"
 }
 
+# TODO: the current token password is set to not expire; a possible improvement
+# is to research how to get a rotating password mechanism working.
 resource "azurerm_container_registry_token_password" "ci_push" {
   container_registry_token_id = azurerm_container_registry_token.ci_push.id
   password1 {}

--- a/infrastructure/base/modules/container-registry/outputs.tf
+++ b/infrastructure/base/modules/container-registry/outputs.tf
@@ -18,11 +18,29 @@ output "azure_client_id" {
   value = azuread_service_principal.github-actions-access.application_id
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 output "azuread_application_username" {
   value = nonsensitive(azuread_application_password.github-actions-access.value)
 }
 
-
+# TODO: remove once the ACR token login is approved and integrated
 output "azuread_application_password" {
   value = nonsensitive(azuread_application_password.github-actions-access.value)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ACR token-based authentication outputs
+# ──────────────────────────────────────────────────────────────────────────────
+
+output "azurerm_container_registry_name" {
+  value = azurerm_container_registry.acr.name
+}
+
+output "registry_token_username" {
+  value = azurerm_container_registry_token.ci_push.name
+}
+
+output "registry_token_password" {
+  value     = azurerm_container_registry_token_password.ci_push.password1[0].value
+  sensitive = true
 }

--- a/infrastructure/base/modules/github_secrets/main.tf
+++ b/infrastructure/base/modules/github_secrets/main.tf
@@ -136,6 +136,8 @@ resource "github_actions_variable" "registry_token_username" {
   value         = var.registry_token_username
 }
 
+# TODO: the current token password is set to not expire; a possible improvement
+# is to research how to get a rotating password mechanism working.
 resource "github_actions_secret" "registry_token_password" {
   repository      = var.repo_name
   secret_name     = "REGISTRY_TOKEN_PASSWORD"

--- a/infrastructure/base/modules/github_secrets/main.tf
+++ b/infrastructure/base/modules/github_secrets/main.tf
@@ -58,12 +58,14 @@ resource "github_actions_variable" "registry_login_server" {
   value            = var.registry_login_server
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 resource "github_actions_secret" "registry_password" {
   repository       = var.repo_name
   secret_name      = "REGISTRY_PASSWORD"
   plaintext_value  = var.registry_password
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 resource "github_actions_variable" "registry_username" {
   repository       = var.repo_name
   variable_name    = "REGISTRY_USERNAME"
@@ -116,4 +118,26 @@ resource "github_actions_variable" "nextauth_url_staging" {
   repository       = var.repo_name
   variable_name    = "NEXTAUTH_URL_STAGING"
   value            = "https://client.staging.${var.domain}"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ACR token-based authentication
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "github_actions_variable" "registry_name" {
+  repository    = var.repo_name
+  variable_name = "REGISTRY_NAME"
+  value         = var.registry_name
+}
+
+resource "github_actions_variable" "registry_token_username" {
+  repository    = var.repo_name
+  variable_name = "REGISTRY_TOKEN_USERNAME"
+  value         = var.registry_token_username
+}
+
+resource "github_actions_secret" "registry_token_password" {
+  repository      = var.repo_name
+  secret_name     = "REGISTRY_TOKEN_PASSWORD"
+  plaintext_value = var.registry_token_password
 }

--- a/infrastructure/base/modules/github_secrets/variables.tf
+++ b/infrastructure/base/modules/github_secrets/variables.tf
@@ -42,10 +42,12 @@ variable "registry_login_server" {
   type = string
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 variable "registry_password" {
   type = string
 }
 
+# TODO: remove once the ACR token login is approved and integrated
 variable "registry_username" {
   type = string
 }
@@ -62,4 +64,21 @@ variable "domain" {
 variable "support_email" {
   type = string
   description = "Email address to which users can send support requests"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ACR token-based authentication
+# ──────────────────────────────────────────────────────────────────────────────
+
+variable "registry_name" {
+  type = string
+}
+
+variable "registry_token_username" {
+  type = string
+}
+
+variable "registry_token_password" {
+  type      = string
+  sensitive = true
 }


### PR DESCRIPTION
## Summary

- Replaces broken Azure AD service principal password auth with ACR token-based credentials for Docker image push in CI
- Adds `azurerm_container_registry_token` and `azurerm_container_registry_token_password` Tofu resources alongside existing SP resources (kept as fallback)
- Updates `publish-marxan-docker-images` and `publish-webshot-docker-images` workflows to use `REGISTRY_TOKEN_USERNAME` / `REGISTRY_TOKEN_PASSWORD`
- Removes `azure/login` OIDC step and `id-token:write` permission from publish workflows (no longer needed for image push)
- Old SP-based resources marked with `TODO: remove once the ACR token login is approved and integrated`

## Context

The Azure AD application password used for `docker/login-action` stopped working, and recreating it via `tofu taint` failed with a 409 due to changed Azure AD permissions. ACR token-based auth is cloud-agnostic (plain username/password) and doesn't depend on Azure AD.

## Test plan

- [ ] Set `REGISTRY_TOKEN_USERNAME` and `REGISTRY_TOKEN_PASSWORD` manually in GitHub (from the manually created ACR token)
- [ ] Run `test-acr-token-login` workflow to verify token-based Docker login works
- [ ] Run `publish-marxan-docker-images` workflow via `workflow_dispatch` to verify full image build+push
- [ ] Apply Tofu changes with `-target` to create the token resources in state
- [ ] Once validated, remove old SP password resources marked with TODO