### PR TITLE
[MRXNM-88] fix(api/cloning): stop project import crash on nested-zip entries

### DIFF
--- a/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.handler.ts
+++ b/api/apps/api/src/modules/clone/infra/import/generate-export-from-zip-file.handler.ts
@@ -18,7 +18,7 @@ import { Logger } from '@nestjs/common';
 import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
 import { Either, isLeft, left, right } from 'fp-ts/lib/Either';
 import { Readable } from 'stream';
-import { Entry, Parse } from 'unzipper';
+import { Open } from 'unzipper';
 import { ExportId } from '../../export';
 import { ExportRepository } from '../../export/application/export-repository.port';
 import { ManifestFileService } from '../../export/application/manifest-file-service.port';
@@ -48,7 +48,7 @@ export class GenerateExportFromZipFileHandler
     private readonly manifestFileService: ManifestFileService,
   ) {}
 
-  private storeCloningFiles(
+  private async storeCloningFiles(
     exportId: string,
     zipReadable: Readable,
   ): Promise<
@@ -58,49 +58,32 @@ export class GenerateExportFromZipFileHandler
     >
   > {
     const uris: Record<string, string> = {};
-    let error = false;
+    // Open.buffer (central-directory) instead of Parse() (streaming): the
+    // streaming parser stalled / threw on nested-zip entries and the old
+    // event-listener shape let those failures escape uncaught.
+    try {
+      const buffer = await readableToBuffer(zipReadable);
+      const dir = await Open.buffer(buffer);
+      for (const file of dir.files) {
+        if (file.type !== 'File') continue;
 
-    return new Promise<
-      Either<
-        typeof errorStoringCloningFile | typeof unknownError,
-        Record<string, string>
-      >
-    >((resolve) => {
-      zipReadable
-        .pipe(Parse())
-        .on('entry', async (entry: Entry) => {
-          if (entry.type !== 'File' || error) {
-            entry.autodrain();
-            return;
-          }
+        const result = await this.fileRepository.saveCloningFile(
+          exportId,
+          file.stream(),
+          file.path,
+        );
 
-          const result = await this.fileRepository.saveCloningFile(
-            exportId,
-            entry,
-            entry.path,
-          );
+        if (isLeft(result)) {
+          return left(errorStoringCloningFile);
+        }
 
-          if (isLeft(result)) {
-            error = true;
-            return;
-          }
-
-          uris[entry.path] = result.right;
-        })
-        .on('close', () => {
-          if (error) {
-            this.logger.error(error);
-            resolve(left(errorStoringCloningFile));
-            return;
-          }
-
-          resolve(right(uris));
-        })
-        .on('error', () => {
-          this.logger.error(error);
-          resolve(left(errorStoringCloningFile));
-        });
-    });
+        uris[file.path] = result.right;
+      }
+      return right(uris);
+    } catch (err) {
+      this.logger.error(err);
+      return left(errorStoringCloningFile);
+    }
   }
 
   private getExportComponents(

--- a/api/apps/api/test/projects/project-cloning/import-project.e2e-spec.ts
+++ b/api/apps/api/test/projects/project-cloning/import-project.e2e-spec.ts
@@ -27,7 +27,7 @@ import { HttpStatus } from '@nestjs/common';
 import { CommandBus, CqrsModule } from '@nestjs/cqrs';
 import * as archiver from 'archiver';
 import { isLeft } from 'fp-ts/lib/These';
-import { createWriteStream, rmSync } from 'fs';
+import { createWriteStream, readFileSync, rmSync, writeFileSync } from 'fs';
 import { Readable } from 'stream';
 import * as request from 'supertest';
 import { DataSource } from 'typeorm';
@@ -81,6 +81,11 @@ test('should deny importing project when a modified zip is provided', async () =
   await fixtures.WhenImportIsRequested().ThenABadRequestErrorIsReturned();
 });
 
+test('should reject a truncated zip with a 400 rather than crashing the process', async () => {
+  await fixtures.GivenImportFile({ withZipFileTruncation: true });
+  await fixtures.WhenImportIsRequested().ThenABadRequestErrorIsReturned();
+});
+
 export const getFixtures = async () => {
   const app = await bootstrapApplication([CqrsModule], [EventBusTestUtils]);
   const manifestFileService = app.get(ManifestFileService);
@@ -113,7 +118,13 @@ export const getFixtures = async () => {
       await app.close();
     },
     GivenImportFile: async (
-      { withZipFileModification } = { withZipFileModification: false },
+      {
+        withZipFileModification,
+        withZipFileTruncation,
+      }: {
+        withZipFileModification?: boolean;
+        withZipFileTruncation?: boolean;
+      } = {},
     ) => {
       const exportConfigContent: ProjectExportConfigContent = {
         version: exportVersion,
@@ -196,6 +207,14 @@ export const getFixtures = async () => {
       await cloningFilesRepo.deleteExportFolder(exportId.value);
 
       uriZipFile = await saveFile(__dirname + '/export.zip', zipFile);
+
+      if (withZipFileTruncation) {
+        const original = readFileSync(uriZipFile);
+        writeFileSync(
+          uriZipFile,
+          original.subarray(0, Math.floor(original.length / 2)),
+        );
+      }
     },
     GivenImportWasRequested: async () => {
       const response = await request(app.getHttpServer())

--- a/api/libs/utils/src/file-operations.ts
+++ b/api/libs/utils/src/file-operations.ts
@@ -2,6 +2,7 @@ import { Either, left, right } from 'fp-ts/lib/Either';
 import { createWriteStream, existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 
 export const fileAlreadyExists = Symbol(`file already exists`);
 export const unknownError = Symbol(`unknown error`);
@@ -37,24 +38,17 @@ export async function storeFile(
   stream: Readable,
   opts: StoreFileOptions = { override: false },
 ): Promise<Either<StoreFileError, string>> {
-  const fileExists = existsSync(path);
-
-  if (fileExists && !opts.override) {
+  if (existsSync(path) && !opts.override) {
     return left(fileAlreadyExists);
   }
 
-  const writer = createWriteStream(path);
-
-  return new Promise((resolve) => {
-    writer.on('close', () => {});
-    writer.on(`finish`, () => {
-      resolve(right(path));
-    });
-    writer.on('error', (error) => {
-      console.error(error);
-      resolve(left(unknownError));
-    });
-
-    stream.pipe(writer);
-  });
+  try {
+    // pipeline (not raw .pipe()) so a source-side error doesn't escape as
+    // an unhandled 'error' event.
+    await pipeline(stream, createWriteStream(path));
+    return right(path);
+  } catch (error) {
+    console.error(error);
+    return left(unknownError);
+  }
 }

--- a/api/libs/utils/src/zip-file-extractor.spec.ts
+++ b/api/libs/utils/src/zip-file-extractor.spec.ts
@@ -1,0 +1,102 @@
+import * as archiver from 'archiver';
+import { isLeft, isRight } from 'fp-ts/lib/Either';
+import { Readable } from 'stream';
+
+import { readableToBuffer } from './readable-to-buffer';
+import {
+  extractFile,
+  extractFileFailed,
+  fileNotFound,
+} from './zip-file-extractor';
+
+async function buildZip(entries: Record<string, string>): Promise<Buffer> {
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  for (const [name, content] of Object.entries(entries)) {
+    archive.append(content, { name });
+  }
+  await archive.finalize();
+  return readableToBuffer(archive);
+}
+
+describe('extractFile', () => {
+  it('returns Right with file content when the target file exists', async () => {
+    const zip = await buildZip({
+      'config.json': '{"hello":"world"}',
+      'other.txt': 'lorem ipsum',
+    });
+
+    const result = await extractFile(Readable.from(zip), 'config.json');
+
+    expect(isRight(result)).toBe(true);
+    if (isRight(result)) expect(result.right).toBe('{"hello":"world"}');
+  });
+
+  it('returns Left(fileNotFound) when the target file is not in the zip', async () => {
+    const zip = await buildZip({ 'other.txt': 'lorem ipsum' });
+
+    const result = await extractFile(Readable.from(zip), 'missing.json');
+
+    expect(isLeft(result)).toBe(true);
+    if (isLeft(result)) expect(result.left).toBe(fileNotFound);
+  });
+
+  it('returns Left(extractFileFailed) for a truncated zip', async () => {
+    const zip = await buildZip({
+      'config.json': '{"hello":"world"}',
+      'big.txt': 'x'.repeat(4096),
+    });
+    const truncated = zip.subarray(0, Math.floor(zip.length / 2));
+
+    const result = await extractFile(Readable.from(truncated), 'config.json');
+
+    expect(isLeft(result)).toBe(true);
+    if (isLeft(result)) expect(result.left).toBe(extractFileFailed);
+  });
+
+  // Regression: the previous implementation used `new Promise(async resolve => …)`
+  // with a for-await loop that kept iterating after `resolve(right(...))`.
+  // A late stream error on the abandoned iterator surfaced as an unhandled
+  // rejection that crashed the api pod. This guards against re-introducing
+  // that escape path.
+  it('does not leak unhandled rejections after returning Right on an early entry', async () => {
+    const zip = await buildZip({
+      'early.json': '{"first":true}',
+      ...Object.fromEntries(
+        Array.from({ length: 20 }, (_, i) => [`trail-${i}.txt`, `entry ${i}`]),
+      ),
+    });
+
+    const rejections: unknown[] = [];
+    const handler = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', handler);
+    try {
+      const result = await extractFile(Readable.from(zip), 'early.json');
+      expect(isRight(result)).toBe(true);
+      // Let any rogue background work surface before we assert.
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      process.off('unhandledRejection', handler);
+    }
+    expect(rejections).toEqual([]);
+  });
+
+  it('does not leak unhandled rejections when the zip is truncated', async () => {
+    const zip = await buildZip({
+      'config.json': '{"hello":"world"}',
+      'big.txt': 'x'.repeat(4096),
+    });
+    const truncated = zip.subarray(0, Math.floor(zip.length / 2));
+
+    const rejections: unknown[] = [];
+    const handler = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', handler);
+    try {
+      const result = await extractFile(Readable.from(truncated), 'config.json');
+      expect(isLeft(result)).toBe(true);
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      process.off('unhandledRejection', handler);
+    }
+    expect(rejections).toEqual([]);
+  });
+});

--- a/api/libs/utils/src/zip-file-extractor.ts
+++ b/api/libs/utils/src/zip-file-extractor.ts
@@ -1,6 +1,7 @@
 import { Either, left, right } from 'fp-ts/lib/Either';
 import { Readable } from 'stream';
-import { Parse } from 'unzipper';
+import { Open } from 'unzipper';
+import { readableToBuffer } from './readable-to-buffer';
 
 export const extractFileFailed = Symbol('Extract file failed');
 export const fileNotFound = Symbol('File not found');
@@ -9,22 +10,17 @@ export async function extractFile(
   readable: Readable,
   fileRelativePath: string,
 ): Promise<Either<typeof extractFileFailed | typeof fileNotFound, string>> {
-  return new Promise<
-    Either<typeof extractFileFailed | typeof fileNotFound, string>
-  >(async (resolve) => {
-    const zip = readable.pipe(Parse({ forceStream: true })).on('error', () => {
-      resolve(left(extractFileFailed));
-    });
-
-    for await (const entry of zip) {
-      if (entry.path !== fileRelativePath) {
-        entry.autodrain();
-        continue;
-      }
-      const buffer = await entry.buffer();
-      resolve(right(buffer.toString()));
-    }
-
-    resolve(left(fileNotFound));
-  });
+  // Open.buffer (central-directory mode) instead of Parse() (streaming):
+  // Parse's underlying zlib stalls/errors unpredictably on entries with
+  // nested zip payloads.
+  try {
+    const buffer = await readableToBuffer(readable);
+    const dir = await Open.buffer(buffer);
+    const file = dir.files.find((f) => f.path === fileRelativePath);
+    if (!file) return left(fileNotFound);
+    const content = await file.buffer();
+    return right(content.toString());
+  } catch (err) {
+    return left(extractFileFailed);
+  }
 }


### PR DESCRIPTION
[MRXNM-88](https://vizzuality.atlassian.net/browse/MRXNM-88) — less-technical walkthrough of the mechanism in the ticket comments.

## Summary

- Project import (`POST /api/v1/projects/import`) crashed the api pod with `Z_BUF_ERROR: unexpected end of file`, *after* HTTP 201 had already been returned. The export zip itself is never corrupt — `unzip -t` validates fine.
- Root cause: `unzipper.Parse()` (streaming) trips on archiver-produced entries that are themselves zips. The error escaped as an unhandled rejection from a `new Promise(async (resolve) => …)` executor whose Promise had already settled — request returned 201, sagas fired, then the abandoned for-await crashed the process seconds later.
- Fix: switch the two zip-reading sites to `unzipper.Open.buffer` (central-directory mode), drop the async-executor pattern in `extractFile`, and use `stream/promises.pipeline` in `storeFile`.

## Z_BUF_ERROR casuistry

- `archiver` writes every local file header with PKWARE general-purpose bit 3 set (data descriptors) → `compressed_size = 0` in the local header. A streaming parser has to feed bytes to a per-entry zlib inflate until zlib itself signals `Z_STREAM_END`, then read the data descriptor. `Z_BUF_ERROR` (errno -5) = "input exhausted, deflate stream not terminated" — Parse called `.end()` on the inflate before zlib had seen everything it needed.
- The failing entries are nested `.zip` files inside `marxan-execution-metadata/…` — already-compressed payloads re-deflated by archiver. Their deflate streams exercise inflate paths the streaming parser handles less reliably.
- The crash was timing-dependent on how each entry was consumed:

  | Consumption pattern | Outcome |
  |---|---|
  | `autodrain()` | OK |
  | `entry.pipe(writer)` parallel (prior code) | `Z_BUF_ERROR` at entry 51 → pod crash |
  | `entry.pipe(writer)` sequential w/ pipeline | Hang at entry 51 (entry never ends nor errors) |

- `Open.buffer` reads the central directory first (authoritative offsets/sizes/CRC) and decompresses each entry independently — no streaming-state guesses. We already have the whole zip in memory via multer's `memoryStorage`, so streaming bought us nothing and cost us the entire bug class. The `pipeline` + plain-async-function changes are independently valuable for closing unhandled-rejection escape paths.

## Test plan

- [ ] Upload the previously-reproducing export zip on staging; expect the import to complete end-to-end with no `Z_BUF_ERROR` in api logs.
- [ ] Upload a deliberately truncated zip (`head -c $((SIZE/2))`); expect HTTP 400 `Invalid export zip file`, not a process crash.
- [ ] `make test-e2e-api environment=local` — confirm `import-project.e2e-spec.ts` still passes.

[MRXNM-88]: https://vizzuality.atlassian.net/browse/MRXNM-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ