### PR TITLE
fix(app): scenario legend feature gradient missing for shapefile features [MRXNM-83]

### DIFF
--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -211,11 +211,13 @@ export const useFeaturesLegend = () => {
 
   const continuousFeaturesItems =
     projectFeaturesQuery.data?.continuousFeatures.map(
-      ({ id, featureClassName, amountRange, color }) => {
+      ({ id, featureClassName, amountRange, amountMin, amountMax, color }) => {
         return {
           id,
           name: featureClassName,
           amountRange,
+          amountMin,
+          amountMax,
           color,
         };
       }
@@ -236,6 +238,8 @@ export const useFeaturesLegend = () => {
       id,
       name,
       amountRange: f?.amountRange ?? { min: null, max: null },
+      amountMin: f?.amountMin,
+      amountMax: f?.amountMax,
       splitted,
       color: featureColors?.find(({ id: featureId }) => featureId === id)?.color,
     };
@@ -305,7 +309,7 @@ export const useFeaturesLegend = () => {
     ...LEGEND_LAYERS['continuous-features']({
       items: uniqueContinuousFeatures,
       onChangeVisibility: (featureId: Feature['id']) => {
-        const { color, amountRange, splitted } =
+        const { color, amountRange, amountMin, amountMax, splitted } =
           uniqueContinuousFeatures.find(({ id }) => id === featureId) || {};
 
         const newSelectedFeatures = [...selectedContinuousFeatures];
@@ -326,7 +330,10 @@ export const useFeaturesLegend = () => {
             id: featureId,
             settings: {
               visibility: !isIncluded,
-              amountRange,
+              amountRange: {
+                min: amountMin ?? amountRange?.min,
+                max: amountMax ?? amountRange?.max,
+              },
               color,
             },
           })


### PR DESCRIPTION
## Summary
- Mirrors the inventory legend fix from `fcb26e0be` for the **scenario edit map** legend (`app/layout/scenarios/edit/map/legend/hooks/index.ts`).
- The `useFeaturesLegend` continuous-features toggle was dispatching the converted `amountRange` (km², from the API serializer that divides shapefile amounts by 1M) into `layerSettings`, while MVT tiles emit raw m² values. Every planning unit's `amount` exceeded the max stop, so the Mapbox `interpolate` clamped them all to the max color — rendering a flat fill instead of a gradient (Alto Paraná Atlantic Forests in the ticket's screenshot).
- Pulls `amountMin`/`amountMax` (raw) through `continuousFeaturesItems` and `parsedTargetedFeatures`, then dispatches `{ min: amountMin ?? amountRange?.min, max: amountMax ?? amountRange?.max }` so the interpolation stops match the tile units.
- Eye-icon path in the features list panel was already correct: it sources `feature.amountRange` from `useSelectedFeatures`, which constructs `{ min: metadata.amountMin, max: metadata.amountMax }` directly from the `GeoFeature` entity's raw m² columns. Not touched.

## Test plan
- [ ] On a scenario containing a shapefile-based continuous feature (e.g. Atlantic Forest baseline → Alto Paraná Atlantic Forests):
  - [ ] Toggle the feature via the right-side **Legend → Features** eye-icon. Map renders a gradient identical to the inventory panel.
  - [ ] Toggle the same feature via the features list eye-icon (left panel). Same gradient.
- [ ] Verify a CSV-uploaded continuous feature (e.g. Bradypus torquatus on the same project) still renders. Note: this PR does not address the separate concern that 0-amount PUs from wide-format CSV uploads remain in the tile; that will be triaged after this fix lands if still misleading.
- [ ] Toggle visibility off — gradient layer disappears cleanly.
- [ ] Confirm gap-analysis and pre/post-highlight rendering paths are unaffected.

## Notes
- Rebased onto `origin/staging`. The earlier duplicate `fcb26e0be` from `main` was dropped automatically during rebase (already upstream as `ca9fe180e`).
- This fix needs to flow back to `develop` once verified — file currently lacks the prior dependency commits there.