### PR TITLE
fix(app): prevent project map crash on narrow viewports [MRXNM-87]

### DIFF
--- a/app/components/map/component.tsx
+++ b/app/components/map/component.tsx
@@ -16,6 +16,37 @@ const DEFAULT_VIEWPORT = {
   longitude: 0,
 };
 
+type FitBoundsPadding = { top: number; right: number; bottom: number; left: number };
+
+// fitBounds() throws "@math.gl/web-mercator: assertion failed." when the
+// passed padding doesn't leave room inside the viewport. Scale padding down
+// proportionally so callers can pass desktop-sized padding without crashing
+// on narrow (mobile) containers.
+const clampFitBoundsPadding = (
+  padding: number | FitBoundsPadding | undefined,
+  width: number,
+  height: number
+): number | FitBoundsPadding | undefined => {
+  if (padding == null) return padding;
+  const maxHorizontal = Math.max(0, width - 1);
+  const maxVertical = Math.max(0, height - 1);
+  if (typeof padding === 'number') {
+    return Math.min(padding, Math.floor(maxHorizontal / 2), Math.floor(maxVertical / 2));
+  }
+  const { top, right, bottom, left } = padding;
+  const horizontal = left + right;
+  const vertical = top + bottom;
+  const scaleX = horizontal > maxHorizontal && horizontal > 0 ? maxHorizontal / horizontal : 1;
+  const scaleY = vertical > maxVertical && vertical > 0 ? maxVertical / vertical : 1;
+  if (scaleX >= 1 && scaleY >= 1) return padding;
+  return {
+    top: Math.floor(top * scaleY),
+    right: Math.floor(right * scaleX),
+    bottom: Math.floor(bottom * scaleY),
+    left: Math.floor(left * scaleX),
+  };
+};
+
 export const Map = ({
   mapboxApiAccessToken,
   children,
@@ -95,19 +126,25 @@ export const Map = ({
     const { bbox, options = {}, viewportOptions = {} } = bounds;
     const { transitionDuration = 0 } = viewportOptions;
 
-    if (mapContainerRef.current.offsetWidth <= 0 || mapContainerRef.current.offsetHeight <= 0) {
+    const containerWidth = mapContainerRef.current.offsetWidth;
+    const containerHeight = mapContainerRef.current.offsetHeight;
+
+    if (containerWidth <= 0 || containerHeight <= 0) {
       console.error("mapContainerRef doesn't have dimensions");
       return null;
     }
 
+    const safePadding = clampFitBoundsPadding(options.padding, containerWidth, containerHeight);
+
     const { longitude, latitude, zoom } = fitBounds({
-      width: mapContainerRef.current.offsetWidth,
-      height: mapContainerRef.current.offsetHeight,
+      width: containerWidth,
+      height: containerHeight,
       bounds: [
         [bbox[1], bbox[3]],
         [bbox[0], bbox[2]],
       ],
       ...options,
+      ...(safePadding !== undefined && { padding: safePadding }),
     });
 
     const newViewport = {

--- a/app/layout/projects/show/map/index.tsx
+++ b/app/layout/projects/show/map/index.tsx
@@ -52,6 +52,7 @@ import LegendTypeGradient from 'components/map/legend/types/gradient';
 import LegendTypeMatrix from 'components/map/legend/types/matrix';
 import MapScale from 'components/map/scale';
 import HelpBeacon from 'layout/help/beacon';
+import { SIDEBAR_WIDTH } from 'layout/project/sidebar/constants';
 import { Scenario } from 'types/api/scenario';
 import { MapProps } from 'types/map';
 import { cn } from 'utils/cn';
@@ -276,9 +277,25 @@ export const ProjectMap = (): JSX.Element => {
   }, [rawScenariosData, sid1]);
 
   useEffect(() => {
+    // On narrow viewports the sidebar overlays (or hides) the map instead of
+    // offsetting it, so reserving SIDEBAR_WIDTH of left padding would push the
+    // padded area past the viewport. @math.gl/web-mercator's fitBounds()
+    // asserts padding fits inside the container — exceeding it throws
+    // "assertion failed" and crashes the page (MRXNM-87).
+    const viewportWidth =
+      typeof window === 'undefined' ? Number.POSITIVE_INFINITY : window.innerWidth;
+    const fitsSidebar = viewportWidth > SIDEBAR_WIDTH + 200;
+
     setBounds({
       bbox: BBOX,
-      options: { padding: { top: 50, right: 50, bottom: 50, left: 575 } },
+      options: {
+        padding: {
+          top: 50,
+          right: 50,
+          bottom: 50,
+          left: fitsSidebar ? SIDEBAR_WIDTH + 25 : 50,
+        },
+      },
       viewportOptions: { transitionDuration: 0 },
     });
   }, [BBOX]);

--- a/app/types/map.d.ts
+++ b/app/types/map.d.ts
@@ -17,7 +17,12 @@ export interface MapProps extends InteractiveMapProps {
   /** An object that defines the bounds */
   bounds?: {
     bbox: number[];
-    options?: {};
+    options?: {
+      padding?: number | { top: number; right: number; bottom: number; left: number };
+      minExtent?: number;
+      maxZoom?: number;
+      offset?: number[];
+    };
     viewportOptions?: Partial<ViewportProps>;
   };
 


### PR DESCRIPTION
## Summary

- Opening `/projects/[pid]` on a mobile browser rendered an apparent **"500 - Server-side error occurred"** page. The crash was actually **client-side**: the project map's fit-bounds effect hardcoded `padding: { left: 575 }`, which exceeds the viewport width on phones (e.g. 390 px). `@math.gl/web-mercator`'s `fitBounds()` asserts that padding fits inside the container and throws `"@math.gl/web-mercator: assertion failed."` otherwise. The throw bubbled to Next.js's error boundary, which rendered `_error.tsx` — that page (and `500.tsx`) literally title *"500 - Server-side error occurred"*, which made the client crash look like an SSR failure.
- **Call-site fix** (`app/layout/projects/show/map/index.tsx`): derive the left padding from the actual viewport using `SIDEBAR_WIDTH`, falling back to a small constant when the viewport can't accommodate the sidebar. Also replaces the `575` / `550` magic-number drift with the `SIDEBAR_WIDTH` constant.
- **Defense in depth** (`app/components/map/component.tsx`): clamp `options.padding` proportionally to the container dimensions before passing it to `fitBounds()`, so any future caller passing oversize padding degrades gracefully instead of crashing the page.
- **Type tightening** (`app/types/map.d.ts`): `MapProps.bounds.options` is no longer `{}` — `padding`, `minExtent`, `maxZoom`, `offset` are now described.

## Root cause stack (captured from production)

```
Error: @math.gl/web-mercator: assertion failed.
    at f (.../4508-…js)
    at w (.../4508-…js)
    at .../8544-…js  ← fitBounds()
    …
A client-side exception has occurred, see here for more info: https://nextjs.org/docs/messages/client-side-exception-occurred
```

## Test plan

- [ ] On a mobile viewport (≤ ~750 px wide) or Chrome DevTools device emulation (iPhone 12, 390 × 844): open a project at `/projects/[pid]` and confirm the page loads without crashing.
- [ ] On desktop (≥ 1024 px): open the same project and confirm the map still fits the project bounds to the right of the sidebar (no visual regression).
- [ ] Resize the window across the breakpoint and reload — the map should fit-bounds correctly on both initial loads.
- [ ] No console errors mentioning `@math.gl/web-mercator: assertion failed.` on either viewport.
- [ ] Existing project map flows (centerMap on sidebar toggle, fit-bounds control button, layer toggles) still behave as before.

## Notes

- `_error.tsx` and `500.tsx` share the same misleading heading — out of scope for this PR but worth a follow-up so future client-side crashes don't masquerade as server errors.