### PR TITLE
fix(app): map legend Features toggle controls gap analysis highlights

### DIFF
--- a/app/hooks/map/constants.tsx
+++ b/app/hooks/map/constants.tsx
@@ -298,7 +298,7 @@ export const LEGEND_LAYERS = {
       }),
     };
   },
-  features: () => ({
+  features: ({ onChangeVisibility }: { onChangeVisibility?: () => void } = {}) => ({
     id: 'features',
     name: 'Features',
     icon: (
@@ -312,6 +312,7 @@ export const LEGEND_LAYERS = {
       opacity: true,
       visibility: true,
     },
+    ...(onChangeVisibility && { onChangeVisibility }),
   }),
   // ANALYSIS
   ['continuous-features']: (options: {

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -778,7 +778,7 @@ export function usePUGridLayer({
                   'source-layer': 'layer0',
                   layout: {
                     visibility: getLayerVisibility(
-                      restLayerSettings[`gap-analysis-${id}`]?.visibility || 1
+                      restLayerSettings[`gap-analysis-${id}`]?.visibility ?? true
                     ),
                   },
                   paint: {
@@ -786,7 +786,7 @@ export function usePUGridLayer({
                     'fill-opacity': [
                       'case',
                       ['any', ['in', id, ['get', 'featureList']]],
-                      0.5 * restLayerSettings[`gap-analysis-${id}`]?.opacity || 1,
+                      0.5 * (restLayerSettings[`gap-analysis-${id}`]?.opacity ?? 1),
                       0,
                     ],
                   },
@@ -795,14 +795,14 @@ export function usePUGridLayer({
                   type: 'fill',
                   'source-layer': 'layer0',
                   layout: {
-                    visibility: getLayerVisibility(restLayerSettings[id]?.visibility || 1),
+                    visibility: getLayerVisibility(restLayerSettings[id]?.visibility ?? true),
                   },
                   paint: {
                     'fill-color': COLORS.highlightFeatures,
                     'fill-opacity': [
                       'case',
                       ['any', ['in', id, ['get', 'featureList']]],
-                      0.5 * restLayerSettings[id]?.opacity || 1,
+                      0.5 * (restLayerSettings[id]?.opacity ?? 1),
                       0,
                     ],
                   },

--- a/app/layout/project/sidebar/scenario/grid-setup/gap-analysis/list/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/gap-analysis/list/index.tsx
@@ -52,7 +52,7 @@ export const ScenariosPreGapAnalysisList = ({ search }: { search?: string }) => 
         setLayerSettings({
           id: `gap-analysis-${id}`,
           settings: {
-            visibility: layerSettings[`gap-analysis-${id}`]?.visibility || 1,
+            visibility: newHighlightFeatures.includes(id),
           },
         })
       );

--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -512,7 +512,7 @@ export const useGapAnalysisLegend = () => {
         setLayerSettings({
           id: `gap-analysis-${featureId}`,
           settings: {
-            visibility: !layerSettings[`gap-analysis-${featureId}`]?.visibility,
+            visibility: !isIncluded,
           },
         })
       );

--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -426,6 +426,61 @@ export const useWDPAPreviewLegend = () => {
   });
 };
 
+export const useFeaturesLayerLegend = () => {
+  const { query } = useRouter();
+  const { sid } = query as { sid: string };
+  const dispatch = useAppDispatch();
+  const scenarioSlice = getScenarioEditSlice(sid);
+  const { setLayerSettings, setPreHighlightFeatures } = scenarioSlice.actions;
+  const { layerSettings, preHighlightFeatures } = useAppSelector(
+    (state) => state[`/scenarios/${sid}/edit`]
+  );
+
+  const gapAnalysisQuery = usePreGapAnalysis(sid, {});
+  const allFeatureIds = gapAnalysisQuery.data?.map(({ id }) => id) || [];
+
+  return LEGEND_LAYERS['features']({
+    onChangeVisibility: () => {
+      const isCurrentlyVisible = layerSettings['features']?.visibility;
+      const newVisibility = !isCurrentlyVisible;
+
+      dispatch(
+        setLayerSettings({
+          id: 'features',
+          settings: { visibility: newVisibility },
+        })
+      );
+
+      if (newVisibility) {
+        // Toggle ALL gap analysis features ON (purple PU highlights)
+        dispatch(setPreHighlightFeatures(allFeatureIds));
+
+        allFeatureIds.forEach((featureId) => {
+          dispatch(
+            setLayerSettings({
+              id: `gap-analysis-${featureId}`,
+              settings: { visibility: true },
+            })
+          );
+        });
+      } else {
+        // Toggle ALL gap analysis features OFF
+        const featuresToClear = [...preHighlightFeatures];
+        dispatch(setPreHighlightFeatures([]));
+
+        featuresToClear.forEach((featureId) => {
+          dispatch(
+            setLayerSettings({
+              id: `gap-analysis-${featureId}`,
+              settings: { visibility: false },
+            })
+          );
+        });
+      }
+    },
+  });
+};
+
 export const useGapAnalysisLegend = () => {
   const { query } = useRouter();
   const { sid } = query as { sid: string };
@@ -437,6 +492,8 @@ export const useGapAnalysisLegend = () => {
   );
 
   const gapAnalysisQuery = usePreGapAnalysis(sid, {});
+
+  const allFeatureIds = gapAnalysisQuery.data?.map(({ id }) => id) || [];
 
   return LEGEND_LAYERS['gap-analysis']({
     items: gapAnalysisQuery.data,
@@ -459,6 +516,17 @@ export const useGapAnalysisLegend = () => {
           },
         })
       );
+
+      // Keep master "Features" toggle in sync: active only when all features are visible
+      const allVisible = allFeatureIds.every((id) => newPreHighlightFeatures.includes(id));
+      if (layerSettings['features']?.visibility !== allVisible) {
+        dispatch(
+          setLayerSettings({
+            id: 'features',
+            settings: { visibility: allVisible },
+          })
+        );
+      }
     },
   });
 };
@@ -524,6 +592,7 @@ export const useScenarioLegend = () => {
       name: 'Planning Grid',
       layers: [
         usePlanningGridLegend(),
+        useFeaturesLayerLegend(),
         ...useCostSurfaceLegend(),
         useLockInLegend(),
         useLockOutLegend(),


### PR DESCRIPTION
## Summary

- The **"Features" master toggle** inside Planning Grid in the map legend had no visible effect — clicking it only set a flag but didn't activate any features on the map
- Adds `useFeaturesLayerLegend` hook that makes the master toggle actually enable/disable **all** gap analysis features (purple PU grid highlights)
- Master toggle eye icon deactivates automatically when any individual feature is toggled off, and only shows active when all features are visible
- Fixes `|| 1` operator precedence bugs in `usePUGridLayer` where `false || 1` evaluated to `1` (truthy), preventing proper visibility/opacity control

## Test plan

- [ ] Navigate to scenario edit page with `?tab=features`
- [ ] In the map legend, expand **Planning Grid > Features** subgroup
- [ ] Click the **"Features" master toggle** eye icon → all features should get purple PU highlights on the map, all subgroup eye icons turn blue
- [ ] Click master toggle again → all purple highlights removed
- [ ] Click an individual feature eye icon (e.g. "Alto Parana Atlantic Forests") → purple hexagons appear for that feature
- [ ] With master toggle ON, disable one individual feature → master toggle eye should deactivate
- [ ] Sidebar eye icons should NOT be affected by any legend toggle