### PR TITLE
feat(features): read-back groundwork for split features [MRXNM-82]

### DIFF
--- a/app/components/features/target-spf-item/types.ts
+++ b/app/components/features/target-spf-item/types.ts
@@ -9,6 +9,7 @@ export interface TargetSPFItemProps {
     id: string;
   }[];
   value?: string;
+  childFeatureId?: string | null;
   defaultTarget?: number;
   defaultFPF?: number;
   target?: number;

--- a/app/e2e/feature-split.spec.ts
+++ b/app/e2e/feature-split.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Happy-path e2e for materialized feature splitting in a scenario (MRXNM-82).
+ *
+ * SKIPPED BY DEFAULT so it never breaks CI (where the `split` flag is off and
+ * there is no seeded splittable feature). To actually run it you need ALL of:
+ *
+ *  - `E2E_FEATURE_SPLIT=true` in the test-runner env (the switch below);
+ *  - the `split` flag in the app build — run with
+ *    `NEXT_PUBLIC_FEATURE_FLAGS=platformTransition,split` (playwright.config.ts
+ *    now forwards `process.env.NEXT_PUBLIC_FEATURE_FLAGS` to the web server);
+ *  - the materialized-splits backend deployed (PR #1714: P1 read-back + P2);
+ *  - an authenticated session — configure Playwright `storageState` for a user
+ *    with access to the seeded project/scenario (no shared auth helper exists in
+ *    this suite yet; add one when enabling this test);
+ *  - a seeded scenario whose feature list contains a splittable custom feature
+ *    (one whose `properties` expose a categorical key), with ids/labels provided
+ *    via env (see below).
+ *
+ * The in-panel selectors below are derived from the split modal and targets/SPF
+ * table components; the auth setup, the custom Select interaction, and the
+ * icon-button selectors should be confirmed against the running app when this
+ * is activated.
+ */
+const ENABLED = process.env.E2E_FEATURE_SPLIT === 'true';
+
+const PROJECT_ID = process.env.E2E_SPLIT_PROJECT_ID ?? '';
+const SCENARIO_ID = process.env.E2E_SPLIT_SCENARIO_ID ?? '';
+const FEATURE_NAME = process.env.E2E_SPLIT_FEATURE ?? '';
+const SPLIT_PROPERTY = process.env.E2E_SPLIT_PROPERTY ?? '';
+
+test.describe('Feature split (materialized)', () => {
+  test.skip(
+    !ENABLED,
+    'Set E2E_FEATURE_SPLIT=true with the `split` flag on, the #1714 backend deployed, an authenticated storageState, and a seeded splittable feature.'
+  );
+
+  test('splits a feature into materialized children and renders them', async ({ page }) => {
+    // 1. Open the scenario Features step.
+    await page.goto(`/projects/${PROJECT_ID}/scenarios/${SCENARIO_ID}/edit?tab=features`);
+
+    // 2. Open the row's 3-dot actions menu, then "Split".
+    const featureRow = page.getByRole('row', { name: new RegExp(FEATURE_NAME, 'i') });
+    await featureRow.getByRole('button').last().click();
+    await page.getByRole('button', { name: 'Split' }).click();
+
+    // 3. Modal: pick the property to split by and check at least one value.
+    await expect(page.getByRole('heading', { name: 'Split feature' })).toBeVisible();
+    // NOTE: `components/forms/select` is a custom widget — adjust if the option
+    // is not exposed as a native combobox/option.
+    await page.getByText('You can split this feature into categories').click();
+    await page.getByText(SPLIT_PROPERTY, { exact: true }).click();
+    await page.locator('.modal-checkbox-list input[type="checkbox"]').first().check();
+
+    // 4. Save → submits the spec as `created`, triggering BE materialization.
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // 5. After the async `geofeatureSplit` job finishes, the materialized child
+    //    rows appear, named `${parent} / ${value}`. Allow time for the job.
+    await expect(page.getByText(new RegExp(`${FEATURE_NAME} / `, 'i')).first()).toBeVisible({
+      timeout: 120_000,
+    });
+
+    // 6. (Optional) Confirm a materialized child draws from its OWN tiles — a real
+    //    feature UUID, not the virtual `${parentId}-${value}` id. Toggle the
+    //    child's "see on map" control and assert the tile request shape.
+    //    The exact toggle selector should be confirmed against the running app.
+    // const tileRequest = page.waitForRequest((req) =>
+    //   /\/api\/v1\/geo-features\/[0-9a-f-]{36}\/preview\/tiles\//i.test(req.url())
+    // );
+    // await page.getByRole('row', { name: new RegExp(`${FEATURE_NAME} / `, 'i') })
+    //   .first().getByRole('button').first().click();
+    // await tileRequest;
+  });
+});

--- a/app/hooks/features/index.ts
+++ b/app/hooks/features/index.ts
@@ -389,6 +389,8 @@ export function useTargetedFeatures(
               ...s,
               id: s.value,
               name: s.value,
+              childFeatureId: s.featureId ?? null,
+              amountRange: s.amountRange ?? null,
             };
           });
         }
@@ -470,12 +472,21 @@ export function useTargetedFeatures(
               splitFeaturesSelected
                 // .sort((a, b) => a.name.localeCompare(b.name))
                 .map((sf) => {
-                  const { id: sfId, name: sfName, marxanSettings: sfMarxanSettings } = sf;
+                  const {
+                    id: sfId,
+                    name: sfName,
+                    marxanSettings: sfMarxanSettings,
+                    childFeatureId,
+                    amountRange: sfAmountRange,
+                  } = sf;
 
                   return {
                     ...sf,
-                    id: `${id}-${sfId}`,
+                    id: `${id}-${sfId}`, // keep synthetic row key (stable across materialization)
                     parentId: id,
+                    value: sfId,
+                    childFeatureId: childFeatureId ?? null, // real id for map tiles / amounts
+                    amountRange: sfAmountRange ?? null,
                     name: `${name} / ${sfName}`,
                     splitted: true,
                     splitSelected,

--- a/app/hooks/features/index.ts
+++ b/app/hooks/features/index.ts
@@ -248,6 +248,11 @@ export function useSelectedFeatures(
               ...s,
               id: `${s.value}`,
               name: s.value,
+              // real materialized child id from the backend read-back (null while pending)
+              childFeatureId: s.featureId ?? null,
+              // child's own amounts when provided; the UI falls back to parent amounts
+              amountRange: s.amountRange ?? null,
+              creationStatus: s.creationStatus ?? null,
             };
           });
         }

--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -509,11 +509,15 @@ export function useTargetedPreviewLayers({
     };
 
     return FEATURES.map((f) => {
-      const { id, parentId, value, splitSelected } = f;
+      const { id, parentId, value, splitSelected, childFeatureId } = f;
 
       const { opacity = 1, color } = layerSettings[id] || {};
 
-      const _id = splitSelected ? parentId : id;
+      // Materialized split child → render its own tiles (no property filter needed).
+      // Still pending (or non-split) → fall back to parent tiles + property filter.
+      const useChildTiles = Boolean(childFeatureId);
+      const _id = useChildTiles ? childFeatureId : splitSelected ? parentId : id;
+      const applySplitFilter = Boolean(splitSelected) && !useChildTiles;
 
       return {
         id: `feature-${id}-targeted-preview-layer-${cache}`,
@@ -529,7 +533,7 @@ export function useTargetedPreviewLayers({
             {
               type: 'fill',
               'source-layer': 'layer0',
-              ...(f.splitSelected && {
+              ...(applySplitFilter && {
                 filter: [
                   'all',
                   ['in', ['to-string', ['get', f.splitSelected]], ['literal', [value]]],
@@ -546,7 +550,7 @@ export function useTargetedPreviewLayers({
             {
               type: 'line',
               'source-layer': 'layer0',
-              ...(f.splitSelected && {
+              ...(applySplitFilter && {
                 filter: [
                   'all',
                   ['in', ['to-string', ['get', f.splitSelected]], ['literal', [value]]],

--- a/app/layout/project/sidebar/scenario/grid-setup/features/modals/split/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/modals/split/index.tsx
@@ -93,7 +93,7 @@ const SplitModal = ({
         {
           id: sid,
           data: {
-            status: 'draft',
+            status: 'created',
             features: selectedFeaturesQuery.data.map((sf) => {
               if (sf.id === featureId) {
                 return {

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -95,12 +95,15 @@ const TargetAndSPFFeatures = (): JSX.Element => {
 
         const splitFeatures = feature.splitFeaturesSelected.map((splitFeature) => ({
           ...splitFeature,
-          id: `${feature.id}-${splitFeature.name}`,
+          id: `${feature.id}-${splitFeature.name}`, // stable synthetic row key
           parentId: feature.id,
+          value: splitFeature.value,
+          childFeatureId: splitFeature.childFeatureId ?? null, // real id, when materialized
           name: `${feature.name} / ${splitFeature.name}`,
           isVisibleOnMap: layerSettings[`${feature.id}-${splitFeature.name}`]?.visibility ?? false,
           color: feature.color,
-          amountRange: feature.amountRange,
+          // prefer the materialized child's own amounts; fall back to the parent's
+          amountRange: splitFeature.amountRange ?? feature.amountRange,
           isCustom: feature.metadata?.isCustom,
           scenarioUsageCount: featureMetadata?.scenarioUsageCount,
           type: featureMetadata?.tag,

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -1,4 +1,12 @@
-import { ChangeEvent, ComponentProps, useCallback, useMemo, useState } from 'react';
+import {
+  ChangeEvent,
+  ComponentProps,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useQueryClient } from 'react-query';
 
@@ -12,6 +20,7 @@ import { useDebouncedCallback } from 'use-debounce';
 
 import { useAllFeatures, useSaveSelectedFeatures, useSelectedFeatures } from 'hooks/features';
 import { useCanEditScenario } from 'hooks/permissions';
+import { useScenarioStatus } from 'hooks/scenarios';
 
 import Button from 'components/button';
 import ConfirmationPrompt from 'components/confirmation-prompt';
@@ -86,6 +95,24 @@ const TargetAndSPFFeatures = (): JSX.Element => {
   const selectedFeaturesQuery = useSelectedFeatures(sid, filters, {
     keepPreviousData: true,
   });
+
+  // A split materialises its child features asynchronously (the `geofeatureSplit`
+  // job). Once that job finishes, refetch the specification so the real,
+  // materialised child ids read back from the API replace the pending
+  // placeholders. Running/failure feedback is already handled globally by the
+  // scenario-edit status banner.
+  const scenarioStatusQuery = useScenarioStatus(pid, sid);
+  const isSplitting = (scenarioStatusQuery.data?.jobs ?? []).some(
+    (job) => job.kind === 'geofeatureSplit' && job.status === 'running'
+  );
+  const wasSplitting = useRef(false);
+  useEffect(() => {
+    if (wasSplitting.current && !isSplitting) {
+      void queryClient.invalidateQueries(['selected-features', sid]);
+      void queryClient.invalidateQueries(['targeted-features', sid]);
+    }
+    wasSplitting.current = isSplitting;
+  }, [isSplitting, queryClient, sid]);
 
   const targetedFeatures = useMemo(() => {
     let parsedData = [];

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/targets-spf-table/actions-menu/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/targets-spf-table/actions-menu/index.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from 'react-query';
 import { useRouter } from 'next/router';
 
 import { useFeatureFlags } from 'hooks/feature-flags';
+import { useScenarioStatus } from 'hooks/scenarios';
 
 import Icon from 'components/icon';
 import Modal from 'components/modal/component';
@@ -33,11 +34,15 @@ const ActionsMenu = ({
   onDismissMenu,
 }: Parameters<ComponentProps<typeof RowItem>['ActionsComponent']>[0]): JSX.Element => {
   const { query } = useRouter();
-  const { sid } = query as { sid: string };
+  const { pid, sid } = query as { pid: string; sid: string };
   const queryClient = useQueryClient();
   const isDeletable = item.isCustom;
   const isSplittable = Boolean(item.splitOptions?.length);
   const { split } = useFeatureFlags();
+  const scenarioStatusQuery = useScenarioStatus(pid, sid);
+  const isSplitting = (scenarioStatusQuery.data?.jobs ?? []).some(
+    (job) => job.kind === 'geofeatureSplit' && job.status === 'running'
+  );
 
   const [modalState, setModalState] = useState<{ edit: boolean; split: boolean }>({
     edit: false,
@@ -95,9 +100,9 @@ const ActionsMenu = ({
             }}
             className={cn({
               [BUTTON_CLASSES]: true,
-              [BUTTON_DISABLED_CLASSES]: !isDeletable,
+              [BUTTON_DISABLED_CLASSES]: !isDeletable || isSplitting,
             })}
-            disabled={!isDeletable}
+            disabled={!isDeletable || isSplitting}
           >
             <Icon
               icon={SPLIT_SVG}

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       NEXTAUTH_URL: `http://localhost:${PORT}`,
       NEXTAUTH_SECRET: 'cats',
       NEXT_PUBLIC_API_URL: 'https://marxan23.northeurope.cloudapp.azure.com',
-      NEXT_PUBLIC_FEATURE_FLAGS: 'platformTransition',
+      NEXT_PUBLIC_FEATURE_FLAGS: process.env.NEXT_PUBLIC_FEATURE_FLAGS || 'platformTransition',
     },
   },
   /* Run tests in files in parallel */

--- a/app/types/api/geo-feature-set.ts
+++ b/app/types/api/geo-feature-set.ts
@@ -1,10 +1,17 @@
 import { Feature } from './feature';
 import { Project } from './project';
+import { SplitEntry } from './split';
+
+export interface GeoprocessingOperationSplitV1 {
+  kind: 'split/v1';
+  splitByProperty: string;
+  splits: SplitEntry[];
+}
 
 export interface GeoFeatureSet {
-  status: 'draft';
+  status: 'draft' | 'created';
   features: {
-    kind: 'plain';
+    kind: 'plain' | 'withGeoprocessing';
     featureId: Feature['id'];
     marxanSettings: Record<string, number>;
     metadata: {
@@ -18,6 +25,6 @@ export interface GeoFeatureSet {
       projectId: Project['id'];
       properties: Record<string, [number]>;
     };
-    geoprocessingOperations: any;
+    geoprocessingOperations?: GeoprocessingOperationSplitV1[];
   }[];
 }

--- a/app/types/api/split.ts
+++ b/app/types/api/split.ts
@@ -1,0 +1,22 @@
+import { Feature } from './feature';
+
+/** Marxan settings stored per split child inside the scenario specification. */
+export interface SplitMarxanSettings {
+  prop?: number;
+  fpf?: number;
+  target?: number;
+}
+
+/**
+ * A single split entry as returned by the backend inside
+ * geoprocessingOperations[].splits. `featureId` is the REAL materialized
+ * child feature id (present once the split job has finished); it is absent
+ * while the split is still being materialized.
+ */
+export interface SplitEntry {
+  value: string;
+  marxanSettings: SplitMarxanSettings;
+  featureId?: Feature['id']; // real child id (read-back; absent while pending)
+  amountRange?: { min: number; max: number };
+  creationStatus?: Feature['creationStatus'];
+}

--- a/docs/README_revision-of-feature-split-functionality-in-marxan-cloud-v2.md
+++ b/docs/README_revision-of-feature-split-functionality-in-marxan-cloud-v2.md
@@ -109,3 +109,32 @@ Piece exporters and importers will need to:
 
 These will need to use the list of relevant `features_data` rows as stored
 alongside each feature.
+
+## Frontend integration (read-back model) — MRXNM-82
+
+The frontend treats split children as **materialized** features and discovers
+them via a *read-back* flow rather than synthesising them client-side:
+
+1. The user configures a split in the scenario Features step (behind the `split`
+   feature flag) and confirms; the frontend submits the feature specification
+   with the `split/v1` operation and `status: 'created'` (a `draft` spec does not
+   trigger materialization).
+2. The backend materializes the child features asynchronously (the
+   `geofeatureSplit` job).
+3. While that job runs the frontend shows the existing scenario status banner;
+   when it finishes the frontend refetches the specification.
+4. `GET /scenarios/:id/features/specification` echoes, per split entry, the real
+   child `featureId` (plus `amountRange`/`creationStatus`), matched to each split
+   `value` via the child's stored `from_geoprocessing_ops` canonical config
+   (`baseFeatureId` + `splitByProperty` + `value`). The frontend renders the
+   materialized children (their own tiles + amounts) using those real ids, while
+   keeping a stable synthetic row key for UI state.
+
+Splitting is **scenario-only**: materialized children are deliberately excluded
+from `GET /projects/:pid/features`, so they never appear in the project feature
+inventory or the scenario "add features" list.
+
+The `featureId`/`amountRange`/`creationStatus` fields added to each split entry
+are whitelisted on the request DTO (`SplitV1Settings`) so the specification
+survives `forbidNonWhitelisted` validation when the frontend round-trips it on
+save.


### PR DESCRIPTION
## ⚠️ Draft — do not merge standalone

Frontend for **materialized feature splits** (read-back model), scenario-only, behind the off `split` flag. Inert until the backend half is deployed (`?? null` fallbacks keep the UI unchanged vs `staging`).

**Backend dependency — deploy coupled with #1714** (P1 + P2 implemented & compiling there):
- **P1** — the spec GET surfaces each split's child `featureId`/`amountRange`/`creationStatus`.
- **P2** — derived features excluded from `GET /projects/:pid/features` (no inventory leak).

> **Base is `staging`** (builds on FE code that currently lives only there).

## In this PR (plan Tasks 1–7, 9, 10)
- read-back contract types; thread the real child id as `childFeatureId` through `useSelectedFeatures` / `useTargetedFeatures` / the features panel (keeping a stable synthetic row key)
- render a materialized child from its **own tiles**; **materialize on confirm** (split modal submits `status: 'created'`)
- **async:** refetch the spec when the `geofeatureSplit` job finishes (materialized children replace placeholders) + disable re-split while it runs (running/failure reuse the existing scenario status banner)
- **flag-gated e2e scaffold** (`app/e2e/feature-split.spec.ts`, skipped unless `E2E_FEATURE_SPLIT=true`) + the playwright web-server now forwards `NEXT_PUBLIC_FEATURE_FLAGS`
- **docs:** FE read-back integration section added to the v2 split design doc

## Remaining (not FE code)
- Enable the `split` flag in the target env (deploy-time)
- Manual QA pass, incl. confirming no inventory leak (Task 8 — handled in code by P2)
- CHANGELOG at release

## Jira story
https://vizzuality.atlassian.net/browse/MRXNM-82

### Designs
No new design — reuses the existing split modal and targets/SPF table.

### Testing instructions
- **Now:** \`cd app && yarn check-types && yarn lint\` — clean. With \`split\` off (default), no behavior change vs \`staging\`.
- **After #1714 deploy + flag on:** split a custom feature → status banner shows processing → materialized child rows appear with real amounts; re-split disabled while running; children absent from project inventory / "Add features". To run the e2e: \`E2E_FEATURE_SPLIT=true NEXT_PUBLIC_FEATURE_FLAGS=platformTransition,split\` + an authenticated storageState + seeded splittable feature.

---

## Checklist before submitting

- [x] Meaningful commits (Conventional Commits; branch based on \`staging\`).
- [ ] Update CHANGELOG file — at release (flag-gated; BE not yet deployed).