### PR TITLE
fix(app): compute feature colors without scenario ID on project page

### DIFF
--- a/app/hooks/features/index.ts
+++ b/app/hooks/features/index.ts
@@ -785,5 +785,22 @@ export function useColorFeatures(projectId: Project['id'], sid: Scenario['id']) 
     });
   }
 
+  // When no scenario ID is available (e.g., project page), compute colors
+  // from all features alone so the legend and inventory panel can load feature data.
+  if (!sid && useAllFeaturesQuery.isSuccess) {
+    const data = useAllFeaturesQuery.data?.data || [];
+    return data.map(({ id }, index) => {
+      const color =
+        data.length > COLORS['features-preview'].ramp.length
+          ? chroma.scale(COLORS['features-preview'].ramp).colors(data.length)[index]
+          : COLORS['features-preview'].ramp[index];
+
+      return {
+        id,
+        color,
+      };
+    });
+  }
+
   return [];
 }


### PR DESCRIPTION
useColorFeatures returned [] when sid was undefined (project page has no scenario in the URL), which disabled the legend's and inventory panel's feature queries. This caused the legend to use stale/inconsistent cache data, potentially misclassifying continuous features as binary and rendering them with solid color instead of the expected gradient.

Please provide a description for this PR.

Ideally, each PR should addresses exactly a self-container Jira item, in which case all that would be needed is to provide a link to the Jira item below.

The Jira item should include

- description
- acceptance criteria
- testing instructions

## Jira story

Provide a link to the story this PR is linked to.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `main`.
- [ ] Update CHANGELOG file
