### PR TITLE
fix(uploads): raise & centralize project-import size limit [MRXNM-91]

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -52,6 +52,17 @@ applications.
   environments and via Persistent Volumes in Kubernetes environments) should
   be set accordingly
 
+* `API_UPLOAD_PROJECT_IMPORT_MAX_SIZE` (number, optional, default is
+  `1073741824`, i.e. 1 GiB): maximum size, in bytes, accepted by the project
+  import and legacy-project import upload endpoints. Must mirror the frontend
+  `PROJECT_UPLOADER_MAX_SIZE` constant
+  (`app/constants/file-uploader-size-limits.js`)
+
+* `API_UPLOAD_FEATURE_CSV_MAX_SIZE` (number, optional, default is `52428800`,
+  i.e. 50 MiB): maximum size, in bytes, accepted by the feature-amounts CSV
+  upload endpoint. Must mirror the frontend `FEATURES_UPLOADER_CSV_MAX_SIZE`
+  constant
+
 * `API_DAEMON_LISTEN_PORT` (number, optional, default is 3000; this variable is
   only useful when running the service natively, not in a Docker container):
   port on which the Express daemon of the API service will listen. If

--- a/api/apps/api/config/custom-environment-variables.json
+++ b/api/apps/api/config/custom-environment-variables.json
@@ -86,7 +86,9 @@
     "limits": {
       "singleGeometry": "API_UPLOAD_SINGLE_MAX_SIZE",
       "complexGeometryWithoutProperties": "API_UPLOAD_COMPLEX_MAX_SIZE",
-      "complexGeometryWithProperties": "API_UPLOAD_COMPLEX_PROPERTIES_MAX_SIZE"
+      "complexGeometryWithProperties": "API_UPLOAD_COMPLEX_PROPERTIES_MAX_SIZE",
+      "projectImport": "API_UPLOAD_PROJECT_IMPORT_MAX_SIZE",
+      "featureCsvUpload": "API_UPLOAD_FEATURE_CSV_MAX_SIZE"
     }
   },
   "sparkpost": {

--- a/api/apps/api/src/modules/projects/projects.cloning.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.cloning.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   Header,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
   Param,
   Post,
@@ -64,6 +65,8 @@ import {
 @ApiTags('Project - cloning')
 @Controller(`${apiGlobalPrefixes.v1}/projects`)
 export class ProjectCloningController {
+  private readonly logger = new Logger(ProjectCloningController.name);
+
   constructor(private readonly projectsService: ProjectsService) {}
 
   @ImplementsAcl()
@@ -307,6 +310,11 @@ export class ProjectCloningController {
         case invalidExportZipFile:
           throw new BadRequestException('Invalid export zip file');
         default:
+          this.logger.error(
+            `Unexpected error importing project (user ${req.user.id}): ${String(
+              idsOrError.left,
+            )}`,
+          );
           throw new InternalServerErrorException(idsOrError.left);
       }
     }

--- a/api/apps/api/src/modules/projects/projects.cloning.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.cloning.controller.ts
@@ -26,7 +26,7 @@ import {
 import { apiGlobalPrefixes } from '@marxan-api/api.config';
 import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { uploadOptions } from '@marxan-api/utils/file-uploads.utils';
+import { projectImport } from '@marxan-api/modules/uploads';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
 import {
   notAllowed,
@@ -285,9 +285,7 @@ export class ProjectCloningController {
    * handle bigger archives, which may came with their own set of additional
    * challenges.
    */
-  @UseInterceptors(
-    FileInterceptor('file', { limits: uploadOptions(50 * 1024 ** 2).limits }),
-  )
+  @UseInterceptors(FileInterceptor('file', { limits: projectImport() }))
   async importProject(
     @Body() dto: RequestProjectImportBodyDto,
     @UploadedFile() file: Express.Multer.File,

--- a/api/apps/api/src/modules/projects/projects.legacy-projects.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.legacy-projects.controller.ts
@@ -25,7 +25,7 @@ import {
 import { apiGlobalPrefixes } from '@marxan-api/api.config';
 import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { uploadOptions } from '@marxan-api/utils/file-uploads.utils';
+import { projectImport } from '@marxan-api/modules/uploads';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
 import { ProjectsService } from './projects.service';
 import { isLeft } from 'fp-ts/Either';
@@ -208,7 +208,7 @@ export class LegacyProjectsController {
   @Post('import/legacy/:projectId/data-file')
   @ApiOkResponse({ type: AddFileToLegacyProjectImportResponseDto })
   @ApiConsumes('multipart/form-data')
-  @UseInterceptors(FileInterceptor('file', { limits: uploadOptions().limits }))
+  @UseInterceptors(FileInterceptor('file', { limits: projectImport() }))
   async addFileToLegacyProjectImport(
     @Body() dto: AddFileToLegacyProjectImportBodyDto,
     @Param('projectId', ParseUUIDPipe) projectId: string,

--- a/api/apps/api/src/modules/projects/projects.project-features.controller.ts
+++ b/api/apps/api/src/modules/projects/projects.project-features.controller.ts
@@ -32,7 +32,7 @@ import {
 import { apiGlobalPrefixes } from '@marxan-api/api.config';
 import { JwtAuthGuard } from '@marxan-api/guards/jwt-auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { uploadOptions } from '@marxan-api/utils/file-uploads.utils';
+import { featureCsvUpload } from '@marxan-api/modules/uploads';
 
 import { JSONAPIQueryParams } from '@marxan-api/decorators/json-api-parameters.decorator';
 import { RequestWithAuthenticatedUser } from '@marxan-api/app.controller';
@@ -167,9 +167,7 @@ export class ProjectFeaturesController {
     description: 'Id of the Project the feature is part of',
   })
   @ApiOkResponse()
-  @UseInterceptors(
-    FileInterceptor('file', { limits: uploadOptions(50 * 1024 ** 2).limits }),
-  )
+  @UseInterceptors(FileInterceptor('file', { limits: featureCsvUpload() }))
   @Post(`:projectId/features/csv`)
   async setFeatureAmountFromCSV(
     @Param('projectId', ParseUUIDPipe) projectId: string,

--- a/api/apps/api/src/modules/projects/projects.service.ts
+++ b/api/apps/api/src/modules/projects/projects.service.ts
@@ -7,6 +7,7 @@ import {
   forwardRef,
   Inject,
   Injectable,
+  Logger,
 } from '@nestjs/common';
 import { FetchSpecification } from 'nestjs-base-service';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
@@ -146,6 +147,8 @@ export const projectNotFoundForExport = Symbol(`project not found`);
 
 @Injectable()
 export class ProjectsService {
+  private readonly logger = new Logger(ProjectsService.name);
+
   constructor(
     private readonly geoCrud: GeoFeaturesService,
     private readonly projectsCrud: ProjectsCrudService,
@@ -772,15 +775,30 @@ export class ProjectsService {
       ImportProjectCommandResult
     >
   > {
+    const archiveMiB = ((exportFile?.size ?? 0) / 1024 ** 2).toFixed(1);
+    const startedAt = Date.now();
+    this.logger.log(
+      `Project import started: ${archiveMiB} MiB archive (user ${userId})`,
+    );
+
     if (!(await this.projectAclService.canImportProject(userId))) {
+      this.logger.warn(
+        `Project import forbidden for user ${userId} (${archiveMiB} MiB archive)`,
+      );
       return left(forbiddenError);
     }
 
+    const generateStartedAt = Date.now();
     const exportIdOrError = await this.commandBus.execute(
       new GenerateExportFromZipFile(exportFile, new UserId(userId)),
     );
+    const generateMs = Date.now() - generateStartedAt;
 
     if (isLeft(exportIdOrError)) {
+      this.logger.warn(
+        `Project import failed validating ${archiveMiB} MiB archive after ${generateMs}ms ` +
+          `(${String(exportIdOrError.left)}, user ${userId})`,
+      );
       return exportIdOrError;
     }
 
@@ -789,9 +807,17 @@ export class ProjectsService {
     );
 
     if (isLeft(idsOrError)) {
+      this.logger.warn(
+        `Project import failed scheduling import after ${Date.now() - startedAt}ms ` +
+          `(${String(idsOrError.left)}, ${archiveMiB} MiB archive, user ${userId})`,
+      );
       return idsOrError;
     }
 
+    this.logger.log(
+      `Project import accepted in ${Date.now() - startedAt}ms ` +
+        `(archive validation ${generateMs}ms, ${archiveMiB} MiB, user ${userId})`,
+    );
     return right(idsOrError.right);
   }
 

--- a/api/apps/api/src/modules/uploads/upload-limits.spec.ts
+++ b/api/apps/api/src/modules/uploads/upload-limits.spec.ts
@@ -1,0 +1,32 @@
+import { AppConfig } from '@marxan-api/utils/config.utils';
+import { featureCsvUpload, projectImport } from './upload-limits';
+
+describe('upload-limits: project import & feature CSV', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  const mockConfig = (overrides: Record<string, number>) =>
+    jest
+      .spyOn(AppConfig, 'get')
+      .mockImplementation(((property: string, defaultValue: number) =>
+        property in overrides ? overrides[property] : defaultValue) as never);
+
+  it('projectImport defaults to 1 GiB (matches frontend PROJECT_UPLOADER_MAX_SIZE)', () => {
+    mockConfig({});
+    expect(projectImport()?.fileSize).toBe(1073741824);
+  });
+
+  it('projectImport honours fileUploads.limits.projectImport when configured', () => {
+    mockConfig({ 'fileUploads.limits.projectImport': 12345 });
+    expect(projectImport()?.fileSize).toBe(12345);
+  });
+
+  it('featureCsvUpload defaults to 50 MiB (matches frontend FEATURES_UPLOADER_CSV_MAX_SIZE)', () => {
+    mockConfig({});
+    expect(featureCsvUpload()?.fileSize).toBe(52428800);
+  });
+
+  it('featureCsvUpload honours fileUploads.limits.featureCsvUpload when configured', () => {
+    mockConfig({ 'fileUploads.limits.featureCsvUpload': 999 });
+    expect(featureCsvUpload()?.fileSize).toBe(999);
+  });
+});

--- a/api/apps/api/src/modules/uploads/upload-limits.ts
+++ b/api/apps/api/src/modules/uploads/upload-limits.ts
@@ -31,3 +31,29 @@ export const complexGeometryWithProperties = (): MulterOptions['limits'] => ({
       mebibytesToBytes(20),
     ))(),
 });
+
+/**
+ * Project-archive and feature-CSV upload limits.
+ *
+ * These MUST stay in sync with the frontend constants in
+ * `app/constants/file-uploader-size-limits.js`:
+ *   - projectImport    <-> PROJECT_UPLOADER_MAX_SIZE       (1 GiB / 1073741824)
+ *   - featureCsvUpload  <-> FEATURES_UPLOADER_CSV_MAX_SIZE  (50 MiB / 52428800)
+ * Overridable per-environment via API_UPLOAD_PROJECT_IMPORT_MAX_SIZE /
+ * API_UPLOAD_FEATURE_CSV_MAX_SIZE (values in bytes).
+ */
+export const projectImport = (): MulterOptions['limits'] => ({
+  fileSize: (() =>
+    AppConfig.get<number>(
+      'fileUploads.limits.projectImport',
+      mebibytesToBytes(1024),
+    ))(),
+});
+
+export const featureCsvUpload = (): MulterOptions['limits'] => ({
+  fileSize: (() =>
+    AppConfig.get<number>(
+      'fileUploads.limits.featureCsvUpload',
+      mebibytesToBytes(50),
+    ))(),
+});

--- a/app/layout/projects/all/toolbar/upload-btn/upload-modal/component.tsx
+++ b/app/layout/projects/all/toolbar/upload-btn/upload-modal/component.tsx
@@ -100,18 +100,35 @@ export const UploadModal: React.FC<UploadModalProps> = ({ onDismiss }: UploadMod
 
             console.info('Project uploaded');
           },
-          onError: ({ response }) => {
-            const { errors } = response.data;
-
+          onError: (error: any) => {
             setLoading(false);
+
+            const response = error?.response;
+            const appErrors = response?.data?.errors;
+            // No response (timeout/aborted/network) or a gateway/server 5xx with
+            // no structured app error: the upload likely timed out. Large projects
+            // can take a while and may still be importing in the background.
+            const timedOutOrUnreachable = error?.code === 'ECONNABORTED' || !response;
+            const gatewayOrServerError = response?.status >= 500 && !Array.isArray(appErrors);
+
+            let messages: string[];
+            if (timedOutOrUnreachable || gatewayOrServerError) {
+              messages = [
+                'The upload took too long or could not be completed. Large projects may exceed the upload time limit; the import may still be processing. Check your projects in a few minutes, and contact support if it does not appear.',
+              ];
+            } else if (Array.isArray(appErrors) && appErrors.length > 0) {
+              messages = appErrors.map((e) => e.title);
+            } else {
+              messages = ['Something went wrong uploading the project. Please try again.'];
+            }
 
             addToast(
               'error-upload-project',
               <>
                 <h2 className="font-medium">Error!</h2>
                 <ul className="text-sm">
-                  {errors.map((e) => (
-                    <li key={`${e.status}`}>{e.title}</li>
+                  {messages.map((m, i) => (
+                    <li key={i}>{m}</li>
                   ))}
                 </ul>
               </>,


### PR DESCRIPTION
## Summary
Project ZIP import rejected files over ~50 MiB even though the UI advertises (and client-side enforces) a 1 GiB limit — a 75 MB project backup failed for the client (Basecamp, QCIF migration). Root cause: the import endpoint hard-coded a 50 MiB multer cap that also *overrode* the env-configurable limit.

- Add config-driven limit helpers in `upload-limits.ts`: `projectImport()` (default **1 GiB** = frontend `PROJECT_UPLOADER_MAX_SIZE`) and `featureCsvUpload()` (default **50 MiB** = frontend `FEATURES_UPLOADER_CSV_MAX_SIZE`).
- Route the **project import**, **legacy-project import**, and **feature-CSV** endpoints through these helpers — no more hard-coded byte values; the limits are now env-tunable and actually take effect.
- Env mapping `API_UPLOAD_PROJECT_IMPORT_MAX_SIZE` / `API_UPLOAD_FEATURE_CSV_MAX_SIZE` (bytes), documented in `ENV_VARS.md`.
- Backend defaults mirror the frontend `file-uploader-size-limits.js` constants byte-for-byte; a comment cross-references both sides.

Fixes the UI↔backend and hardcoded↔config desyncs. Distinct from MRXNM-89 (clone-crash, already fixed); relates to MRXNM-92 (large imports may then hit the aggregation scale cliff).

## Test Plan
- [x] Unit: `upload-limits.spec.ts` — default + config-override resolution for both helpers (4 passing)
- [x] Typecheck + lint clean
- [x] CI e2e (`import-project.e2e-spec.ts`) — no regression
- [ ] **Staging acceptance:** upload a 50 MiB–1 GiB project ZIP (e.g. the 75 MB case) → import succeeds (or fails downstream on MRXNM-92, NOT a size rejection)
- [ ] **Verify Azure App Gateway** (`marxan-tncKubernetesIngress`) does not cap request body below 1 GiB; if it does, add an explicit limit in Terraform. (Could not verify in-session — insufficient Azure read perms; the staging test will surface a gateway 413 if it's the bottleneck. Note `request-timeout: 120` may also need raising for ~1 GiB uploads.)