### PR TITLE
feat(app): add platform transition modal [MRXNM-85]

### DIFF
--- a/app/e2e/platform-transition.spec.ts
+++ b/app/e2e/platform-transition.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+const MODAL_TITLE = 'Important Platform Transition Notice';
+const COOKIE_NAME = 'platform-transition';
+
+async function clearTransitionCookie(context: import('@playwright/test').BrowserContext) {
+  const cookies = await context.cookies();
+  await context.clearCookies();
+  const others = cookies.filter((c) => c.name !== COOKIE_NAME);
+  if (others.length) await context.addCookies(others);
+}
+
+test.describe('Platform transition modal', () => {
+  test.beforeEach(async ({ context }) => {
+    await clearTransitionCookie(context);
+  });
+
+  test('opens on the landing page when flag is on and no cookie is set', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
+  });
+
+  test('opens on other public routes (proves app-root mount)', async ({ page }) => {
+    await page.goto('/about');
+    await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
+  });
+
+  test('dismissing via "Got it" sets the cookie and hides the modal', async ({ page, context }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Got it' }).click();
+    await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
+
+    const cookies = await context.cookies();
+    const cookie = cookies.find((c) => c.name === COOKIE_NAME);
+    expect(cookie?.value).toBe('true');
+  });
+
+  test('reload after dismissal does not re-show the modal', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Got it' }).click();
+    await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
+
+    await page.reload();
+    await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden({ timeout: 5_000 });
+  });
+
+  test('Escape key also dismisses', async ({ page, context }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
+
+    const cookie = (await context.cookies()).find((c) => c.name === COOKIE_NAME);
+    expect(cookie?.value).toBe('true');
+  });
+});

--- a/app/layout/platform-transition/content.tsx
+++ b/app/layout/platform-transition/content.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import Button from 'components/button';
+
+const GUIDE_URL = 'https://tnc.box.com/s/io7czx68a8nnnj3yos8qa724br86lfis';
+
+export interface PlatformTransitionContentProps {
+  onDismiss?: () => void;
+}
+
+export const PlatformTransitionContent: React.FC<PlatformTransitionContentProps> = ({
+  onDismiss,
+}) => {
+  return (
+    <div className="flex max-h-[80vh] flex-col overflow-y-auto px-10 pb-8 pt-2 text-gray-700">
+      <h2 className="font-heading text-2xl text-gray-800">Important Platform Transition Notice</h2>
+
+      <div className="mt-4 space-y-4 text-sm leading-relaxed">
+        <p>
+          MaPP will transition from The Nature Conservancy to a new host and long-term steward
+          starting July 1, 2026, an exciting new stage for the platform&apos;s future development
+          and sustainability.
+        </p>
+
+        <p>
+          We do not expect disruptions during the transition period (May–June). However, temporary
+          performance or access issues may occur during the final migration stage.
+        </p>
+
+        <p>
+          To avoid any risk, we strongly recommend that all users by <strong>June 26</strong>:
+        </p>
+
+        <ul className="ml-6 list-disc space-y-1">
+          <li>Complete any ongoing analyses</li>
+          <li>Export results</li>
+          <li>Back up active/important projects</li>
+          <li>Delete old/inactive projects</li>
+        </ul>
+
+        <p>
+          You can download a quick user guide here for instructions:{' '}
+          <a
+            href={GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-500 underline hover:text-primary-700"
+          >
+            MaPP transition user guide
+          </a>
+          .
+        </p>
+
+        <p>
+          Backing up projects is especially important to ensure they can be restored if needed after
+          the transition.
+        </p>
+
+        <p>
+          We will continue to share updates as we approach the final migration and keep you informed
+          throughout the process.
+        </p>
+
+        <p>Thank you for your continued use of MaPP and your support during this transition.</p>
+
+        <p>
+          If you have any questions or require assistance, you can contact{' '}
+          <a
+            href="mailto:marxanadmin@tnc.org"
+            className="text-primary-500 underline hover:text-primary-700"
+          >
+            marxanadmin@tnc.org
+          </a>
+          .
+        </p>
+      </div>
+
+      <div className="mt-6 flex justify-end">
+        <Button theme="primary" size="base" onClick={onDismiss}>
+          Got it
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PlatformTransitionContent;

--- a/app/layout/platform-transition/index.tsx
+++ b/app/layout/platform-transition/index.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { useCookies } from 'react-cookie';
+
+import { useFeatureFlags } from 'hooks/feature-flags';
+
+import Modal from 'components/modal';
+
+import PlatformTransitionContent from './content';
+
+const COOKIE_NAME = 'platform-transition';
+const COOKIE_EXPIRY = new Date('2026-12-31T23:59:59Z');
+const MODAL_TITLE = 'Important Platform Transition Notice';
+
+export const PlatformTransitionModal = (): JSX.Element | null => {
+  const [cookies, setCookie] = useCookies([COOKIE_NAME]);
+  const { platformTransition } = useFeatureFlags();
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const dismissed = cookies[COOKIE_NAME] === 'true';
+
+  const onDismiss = useCallback(() => {
+    setCookie(COOKIE_NAME, 'true', {
+      path: '/',
+      expires: COOKIE_EXPIRY,
+    });
+  }, [setCookie]);
+
+  if (!platformTransition) return null;
+  if (dismissed) return null;
+  if (!mounted) return null;
+
+  return (
+    <Modal
+      id="platform-transition"
+      title={MODAL_TITLE}
+      open
+      dismissable
+      size="default"
+      onDismiss={onDismiss}
+    >
+      <PlatformTransitionContent />
+    </Modal>
+  );
+};
+
+export default PlatformTransitionModal;

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -18,6 +18,7 @@ import { ToastProvider } from 'hooks/toast';
 
 import Loading from 'layout/loading';
 import { MediaContextProvider } from 'layout/media';
+import PlatformTransitionModal from 'layout/platform-transition';
 import store from 'store';
 import { cn } from 'utils/cn';
 
@@ -98,6 +99,7 @@ const MarxanApp = ({ Component, pageProps }: AppProps) => {
                           >
                             <Component {...pageProps} />
                           </div>
+                          <PlatformTransitionModal />
                         </PlausibleProvider>
                       </HelpProvider>
                     </ToastProvider>

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       NEXTAUTH_URL: `http://localhost:${PORT}`,
       NEXTAUTH_SECRET: 'cats',
       NEXT_PUBLIC_API_URL: 'https://marxan23.northeurope.cloudapp.azure.com',
+      NEXT_PUBLIC_FEATURE_FLAGS: 'platformTransition',
     },
   },
   /* Run tests in files in parallel */


### PR DESCRIPTION
Closes [MRXNM-85](https://vizzuality.atlassian.net/browse/MRXNM-85).

## Summary
- New `PlatformTransitionModal` component mounted once in `pages/_app.tsx`, so the notice appears on every route (public and authenticated).
- Gated by a new `platformTransition` feature flag and a `platform-transition` cookie (expiry `2026-12-31`) — each browser sees the modal at most once.
- Notice content matches the copy from MRXNM-85: paragraphs, action-item list, TNC user-guide link, mailto.
- Existing `UpcomingChangesBanner` and `upcomingChanges` flag are untouched — separate concern, separate flag.
- Renders nothing on the server / first client render to avoid an SSR hydration mismatch around the cookie read.

## How to enable
Add `platformTransition` to the comma-separated `NEXT_PUBLIC_FEATURE_FLAGS` env var on the target environment, then redeploy. Remove and redeploy to retract.

## Test plan
- [x] \`yarn e2e --grep "Platform transition modal"\` — 5/5 pass on Chrome
- [x] Full Chrome suite — 6/6 pass (no regressions in \`example.spec.ts\`)
- [x] \`yarn lint\` — exit 0
- [x] \`yarn check-types\` — exit 0
- [ ] Manual smoke after staging deploy: fresh incognito → modal opens on \`/\` and \`/about\`; "Got it" dismisses; reload keeps it hidden; Escape also dismisses

[MRXNM-85]: https://vizzuality.atlassian.net/browse/MRXNM-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ