### PR TITLE
fix(geoprocessing): EXISTS semi-join for scenario feature-list aggregation [MRXNM-92]

### DIFF
--- a/.github/workflows/tests-geoprocessing-e2e.yml
+++ b/.github/workflows/tests-geoprocessing-e2e.yml
@@ -27,6 +27,7 @@ jobs:
           - 'integration/planning-unit-grid'
           - 'integration/planning-unit-inclusion'
           - 'integration/protected-areas'
+          - 'integration/scenario-planning-units-features-aggregate'
           - 'tiles'
           - 'worker-module'
 

--- a/api/apps/geoprocessing/src/modules/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate-processor.ts
+++ b/api/apps/geoprocessing/src/modules/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate-processor.ts
@@ -15,6 +15,16 @@ import { JobInput } from '@marxan/planning-unit-features';
  * Format per element: "featureId:amount"
  *
  * Only includes features that are part of the scenario (via scenario_features_data).
+ *
+ * Membership in the scenario is expressed as a `WHERE EXISTS` semi-join rather
+ * than an `INNER JOIN` on scenario_features_data: that table has no unique
+ * constraint on (scenario_id, api_feature_id), so a join would multiply every
+ * matching amount row by the number of duplicate feature rows, producing a
+ * huge intermediate result that PostgreSQL sorts (and spills to disk) before
+ * DISTINCT collapses it again. EXISTS short-circuits on the first match, so the
+ * de-duplicated set never materialises. DISTINCT is retained because neither
+ * feature_amounts_per_planning_unit nor scenario_features_data guarantees
+ * uniqueness, but it now sorts only the de-multiplied rows.
  */
 const query = `
 UPDATE scenarios_pu_data
@@ -27,10 +37,13 @@ FROM (
   FROM scenarios_pu_data spd
   INNER JOIN feature_amounts_per_planning_unit fappu
     ON fappu.project_pu_id = spd.project_pu_id
-  INNER JOIN scenario_features_data sfd
-    ON sfd.api_feature_id = fappu.feature_id
-   AND sfd.scenario_id = spd.scenario_id
   WHERE spd.scenario_id = $1
+    AND EXISTS (
+      SELECT 1
+      FROM scenario_features_data sfd
+      WHERE sfd.api_feature_id = fappu.feature_id
+        AND sfd.scenario_id = spd.scenario_id
+    )
   GROUP BY spd.id
 ) AS sub
 WHERE scenarios_pu_data.id = sub.scenario_pu_id;

--- a/api/apps/geoprocessing/test/integration/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate.e2e-spec.ts
@@ -53,7 +53,12 @@ describe('scenario planning units features aggregate', () => {
     processor = new ScenarioPlanningUnitsFeaturesAggregateProcessor(
       geoEntityManager,
     );
+  });
 
+  beforeEach(async () => {
+    // The geo e2e harness truncates every table in a global beforeEach
+    // (test/utils/handle-database.ts), which runs after this describe's
+    // beforeAll. Seed here so the data survives into the test body.
     scenarioPuData = await GivenScenarioPuDataExists(
       geoEntityManager,
       projectId,
@@ -76,7 +81,6 @@ describe('scenario planning units features aggregate', () => {
   });
 
   afterAll(async () => {
-    await CleanUp(geoEntityManager, scenarioId, projectId);
     await app.close();
   });
 
@@ -148,26 +152,4 @@ const GivenScenarioFeatureMembership = async (
       [v4(), scenarioId, apiFeatureId, v4()],
     );
   }
-};
-
-const CleanUp = async (
-  entityManager: EntityManager,
-  scenarioId: string,
-  projectId: string,
-): Promise<void> => {
-  await entityManager.query(
-    `DELETE FROM scenario_features_data WHERE scenario_id = $1`,
-    [scenarioId],
-  );
-  await entityManager.query(
-    `DELETE FROM feature_amounts_per_planning_unit WHERE project_id = $1`,
-    [projectId],
-  );
-  await entityManager.query(
-    `DELETE FROM scenarios_pu_data WHERE scenario_id = $1`,
-    [scenarioId],
-  );
-  await entityManager.query(`DELETE FROM projects_pu WHERE project_id = $1`, [
-    projectId,
-  ]);
 };

--- a/api/apps/geoprocessing/test/integration/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate.e2e-spec.ts
@@ -1,0 +1,173 @@
+import { INestApplication } from '@nestjs/common';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { Job } from 'bullmq';
+import { EntityManager } from 'typeorm';
+import { v4 } from 'uuid';
+
+import { geoprocessingConnections } from '@marxan-geoprocessing/ormconfig';
+import { ScenarioPlanningUnitsFeaturesAggregateProcessor } from '@marxan-geoprocessing/modules/scenario-planning-units-features-aggregate/scenario-planning-units-features-aggregate-processor';
+import { FeatureAmountsPerPlanningUnitEntity } from '@marxan/feature-amounts-per-planning-unit';
+import { JobInput } from '@marxan/planning-unit-features';
+import { ScenariosPuPaDataGeo } from '@marxan/scenarios-planning-unit';
+
+import { bootstrapApplication } from '../../utils';
+import { GivenScenarioPuDataExists } from '../../steps/given-scenario-pu-data-exists';
+
+/**
+ * Regression coverage for the feature-list aggregation query.
+ *
+ * The query joins precomputed per-PU feature amounts against the features that
+ * belong to the scenario. The membership test is expressed as a `WHERE EXISTS`
+ * semi-join over `scenario_features_data` (which has no unique constraint on
+ * (scenario_id, api_feature_id)), so this test deliberately seeds:
+ *  - a feature with DUPLICATE scenario_features_data rows -> must appear once,
+ *  - a feature with a single membership row -> normal case,
+ *  - a feature present in feature_amounts_per_planning_unit but NOT in the
+ *    scenario -> must be excluded.
+ */
+describe('scenario planning units features aggregate', () => {
+  let app: INestApplication;
+  let geoEntityManager: EntityManager;
+  let processor: ScenarioPlanningUnitsFeaturesAggregateProcessor;
+
+  const projectId = v4();
+  const scenarioId = v4();
+  // feature present in the scenario via two (duplicate) membership rows
+  const duplicatedFeatureId = v4();
+  // feature present in the scenario via a single membership row
+  const singleFeatureId = v4();
+  // feature with amounts but NOT part of the scenario -> must be excluded
+  const orphanFeatureId = v4();
+
+  const duplicatedFeatureAmount = 10;
+  const singleFeatureAmount = 20;
+  const orphanFeatureAmount = 30;
+
+  let scenarioPuData: ScenariosPuPaDataGeo[];
+
+  beforeAll(async () => {
+    app = await bootstrapApplication();
+    geoEntityManager = app.get(
+      getEntityManagerToken(geoprocessingConnections.default),
+    );
+    processor = new ScenarioPlanningUnitsFeaturesAggregateProcessor(
+      geoEntityManager,
+    );
+
+    scenarioPuData = await GivenScenarioPuDataExists(
+      geoEntityManager,
+      projectId,
+      scenarioId,
+    );
+
+    await GivenFeatureAmountsExist(geoEntityManager, projectId, scenarioPuData, [
+      { featureId: duplicatedFeatureId, amount: duplicatedFeatureAmount },
+      { featureId: singleFeatureId, amount: singleFeatureAmount },
+      { featureId: orphanFeatureId, amount: orphanFeatureAmount },
+    ]);
+
+    // duplicatedFeatureId gets two membership rows to force a fan-out that the
+    // old INNER JOIN + ARRAY_AGG(DISTINCT) collapsed and the new EXISTS avoids.
+    await GivenScenarioFeatureMembership(geoEntityManager, scenarioId, [
+      duplicatedFeatureId,
+      duplicatedFeatureId,
+      singleFeatureId,
+    ]);
+  });
+
+  afterAll(async () => {
+    await CleanUp(geoEntityManager, scenarioId, projectId);
+    await app.close();
+  });
+
+  it('aggregates the scenario feature list, de-duplicating and excluding non-member features', async () => {
+    await processor.process({
+      data: { scenarioId },
+    } as unknown as Job<JobInput, true>);
+
+    const rows: { id: string; feature_list: string[] }[] =
+      await geoEntityManager.query(
+        `SELECT id, feature_list FROM scenarios_pu_data WHERE scenario_id = $1`,
+        [scenarioId],
+      );
+
+    expect(rows).toHaveLength(scenarioPuData.length);
+
+    const expected = [
+      `${duplicatedFeatureId}:${duplicatedFeatureAmount}`,
+      `${singleFeatureId}:${singleFeatureAmount}`,
+    ].sort();
+
+    for (const row of rows) {
+      expect([...row.feature_list].sort()).toEqual(expected);
+      // orphan feature has amounts but no membership row -> excluded
+      expect(
+        row.feature_list.some((element) =>
+          element.startsWith(`${orphanFeatureId}:`),
+        ),
+      ).toBe(false);
+      // duplicated membership rows must not duplicate the feature entry
+      expect(
+        row.feature_list.filter((element) =>
+          element.startsWith(`${duplicatedFeatureId}:`),
+        ),
+      ).toHaveLength(1);
+    }
+  });
+});
+
+const GivenFeatureAmountsExist = async (
+  entityManager: EntityManager,
+  projectId: string,
+  scenarioPuData: ScenariosPuPaDataGeo[],
+  features: { featureId: string; amount: number }[],
+): Promise<void> => {
+  const repo = entityManager.getRepository(FeatureAmountsPerPlanningUnitEntity);
+  const rows = scenarioPuData.flatMap((pu) =>
+    features.map((feature) =>
+      repo.create({
+        projectId,
+        featureId: feature.featureId,
+        amount: feature.amount,
+        projectPuId: pu.projectPuId,
+      }),
+    ),
+  );
+  await repo.save(rows);
+};
+
+const GivenScenarioFeatureMembership = async (
+  entityManager: EntityManager,
+  scenarioId: string,
+  apiFeatureIds: string[],
+): Promise<void> => {
+  for (const apiFeatureId of apiFeatureIds) {
+    await entityManager.query(
+      `INSERT INTO scenario_features_data (id, scenario_id, api_feature_id, created_by)
+       VALUES ($1, $2, $3, $4)`,
+      [v4(), scenarioId, apiFeatureId, v4()],
+    );
+  }
+};
+
+const CleanUp = async (
+  entityManager: EntityManager,
+  scenarioId: string,
+  projectId: string,
+): Promise<void> => {
+  await entityManager.query(
+    `DELETE FROM scenario_features_data WHERE scenario_id = $1`,
+    [scenarioId],
+  );
+  await entityManager.query(
+    `DELETE FROM feature_amounts_per_planning_unit WHERE project_id = $1`,
+    [projectId],
+  );
+  await entityManager.query(
+    `DELETE FROM scenarios_pu_data WHERE scenario_id = $1`,
+    [scenarioId],
+  );
+  await entityManager.query(`DELETE FROM projects_pu WHERE project_id = $1`, [
+    projectId,
+  ]);
+};


### PR DESCRIPTION
## Problem

The scenario planning-unit feature-list aggregation (`featuresWithPuIntersection` step / `planning-unit-features-aggregate` queue) `INNER JOIN`ed `scenario_features_data`, which has **no unique constraint** on `(scenario_id, api_feature_id)`. Each duplicate membership row multiplied every matching per-PU amount row, so on dense projects the subquery produced a **~24.5M-row sort that spilled to disk and ran 6h+**, stalling the step indefinitely.

Observed on production project *Blueprint Golfo de California* (79 features × 14,500 PUs); scenarios sat at `feature_list` 0/14500 for 6h49m, never finishing. This is the MRXNM-92 scale cliff that blocks BLM calibration / gap analysis on larger projects.

## Fix

Express scenario membership as a `WHERE EXISTS` semi-join instead of an `INNER JOIN`. `EXISTS` short-circuits on the first match, so the fan-out never materialises — the subquery now operates on the de-multiplied row set (~1.1M rows for the affected project, fits in `work_mem`).

`DISTINCT` is **retained** because neither `feature_amounts_per_planning_unit` nor `scenario_features_data` guarantees uniqueness. `JOIN + DISTINCT` and `EXISTS + DISTINCT` produce the **identical** de-duplicated set for all data shapes — only the cost changes. This is a stricter, provably behavior-preserving variant of the originally-proposed "EXISTS + drop DISTINCT".

No schema or index changes; existing indexes are adequate.

## Testing

- Adds an integration regression test (`scenario-planning-units-features-aggregate.e2e-spec.ts`) that seeds:
  - a feature with **duplicate** `scenario_features_data` rows → must appear **once** (dedup),
  - a feature with a single membership row → normal case,
  - a feature present in `feature_amounts_per_planning_unit` but **not** in the scenario → must be **excluded** (EXISTS membership semantics).
- Whole-project `tsc --noEmit`: 0 errors.

## Notes

`feature_list` is a denormalized cache (consumed by tile feature-count and cloning export/import); Marxan's `puvspr.dat` is derived directly from base tables, so element ordering is not significant.