### PR TITLE
fix(geoprocessing/cloning): prevent OOM on clone/export of large scenarios [MRXNM-21]

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-data.piece-exporter.ts
@@ -30,18 +30,25 @@ type OutputScenarioFeaturesDataSelectResult = OutputFeatureDataElement & {
   scenarioFeaturesId: string;
 };
 
-type FeatureDataElementWithFeatureId = Omit<
-  FeatureDataElement,
-  'apiFeature' | 'featureDataFeature'
-> & {
+/**
+ * Raw row shape returned by the scenario_features_data QueryBuilder below.
+ * Keys match the second argument passed to `.select`/`.addSelect`.
+ */
+type ScenarioFeaturesDataRawRow = {
   sfdId: string;
   apiFeatureId: string;
+  featureId: number;
+  currentArea: number;
+  totalArea: number;
+  fpf?: number;
+  metadata?: Record<'sepdistance', number | string>;
+  prop?: number;
+  sepNum?: number;
+  target2?: number;
+  target?: number;
+  targetocc?: number;
   featureDataFeatureId: string;
-};
-
-type FeatureDataElementWithIsCustom = FeatureDataElementWithFeatureId & {
-  apiFeature: { isCustom: boolean; featureClassName: string };
-  featureDataFeature: { isCustom: boolean; featureClassName: string };
+  featureDataHash: string;
 };
 
 @Injectable()
@@ -63,106 +70,48 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
     return piece === ClonePiece.ScenarioFeaturesData;
   }
 
-  private parseScenarioFeaturesDataToFeatureDataElementWithFeatureId(
-    scenarioFeaturesData: ScenarioFeaturesData[],
-  ): FeatureDataElementWithFeatureId[] {
-    return scenarioFeaturesData
-      .filter((sfd) => sfd.featureData.featureId)
-      .map((sfd) => ({
-        sfdId: sfd.id,
-        apiFeatureId: sfd.apiFeatureId,
-        featureDataFeatureId: sfd.featureData.featureId!,
-        currentArea: sfd.currentArea,
-        featureDataHash: sfd.featureData.hash,
-        featureId: sfd.featureId,
-        specificationId: undefined,
-        totalArea: sfd.totalArea,
-        fpf: sfd.fpf,
-        metadata: sfd.metadata,
-        prop: sfd.prop,
-        sepNum: sfd.sepNum,
-        target2: sfd.target2,
-        target: sfd.target,
-        targetocc: sfd.targetocc,
-        outputFeaturesData: [],
-      }));
-  }
-
-  private getScenarioFeaturesDataWithIsCustom(
-    featuresDataWithFeatureId: FeatureDataElementWithFeatureId[],
-    features: FeaturesSelectResult[],
-  ): FeatureDataElementWithIsCustom[] {
-    const featurePropertiesById: Record<
-      string,
-      Omit<FeaturesSelectResult, 'id'>
-    > = {};
-    features.forEach(({ id, feature_class_name, is_custom }) => {
-      featurePropertiesById[id] = { feature_class_name, is_custom };
-    });
-
-    return featuresDataWithFeatureId.map((el) => {
-      const apiFeatureProperties = featurePropertiesById[el.apiFeatureId];
-      const featureDataFeatureProperties =
-        featurePropertiesById[el.featureDataFeatureId];
-
-      if (!apiFeatureProperties)
-        throw new Error(
-          `Feature properties not found for feature with id ${el.apiFeatureId}`,
-        );
-
-      if (!featureDataFeatureProperties)
-        throw new Error(
-          `Feature properties not found for feature with id ${el.featureDataFeatureId}`,
-        );
-      return {
-        ...el,
-        apiFeature: {
-          isCustom: apiFeatureProperties.is_custom,
-          featureClassName: apiFeatureProperties.feature_class_name ?? '',
-        },
-        featureDataFeature: {
-          isCustom: featureDataFeatureProperties.is_custom,
-          featureClassName:
-            featureDataFeatureProperties.feature_class_name ?? '',
-        },
-      };
-    });
-  }
-
-  private getFileContent(
-    scenarioFeaturesDataWithIsCustom: FeatureDataElementWithIsCustom[],
-    outputScenariosFeaturesData: OutputScenarioFeaturesDataSelectResult[],
-  ): ScenarioFeaturesDataContent {
-    const featuresData: FeatureDataElement[] = [];
-
-    scenarioFeaturesDataWithIsCustom.forEach(
-      ({ sfdId, apiFeatureId, featureDataFeatureId, ...sfd }) => {
-        const outputData = outputScenariosFeaturesData.filter(
-          (el) => el.scenarioFeaturesId === sfdId,
-        );
-        featuresData.push({
-          ...sfd,
-          outputFeaturesData: outputData.map(
-            ({ scenarioFeaturesId, ...rest }) => ({
-              ...rest,
-            }),
-          ),
-        });
-      },
-    );
-
-    return {
-      featuresData,
-    };
-  }
-
   async run(input: ExportJobInput): Promise<ExportJobOutput> {
-    const scenarioFeaturesData = await this.geoprocessingEntityManager
-      .getRepository(ScenarioFeaturesData)
-      .find({
-        where: { scenarioId: input.resourceId },
-        relations: ['featureData'],
-      });
+    /**
+     * Memory/CPU efficiency (MRXNM-21):
+     *
+     * Large scenarios produce ~1.14M scenario_features_data rows
+     * (14.5k planning units x 79 features). The previous implementation:
+     *   1. Hydrated every row as a TypeORM entity with its `featureData`
+     *      relation (a heavy object graph kept fully in memory).
+     *   2. Ran a nested `.filter(...)` over the output rows for EACH sfd row,
+     *      i.e. O(N x M) ~= 1.14M x 7.9k comparisons (a CPU + GC bomb).
+     *   3. Built several full-size intermediate arrays simultaneously.
+     * All three caused the exporter to OOM.
+     *
+     * This rewrite instead:
+     *   - Reads plain rows via `.getRawMany()` (no entity hydration).
+     *   - Indexes the output rows once into a Map for O(1) lookups.
+     *   - Produces the final `featuresData` array in a single pass.
+     * The output file shape (`ScenarioFeaturesDataContent`) is unchanged so
+     * the importer keeps working as-is.
+     */
+    const rows: ScenarioFeaturesDataRawRow[] =
+      await this.geoprocessingEntityManager
+        .createQueryBuilder(ScenarioFeaturesData, 'sfd')
+        .innerJoin('sfd.featureData', 'fd')
+        .select('sfd.id', 'sfdId')
+        .addSelect('sfd.apiFeatureId', 'apiFeatureId')
+        .addSelect('sfd.featureId', 'featureId') // integer marxan feature id
+        .addSelect('sfd.currentArea', 'currentArea')
+        .addSelect('sfd.totalArea', 'totalArea')
+        .addSelect('sfd.fpf', 'fpf')
+        .addSelect('sfd.metadata', 'metadata')
+        .addSelect('sfd.prop', 'prop')
+        .addSelect('sfd.sepNum', 'sepNum')
+        .addSelect('sfd.target2', 'target2')
+        .addSelect('sfd.target', 'target')
+        .addSelect('sfd.targetocc', 'targetocc')
+        .addSelect('fd.featureId', 'featureDataFeatureId') // uuid (features.id)
+        .addSelect('fd.hash', 'featureDataHash')
+        .where('sfd.scenarioId = :scenarioId', { scenarioId: input.resourceId })
+        // Replicates the old `.filter((sfd) => sfd.featureData.featureId)`
+        .andWhere('fd.featureId IS NOT NULL')
+        .getRawMany();
 
     const outputScenariosFeaturesData: OutputScenarioFeaturesDataSelectResult[] =
       await this.geoprocessingEntityManager
@@ -186,16 +135,23 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
         })
         .execute();
 
-    const scenarioFeaturesDataWithFeatureId =
-      this.parseScenarioFeaturesDataToFeatureDataElementWithFeatureId(
-        scenarioFeaturesData,
-      );
+    // Index output rows by scenarioFeaturesId once -> O(1) lookups per sfd row.
+    const outputDataBySfdId = new Map<string, OutputFeatureDataElement[]>();
+    for (const {
+      scenarioFeaturesId,
+      ...outputData
+    } of outputScenariosFeaturesData) {
+      const existing = outputDataBySfdId.get(scenarioFeaturesId);
+      if (existing) {
+        existing.push(outputData);
+      } else {
+        outputDataBySfdId.set(scenarioFeaturesId, [outputData]);
+      }
+    }
+
     const featuresIds = [
       ...new Set<string>(
-        scenarioFeaturesDataWithFeatureId.flatMap((sfd) => [
-          sfd.apiFeatureId,
-          sfd.featureDataFeatureId,
-        ]),
+        rows.flatMap((row) => [row.apiFeatureId, row.featureDataFeatureId]),
       ),
     ];
 
@@ -212,16 +168,58 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
         .execute();
     }
 
-    const scenarioFeaturesDataWithIsCustom =
-      this.getScenarioFeaturesDataWithIsCustom(
-        scenarioFeaturesDataWithFeatureId,
-        features,
-      );
+    const featurePropertiesById: Record<
+      string,
+      Omit<FeaturesSelectResult, 'id'>
+    > = {};
+    features.forEach(({ id, feature_class_name, is_custom }) => {
+      featurePropertiesById[id] = { feature_class_name, is_custom };
+    });
 
-    const fileContent = this.getFileContent(
-      scenarioFeaturesDataWithIsCustom,
-      outputScenariosFeaturesData,
-    );
+    const featuresData: FeatureDataElement[] = rows.map((row) => {
+      const apiFeatureProperties = featurePropertiesById[row.apiFeatureId];
+      const featureDataFeatureProperties =
+        featurePropertiesById[row.featureDataFeatureId];
+
+      if (!apiFeatureProperties)
+        throw new Error(
+          `Feature properties not found for feature with id ${row.apiFeatureId}`,
+        );
+
+      if (!featureDataFeatureProperties)
+        throw new Error(
+          `Feature properties not found for feature with id ${row.featureDataFeatureId}`,
+        );
+
+      return {
+        currentArea: row.currentArea,
+        featureDataHash: row.featureDataHash,
+        featureId: row.featureId,
+        specificationId: undefined,
+        totalArea: row.totalArea,
+        fpf: row.fpf,
+        metadata: row.metadata,
+        prop: row.prop,
+        sepNum: row.sepNum,
+        target2: row.target2,
+        target: row.target,
+        targetocc: row.targetocc,
+        apiFeature: {
+          isCustom: apiFeatureProperties.is_custom,
+          featureClassName: apiFeatureProperties.feature_class_name ?? '',
+        },
+        featureDataFeature: {
+          isCustom: featureDataFeatureProperties.is_custom,
+          featureClassName:
+            featureDataFeatureProperties.feature_class_name ?? '',
+        },
+        outputFeaturesData: outputDataBySfdId.get(row.sfdId) ?? [],
+      };
+    });
+
+    const fileContent: ScenarioFeaturesDataContent = {
+      featuresData,
+    };
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(
       ClonePiece.ScenarioFeaturesData,

--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-specification.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-specification.piece-exporter.ts
@@ -221,15 +221,47 @@ export class ScenarioFeaturesSpecificationPieceExporter
         input.resourceId,
       );
 
+    /**
+     * Export only the active and candidate specifications, not every historical
+     * snapshot. Each time a specification is (re)computed a brand new full
+     * snapshot of all feature configs is written and previous snapshots are
+     * never pruned, so a heavily-edited scenario accumulates many stale
+     * specifications. `specification_feature_configs.features` holds a large
+     * per-feature calculated payload, so loading every snapshot inflates heap
+     * usage to several GB and crashes the exporter (`JavaScript heap out of
+     * memory`) on large scenarios. A clone only needs the active/candidate
+     * specifications to reproduce the scenario: the importer keys off the
+     * active/candidate flags, and every scenario_features_data row references
+     * the active specification (stale snapshots have no references), so
+     * dropping them changes no scenario_features_data -> specification linkage.
+     * This is a deliberate "stop cloning stale specification history" change.
+     * See MRXNM-21.
+     */
+    const wantedSpecificationIds = [
+      ...new Set(
+        [
+          scenarioSpecificationIds.active,
+          scenarioSpecificationIds.candidate,
+        ].filter((id): id is string => isDefined(id)),
+      ),
+    ];
+
     const specifications: SelectSpecificationsResult[] =
-      await this.apiEntityManager
-        .createQueryBuilder()
-        .select('id')
-        .addSelect('draft')
-        .addSelect('raw')
-        .from('specifications', 's')
-        .where('scenario_id = :scenarioId', { scenarioId: input.resourceId })
-        .execute();
+      wantedSpecificationIds.length === 0
+        ? []
+        : await this.apiEntityManager
+            .createQueryBuilder()
+            .select('id')
+            .addSelect('draft')
+            .addSelect('raw')
+            .from('specifications', 's')
+            .where('scenario_id = :scenarioId', {
+              scenarioId: input.resourceId,
+            })
+            .andWhere('id IN (:...wantedSpecificationIds)', {
+              wantedSpecificationIds,
+            })
+            .execute();
     const specificationIds = specifications.map(
       (specification) => specification.id,
     );

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-data.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-data.piece-exporter.e2e-spec.ts
@@ -205,6 +205,22 @@ const getFixtures = async () => {
             data.length * recordsOfOutputDataForEachScenarioFeaturesData,
           );
 
+          // Every scenario features data record must carry exactly its own
+          // output data, proving the per-sfd Map lookup (MRXNM-21 rewrite)
+          // resolves the same association the previous nested filter did.
+          expect(
+            data.every(
+              (record) =>
+                record.outputFeaturesData.length ===
+                  recordsOfOutputDataForEachScenarioFeaturesData &&
+                record.outputFeaturesData.every(
+                  (output) =>
+                    typeof output.runId === 'number' &&
+                    output.totalArea === 1000,
+                ),
+            ),
+          ).toBe(true);
+
           expect(
             data.every(
               (sfd) =>
@@ -212,7 +228,7 @@ const getFixtures = async () => {
                   sfd.featureDataFeature.featureClassName &&
                 sfd.apiFeature.isCustom === sfd.featureDataFeature.isCustom,
             ),
-          );
+          ).toBe(true);
         },
       };
     },

--- a/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-specification.piece-exporter.e2e-spec.ts
+++ b/api/apps/geoprocessing/test/integration/cloning/piece-exporters/scenario-features-specification.piece-exporter.e2e-spec.ts
@@ -88,6 +88,19 @@ describe(ScenarioFeaturesSpecificationPieceExporter, () => {
       .WhenPieceExporterIsInvoked(input)
       .ThenSavedFileHasConfigsArrayForEachSpecification();
   });
+
+  it('exports only the active/candidate specification, dropping stale snapshots (MRXNM-21)', async () => {
+    const input = fixtures.GivenAScenarioFeaturesSpecificationExportJob();
+    await fixtures.GivenScenarioExist();
+    await fixtures.GivenCustomFeatureExist();
+    await fixtures.GivenScenarioSpecification();
+    await fixtures.GivenScenarioFeaturesDataExist();
+    await fixtures.GivenScenarioSpecificationFeaturesConfigExist(2);
+    await fixtures.GivenStaleSpecificationsAlsoExist();
+    await fixtures
+      .WhenPieceExporterIsInvoked(input)
+      .ThenOnlyTheActiveAndCandidateSpecificationIsSaved();
+  });
 });
 
 const getFixtures = async () => {
@@ -237,6 +250,27 @@ const getFixtures = async () => {
         { features: JSON.stringify(features) },
       );
     },
+    GivenStaleSpecificationsAlsoExist: async () => {
+      // Extra non-active/non-candidate specifications (with their own configs),
+      // mirroring the stale snapshots that accumulate on heavily-edited
+      // scenarios. The exporter must NOT include these. See MRXNM-21.
+      const staleSpecifications = await GivenSpecifications(
+        apiEntityManager,
+        [feature.id, feature.id],
+        scenarioId,
+      );
+      const features = scenarioFeatureDataIds.map((featureId) => ({
+        featureId,
+        calculated: true,
+      }));
+      await GivenSpecificationFeaturesConfig(
+        apiEntityManager,
+        feature.id,
+        staleSpecifications,
+        2,
+        { features: JSON.stringify(features) },
+      );
+    },
     GivenNoScenarioFeaturesSpecification: async (): Promise<void> => {},
     WhenPieceExporterIsInvoked: (input: ExportJobInput) => {
       return {
@@ -325,6 +359,21 @@ const getFixtures = async () => {
             expect(Array.isArray(spec.configs)).toBe(true);
             expect(spec.configs).toEqual([]);
           });
+        },
+        ThenOnlyTheActiveAndCandidateSpecificationIsSaved: async () => {
+          const result = await sut.run(input);
+          const file = await fileRepository.get(result.uris[0].uri);
+          expect((file as Right<Readable>).right).toBeDefined();
+          if (isLeft(file)) throw new Error();
+          const content =
+            await readSavedFile<ScenarioFeaturesSpecificationContent[]>(
+              file.right,
+            );
+          // Only the active (== candidate) specification is exported; the stale
+          // snapshots are dropped. See MRXNM-21.
+          expect(content).toHaveLength(1);
+          expect(content[0].activeSpecification).toEqual(true);
+          expect(content[0].candidateSpecification).toEqual(true);
         },
       };
     },


### PR DESCRIPTION
## Problem (MRXNM-21)
Scenario clone/duplicate and full project export crash the geoprocessing process with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` on large/heavily-edited scenarios. The prod runtime caps the V8 heap at 4096 MB, so the crash is *below* the container memory limit (raising pod memory does not help). Two export pieces each load an entire dataset into memory and `JSON.stringify` it, and they run concurrently (BullMQ) so their heaps add up.

## Changes (two export pieces)

### 1. `scenario-features-specification` — export only the active/candidate specification
Specifications **accumulate**: every recompute (feature edit / calibration prep) writes a brand-new full snapshot of all feature configs and old snapshots are never pruned. On the scenario that triggered this, there were **14 non-draft snapshots ≈ 602 MB of `specification_feature_configs.features`; the active spec was only ≈ 43 MB** (~93% stale). Parsed to JS that's ~4 GB of heap.

A clone only needs the active (+ candidate) specification: the importer keys off the `activeSpecification`/`candidateSpecification` flags, and **100% of the `scenario_features_data` rows reference the active spec — stale snapshots have zero references** — so dropping them changes no `scenario_features_data → specification` linkage. This is a deliberate "stop cloning stale specification history" change (not a transparent no-op), and it shrinks the payload ~14× while speeding up every clone/export.

### 2. `scenario-features-data` — memory/CPU-efficient rewrite (same output format)
Previously hydrated **all ~1.1 M rows** (14.5k PUs × 79 features) as TypeORM entities with the `featureData` relation, ran an `O(N×M)` nested `filter` over output rows (~1.1 M × 7.9 k), and built several full-size intermediate arrays. Now:
- reads plain rows via `getRawMany()` (no entity hydration; entity property paths disambiguate the two distinct `feature_id` columns — integer vs uuid);
- indexes output rows into a `Map` for O(1) lookups;
- builds the result in a single pass.

**Output file format is unchanged**, so the importers are untouched. Peak heap drops from ~2–3 GB to ~1 GB.

## Tests
- New regression test asserting only the active/candidate specification is exported (stale snapshots dropped).
- `scenario-features-data` exporter test strengthened to assert per-record output mapping (proves the Map replacement); fixed two assertions that had no matcher.
- Covered by the `integration/cloning` geo-e2e CI shard.

## Not in scope (separate follow-ups noted on the ticket)
1. Specifications are never pruned when superseded (the root cause of the spec bloat).
2. Geoprocessing prod runs a dev runtime (`nodemon` + `ts-node`, 4 GB heap cap) → crashes hang the pod at 0/1 instead of exiting for k8s to restart cleanly.
3. Stream the project `puvspr` piece (`project-feature-amounts-per-planning-unit`) for very large full-project exports.