### PR TITLE
fix(webshot): skip Puppeteer Chromium download, use system Chrome

### DIFF
--- a/webshot/Dockerfile
+++ b/webshot/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="hello@vizzuality.com"
 ENV NAME marxan-webshot
 ENV USER $NAME
 ENV APP_HOME /opt/$NAME
-ENV PUPPETEER_CACHE_DIR $APP_HOME
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV YARN_VERSION 3.6.4
 
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/webshot/src/domain/blm-previews/png-image.ts
+++ b/webshot/src/domain/blm-previews/png-image.ts
@@ -51,6 +51,7 @@ export const generatePngImageFromBlmData = async (
     .replace(":blmValue", blmValue)}`;
 
   const browser = await puppeteer.launch({
+    executablePath: '/usr/bin/google-chrome-stable',
     args: [
       "--no-sandbox",
       "--disable-setuid-sandbox",

--- a/webshot/src/domain/comparison-map/comparison-map.ts
+++ b/webshot/src/domain/comparison-map/comparison-map.ts
@@ -52,6 +52,7 @@ export const generateSelectionFrequencyComparisonMapForScenarios = async (
     .replace(":scenarioIdB", scenarioIdB)}`;
 
   const browser = await puppeteer.launch({
+    executablePath: '/usr/bin/google-chrome-stable',
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
     headless: "new",
   });

--- a/webshot/src/domain/published-project-maps/published-projects-maps.ts
+++ b/webshot/src/domain/published-project-maps/published-projects-maps.ts
@@ -50,6 +50,7 @@ export const generatePngImageFromPublishedProjectData = async (
     .replace(":scenarioId", scenarioId)}`;
 
   const browser = await puppeteer.launch({
+    executablePath: '/usr/bin/google-chrome-stable',
     args: [
       "--no-sandbox",
       "--disable-setuid-sandbox",

--- a/webshot/src/domain/solutions-report/solutions-report.ts
+++ b/webshot/src/domain/solutions-report/solutions-report.ts
@@ -48,6 +48,7 @@ export const generateSummaryReportForScenario = async (
     .replace(":solutionId", solutionId)}`;
 
   const browser = await puppeteer.launch({
+    executablePath: '/usr/bin/google-chrome-stable',
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
     headless: 'new',
   });


### PR DESCRIPTION
## Summary

- Skip Puppeteer's bundled Chromium download during Docker build (`PUPPETEER_SKIP_DOWNLOAD=true`)
- Point all `puppeteer.launch()` calls to the system-installed Chrome (`/usr/bin/google-chrome-stable`)
- Fixes indefinite hang during `yarn install` link step in CI

## Context

The webshot Docker build hangs at the Yarn link step where Puppeteer's post-install script tries to download ~170MB of Chromium. Chrome is already installed via `apt-get` in the Dockerfile, making this download redundant.

This pattern (`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` + `PUPPETEER_EXECUTABLE_PATH`) existed in the original Alpine-based Dockerfile but was lost when migrating to Ubuntu in commit f8ede3468 (Mar 2022). The download worked reliably until recently when the Puppeteer CDN became unreliable in CI runners.

## Test plan

- [ ] Build webshot Docker image locally: `docker build ./webshot`
- [ ] Verify yarn install completes without downloading Chromium
- [ ] Verify webshot service starts and can generate a PDF/screenshot