### PR TITLE
fix(app): align scenario feature toggle and gradient rendering [MRXNM-83]

### DIFF
--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -492,7 +492,12 @@ export function useTargetedPreviewLayers({
 
     const { layerSettings = {} } = options;
 
-    const FEATURES = features.filter((ft) => Object.keys(layerSettings).includes(ft.id));
+    // Continuous features render their gradient via useContinuousFeaturesLayers;
+    // a solid-color underlay here would bleed through the gradient at edges and
+    // mask amount=0 PUs filtered out by that hook.
+    const FEATURES = features.filter(
+      (ft) => Object.keys(layerSettings).includes(ft.id) && !layerSettings[ft.id]?.amountRange
+    );
 
     const getLayerVisibility = (
       visibility: UseTargetedPreviewLayers['options']['layerSettings'][string]['visibility']

--- a/app/hooks/map/types.ts
+++ b/app/hooks/map/types.ts
@@ -105,7 +105,15 @@ export interface UseTargetedPreviewLayers {
     selectedFeatures?: Array<string>;
     opacity?: number;
     visibility?: boolean;
-    layerSettings?: Record<string, { opacity?: number; visibility?: boolean; color: string }>;
+    layerSettings?: Record<
+      string,
+      {
+        opacity?: number;
+        visibility?: boolean;
+        color: string;
+        amountRange?: { min: number; max: number };
+      }
+    >;
   };
 }
 

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -69,8 +69,11 @@ const TargetAndSPFFeatures = (): JSX.Element => {
   const dispatch = useAppDispatch();
 
   const scenarioSlice = getScenarioEditSlice(sid);
-  const { setLayerSettings } = scenarioSlice.actions;
-  const { layerSettings } = useAppSelector((state) => state[`/scenarios/${sid}/edit`]);
+  const { setLayerSettings, setSelectedFeatures, setSelectedContinuousFeatures } =
+    scenarioSlice.actions;
+  const { layerSettings, selectedFeatures, selectedContinuousFeatures } = useAppSelector(
+    (state) => state[`/scenarios/${sid}/edit`]
+  );
 
   const allFeaturesQuery = useAllFeatures(
     pid,
@@ -211,21 +214,63 @@ const TargetAndSPFFeatures = (): JSX.Element => {
       const selectedFeature = targetedFeatures.find(({ id: featureId }) => featureId === id);
       const isContinuous =
         selectedFeature.amountRange.min !== null && selectedFeature.amountRange.max !== null;
+      const { splitted } = selectedFeature;
+
+      if (isContinuous) {
+        const newSelectedFeatures = [...selectedContinuousFeatures];
+        const isIncluded = newSelectedFeatures.includes(id);
+
+        if (!splitted) {
+          if (!isIncluded) {
+            newSelectedFeatures.push(id);
+          } else {
+            newSelectedFeatures.splice(newSelectedFeatures.indexOf(id), 1);
+          }
+          dispatch(setSelectedContinuousFeatures(newSelectedFeatures));
+        }
+
+        dispatch(
+          setLayerSettings({
+            id,
+            settings: {
+              visibility: !isIncluded,
+              color: selectedFeature?.color,
+              amountRange: selectedFeature.amountRange,
+            },
+          })
+        );
+        return;
+      }
+
+      const newSelectedFeatures = [...selectedFeatures];
+      const isIncluded = newSelectedFeatures.includes(id);
+
+      if (!isIncluded) {
+        newSelectedFeatures.push(id);
+      } else {
+        newSelectedFeatures.splice(newSelectedFeatures.indexOf(id), 1);
+      }
+      dispatch(setSelectedFeatures(newSelectedFeatures));
 
       dispatch(
         setLayerSettings({
           id,
           settings: {
-            visibility: layerSettings[id] ? !layerSettings[id].visibility : true,
+            visibility: !isIncluded,
             color: selectedFeature?.color,
-            ...(isContinuous && {
-              amountRange: selectedFeature.amountRange,
-            }),
           },
         })
       );
     },
-    [dispatch, setLayerSettings, targetedFeatures, layerSettings]
+    [
+      dispatch,
+      setLayerSettings,
+      setSelectedContinuousFeatures,
+      setSelectedFeatures,
+      targetedFeatures,
+      selectedContinuousFeatures,
+      selectedFeatures,
+    ]
   );
 
   const onApplyAllTargets = useCallback(() => {


### PR DESCRIPTION
## Jira story

[MRXNM-83](https://vizzuality.atlassian.net/browse/MRXNM-83)

### Testing instructions

After the previous MRXNM-83 fixes the scenario edit map still diverged from the inventory rendering in two ways. This PR closes the gap.

Reproduce on `staging` (without this PR) with **Atlantic Forest Baseline** scenario, feature **Alto Parana Atlantic Forests**:

1. Open the scenario edit page → **Features** tab in the left panel.
2. Click the eye icon next to *Alto Parana Atlantic Forests* → map paints a uniform solid red over the species polygon (no gradient).
3. Untoggle, then open the right-side **legend** and click the eye icon for the same feature → gradient hex layer appears, but pale "white shapes" leak through at the species-range edges (a solid underlay showing where the gradient is filtered out / very low).
4. Compare with the **Inventory** view on the project page → the same feature renders as a clean per-PU gradient with no solid underlay.

After this PR, both toggles produce the same rendering as the Inventory view.

## Summary

- `useTargetedPreviewLayers` (`app/hooks/map/index.ts`) now skips features whose `layerSettings` entry carries `amountRange`. Continuous features are owned by `useContinuousFeaturesLayers`; the solid `/geo-features`-tile underlay was bleeding through at edges and masking amount=0 PUs that `useContinuousFeaturesLayers` filters upstream.
- `target-spf` `toggleSeeOnMap` (`app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx`) now mirrors the legend hook: dispatches `setSelectedContinuousFeatures` (continuous, non-split) or `setSelectedFeatures` (binary) alongside `setLayerSettings`, with `visibility` derived from selection-array membership. Without this, the gradient layer (`useContinuousFeaturesLayers`) never activated from the left panel.
- Extended `UseTargetedPreviewLayers` `layerSettings` type with the optional `amountRange` field already used by other layer hooks.

## Test plan

- [ ] On the scenario edit page, in the Features tab left panel, toggle a **continuous** feature (e.g. *Alto Parana Atlantic Forests*) → map shows the per-PU gradient identical to Inventory; no solid colour underlay.
- [ ] Toggle the same feature off → layer disappears.
- [ ] In the right-side legend, toggle a **continuous** feature on/off → behaviour matches the left-panel toggle (no "white shapes" at borders).
- [ ] Toggle a **binary** feature (no amount range) from the Features tab → solid-colour preview still renders.
- [ ] Toggle a split continuous feature → no regression (splits still render as before).
- [ ] Compare the scenario rendering side-by-side with the same feature in the Inventory view → identical.
- [ ] `yarn check-types` and `yarn lint` pass (verified locally).

[MRXNM-83]: https://vizzuality.atlassian.net/browse/MRXNM-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ