### PR TITLE
fix(app): fix feature layer gradient missing when toggled from map legend

### DIFF
--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -239,40 +239,46 @@ export function useContinuousFeaturesLayers({
   return useMemo(() => {
     if (!active) return [];
 
-    return features.map((fid) => {
-      const { amountRange, color, opacity = 1 } = layerSettings[fid] || {};
+    return features
+      .map((fid) => {
+        const { amountRange, color, opacity = 1 } = layerSettings[fid] || {};
 
-      return {
-        id: `continuous-features-layer-${pid}-${fid}`,
-        type: 'vector',
-        source: {
+        if (!amountRange || amountRange.min == null || amountRange.max == null || !color) {
+          return null;
+        }
+
+        return {
+          id: `continuous-features-layer-${pid}-${fid}`,
           type: 'vector',
-          tiles: [
-            `${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${pid}/features/${fid}/preview/tiles/{z}/{x}/{y}.mvt`,
-          ],
-        },
-        render: {
-          layers: [
-            {
-              type: 'fill',
-              'source-layer': 'layer0',
-              paint: {
-                'fill-color': [
-                  'interpolate',
-                  ['linear'],
-                  ['get', 'amount'],
-                  amountRange.min,
-                  COLORS.continuous.default,
-                  amountRange.max,
-                  color,
-                ],
-                'fill-opacity': opacity,
+          source: {
+            type: 'vector',
+            tiles: [
+              `${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${pid}/features/${fid}/preview/tiles/{z}/{x}/{y}.mvt`,
+            ],
+          },
+          render: {
+            layers: [
+              {
+                type: 'fill',
+                'source-layer': 'layer0',
+                paint: {
+                  'fill-color': [
+                    'interpolate',
+                    ['linear'],
+                    ['get', 'amount'],
+                    amountRange.min,
+                    COLORS.continuous.default,
+                    amountRange.max,
+                    color,
+                  ],
+                  'fill-opacity': opacity,
+                },
               },
-            },
-          ],
-        },
-      };
-    });
+            ],
+          },
+        };
+      })
+      .filter(Boolean);
   }, [active, pid, features, layerSettings]);
 }
 

--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -205,12 +205,14 @@ export const useFeaturesLegend = () => {
       exact: false,
     })?.data;
 
-    const f = allFeatures?.find(({ id: featureId }) => (splitted ? parentId : id === featureId));
+    const f = allFeatures?.find(({ id: featureId }) =>
+      splitted ? parentId === featureId : id === featureId
+    );
 
     return {
       id,
       name,
-      amountRange: f?.amountRange || {},
+      amountRange: f?.amountRange ?? { min: null, max: null },
       splitted,
       color: featureColors?.find(({ id: featureId }) => featureId === id)?.color,
     };

--- a/app/store/slices/projects/[id].ts
+++ b/app/store/slices/projects/[id].ts
@@ -61,11 +61,14 @@ const projectsDetailSlice = createSlice({
       }>
     ) => {
       const { id: layerId, settings } = action.payload;
+      const definedSettings = Object.fromEntries(
+        Object.entries(settings).filter(([, v]) => v !== undefined)
+      );
       const newSettings = {
         ...state.layerSettings,
         [layerId]: {
           ...state.layerSettings[layerId],
-          ...settings,
+          ...definedSettings,
         },
       };
       state.layerSettings = newSettings;

--- a/app/store/slices/scenarios/edit.ts
+++ b/app/store/slices/scenarios/edit.ts
@@ -228,11 +228,14 @@ export function getScenarioEditSlice(id) {
         }>
       ) => {
         const { id: layerId, settings } = action.payload;
+        const definedSettings = Object.fromEntries(
+          Object.entries(settings).filter(([, v]) => v !== undefined)
+        );
         const newSettings = {
           ...state.layerSettings,
           [layerId]: {
             ...state.layerSettings[layerId],
-            ...settings,
+            ...definedSettings,
           },
         };
         state.layerSettings = newSettings;


### PR DESCRIPTION
## Summary

- **Fix operator precedence bug** in splitted feature lookup (scenario edit legend): `splitted ? parentId : id === featureId` always matched the first feature because parentId (a truthy UUID) was returned instead of being compared
- **Fix invalid amountRange fallback**: `|| {}` produced `{ min: undefined, max: undefined }` which passed the continuous feature check with garbage values; now uses `?? { min: null, max: null }`
- **Filter undefined values in `setLayerSettings` reducers**: prevents stale/missing legend data from overwriting valid layer settings via object spread
- **Add null guard in `useContinuousFeaturesLayers`**: skips creating a Mapbox layer when `amountRange` or `color` is invalid, preventing malformed interpolation expressions

## Test plan

- [ ] On the project page, toggle a continuous feature ON from the sidebar — verify gradient renders
- [ ] Toggle the same feature OFF, then ON from the map legend — verify gradient renders identically
- [ ] On the scenario edit page, toggle a splitted continuous feature from the legend — verify gradient (not flat color)
- [ ] Toggle feature off from legend, then on from sidebar — verify gradient persists
- [ ] Refresh page, toggle continuous feature from legend as first action — verify no crash and gradient renders
- [ ] Check browser console for Mapbox expression errors during all toggles