### PR TITLE
feat(app): platform transition modal opt-in dismissal [MRXNM-86]

### DIFF
--- a/app/e2e/platform-transition.spec.ts
+++ b/app/e2e/platform-transition.spec.ts
@@ -25,28 +25,57 @@ test.describe('Platform transition modal', () => {
     await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
   });
 
-  test('dismissing via "Got it" sets the cookie and hides the modal', async ({ page, context }) => {
+  test('dismissing via "Got it" without the checkbox hides the modal but does not set the cookie', async ({
+    page,
+    context,
+  }) => {
     await page.goto('/');
     await page.getByRole('button', { name: 'Got it' }).click();
     await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
 
-    const cookies = await context.cookies();
-    const cookie = cookies.find((c) => c.name === COOKIE_NAME);
-    expect(cookie?.value).toBe('true');
+    const cookie = (await context.cookies()).find((c) => c.name === COOKIE_NAME);
+    expect(cookie).toBeUndefined();
   });
 
-  test('reload after dismissal does not re-show the modal', async ({ page }) => {
+  test('reload after dismissal without the checkbox re-shows the modal', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('button', { name: 'Got it' }).click();
     await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
 
     await page.reload();
+    await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
+  });
+
+  test('checking "Don\'t show me this again" before dismissing sets the cookie and hides on reload', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/');
+    await page.getByLabel("Don't show me this again").check();
+    await page.getByRole('button', { name: 'Got it' }).click();
+    await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
+
+    const cookie = (await context.cookies()).find((c) => c.name === COOKIE_NAME);
+    expect(cookie?.value).toBe('true');
+
+    await page.reload();
     await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden({ timeout: 5_000 });
   });
 
-  test('Escape key also dismisses', async ({ page, context }) => {
+  test('Escape key dismisses without persisting unless the checkbox is checked', async ({
+    page,
+    context,
+  }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
+
+    expect((await context.cookies()).find((c) => c.name === COOKIE_NAME)).toBeUndefined();
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: MODAL_TITLE })).toBeVisible();
+    await page.getByLabel("Don't show me this again").check();
     await page.keyboard.press('Escape');
     await expect(page.getByRole('dialog', { name: MODAL_TITLE })).toBeHidden();
 

--- a/app/layout/platform-transition/content.tsx
+++ b/app/layout/platform-transition/content.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
 
 import Button from 'components/button';
+import Checkbox from 'components/forms/checkbox';
 
 const GUIDE_URL = 'https://tnc.box.com/s/io7czx68a8nnnj3yos8qa724br86lfis';
+const DONT_SHOW_AGAIN_ID = 'platform-transition-dont-show-again';
 
 export interface PlatformTransitionContentProps {
   onDismiss?: () => void;
+  dontShowAgain?: boolean;
+  onDontShowAgainChange?: (value: boolean) => void;
 }
 
 export const PlatformTransitionContent: React.FC<PlatformTransitionContentProps> = ({
   onDismiss,
+  dontShowAgain = false,
+  onDontShowAgainChange,
 }) => {
   return (
     <div className="flex max-h-[80vh] flex-col overflow-y-auto px-10 pb-8 pt-2 text-gray-700">
@@ -75,7 +81,16 @@ export const PlatformTransitionContent: React.FC<PlatformTransitionContentProps>
         </p>
       </div>
 
-      <div className="mt-6 flex justify-end">
+      <div className="mt-6 flex items-center justify-between gap-4">
+        <label htmlFor={DONT_SHOW_AGAIN_ID} className="flex cursor-pointer items-center gap-2">
+          <Checkbox
+            id={DONT_SHOW_AGAIN_ID}
+            theme="light"
+            checked={dontShowAgain}
+            onChange={(event) => onDontShowAgainChange?.(event.target.checked)}
+          />
+          <span className="text-sm text-gray-700">Don&apos;t show me this again</span>
+        </label>
         <Button theme="primary" size="base" onClick={onDismiss}>
           Got it
         </Button>

--- a/app/layout/platform-transition/index.tsx
+++ b/app/layout/platform-transition/index.tsx
@@ -21,18 +21,24 @@ export const PlatformTransitionModal = (): JSX.Element | null => {
     setMounted(true);
   }, []);
 
-  const dismissed = cookies[COOKIE_NAME] === 'true';
+  const persistedDismissal = cookies[COOKIE_NAME] === 'true';
+  const [open, setOpen] = useState(true);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
 
   const onDismiss = useCallback(() => {
-    setCookie(COOKIE_NAME, 'true', {
-      path: '/',
-      expires: COOKIE_EXPIRY,
-    });
-  }, [setCookie]);
+    if (dontShowAgain) {
+      setCookie(COOKIE_NAME, 'true', {
+        path: '/',
+        expires: COOKIE_EXPIRY,
+      });
+    }
+    setOpen(false);
+  }, [dontShowAgain, setCookie]);
 
   if (!platformTransition) return null;
-  if (dismissed) return null;
+  if (persistedDismissal) return null;
   if (!mounted) return null;
+  if (!open) return null;
 
   return (
     <Modal
@@ -43,7 +49,10 @@ export const PlatformTransitionModal = (): JSX.Element | null => {
       size="default"
       onDismiss={onDismiss}
     >
-      <PlatformTransitionContent />
+      <PlatformTransitionContent
+        dontShowAgain={dontShowAgain}
+        onDontShowAgainChange={setDontShowAgain}
+      />
     </Modal>
   );
 };


### PR DESCRIPTION
## Jira story

[MRXNM-86 — "Don't show me this again" checkbox](https://vizzuality.atlassian.net/browse/MRXNM-86)

Follow-up to [MRXNM-85](https://vizzuality.atlassian.net/browse/MRXNM-85) (#1733). Client feedback: users often close the transition modal reflexively without realizing what it was about, so the previous one-shot cookie dismissal was too aggressive.

## Summary

- The modal now reappears on every fresh load until the user explicitly checks **"Don't show me this again"** before dismissing.
- Visibility is decoupled from persistence: closing without the checkbox hides the modal for the current SPA session (component lives at `_app.tsx` root); closing with the checkbox writes the `platform-transition` cookie and stops it from coming back until cookies are cleared.
- Applies to all dismiss paths — "Got it" button, Escape key, overlay click, and the close (X) button — since they all route through `onDismiss`.

### Testing instructions

1. Ensure the `platformTransition` feature flag is enabled (`NEXT_PUBLIC_FEATURE_FLAGS` includes it).
2. Clear cookies for the site, then load any public route — modal opens.
3. Click **Got it** without checking the box → modal closes, no `platform-transition` cookie is set.
4. Hard-reload the page → modal opens again.
5. Check **Don't show me this again**, then click **Got it** → modal closes and `platform-transition=true` cookie is set with the existing expiry.
6. Hard-reload → modal stays hidden.
7. Repeat steps 3 and 5 using the Escape key instead of the button to confirm the same matrix applies.

Automated coverage: `app/e2e/platform-transition.spec.ts` exercises both branches for **Got it** and Escape.

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `staging`.
- [ ] Update CHANGELOG file — N/A, repo has no CHANGELOG.

[MRXNM-85]: https://vizzuality.atlassian.net/browse/MRXNM-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ