### PR TITLE
fix(app): hide amount=0 planning units in continuous feature layers [MRXNM-83]

### DIFF
--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -261,6 +261,7 @@ export function useContinuousFeaturesLayers({
               {
                 type: 'fill',
                 'source-layer': 'layer0',
+                filter: ['>', ['get', 'amount'], 0],
                 paint: {
                   'fill-color': [
                     'interpolate',


### PR DESCRIPTION
## Summary
Follow-up to #1730. After the unit-mismatch fix landed, the shapefile half of MRXNM-83 was resolved but the **CSV** half was still misleading: on the Atlantic Forest baseline scenario, Bradypus_torquatus rendered as if it covered the entire planning grid. Investigation on staging confirmed why:

| Bradypus tile breakdown | PU count | % |
|---|---|---|
| `amount = 0` | 8,880 | **92.5%** |
| `0 < amount < 500` | 0 | 0% |
| `amount ≥ 500` (range 529–989) | 723 | 7.5% |

Wide-format CSV uploads insert a row for every (feature × planning unit) pair, including `amount = 0` rows for absent species. The interpolate expression maps 0 → `#FFF`, so 8,880 absent-species PUs were rendering as fully opaque white hexagons over a dark basemap — visually indistinguishable from a solid fill.

## Change
Added a Mapbox filter on the fill layer in `useContinuousFeaturesLayers`:
```js
filter: ['>', ['get', 'amount'], 0]
```
Zero-amount PUs are skipped entirely; the gradient now reflects only the planning units where the feature is actually present.

Shapefile-based features are unaffected: their `feature_amounts_per_planning_unit` rows only exist where the polygon intersects a PU, so there are no zero-amount entries to filter.

## Test plan
- [ ] Atlantic Forest baseline scenario → toggle Bradypus_torquatus from the legend. Expect a coastal-strip rendering instead of full-grid coverage.
- [ ] Same scenario → toggle Alto Paraná Atlantic Forests (shapefile). Expect the same gradient as before this PR (no regression).
- [ ] Inventory panel of any project with a CSV-uploaded feature → toggle on, expect zero-amount PUs to be hidden.
- [ ] Confirm gap-analysis, target-achievement and pre/post-highlight layers still render unchanged (this hook only powers the `continuous-features-layer-*` Mapbox layers).

## Notes
- Branched from `origin/staging` to follow the deploy path used for #1730.
- Original ticket MRXNM-83 covered both shapefile and CSV symptoms; this PR closes the CSV half.