### PR TITLE
fix(geoprocessing/cloning): stop hydrating 1.1M entities in features-specification export [MRXNM-21]

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-specification.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-specification.piece-exporter.ts
@@ -16,7 +16,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/lib/Either';
 import { Readable } from 'stream';
-import { In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { EntityManager } from 'typeorm/entity-manager/EntityManager';
 import {
   ExportPieceProcessor,
@@ -41,7 +41,10 @@ type SelectSpecificationsResult = {
   raw: Record<string, unknown>;
 };
 
-type ScenarioFeaturesDataById = Record<string, ScenarioFeaturesData>;
+// Maps a scenario_features_data.id (uuid) to its integer marxan featureId.
+// We deliberately keep only the integer id here instead of the full entity:
+// see the query in `run()` (MRXNM-21).
+type ScenarioFeaturesDataById = Record<string, number>;
 
 type SelectScenarioFeaturesConfigs = {
   specificationId: string;
@@ -123,12 +126,12 @@ export class ScenarioFeaturesSpecificationPieceExporter
   }
 
   private getScenarioFeaturesDataById(
-    scenarioFeaturesData: ScenarioFeaturesData[],
+    scenarioFeaturesData: { id: string; featureId: number }[],
   ) {
     const scenarioFeaturesDataById: ScenarioFeaturesDataById = {};
 
-    scenarioFeaturesData.forEach((feature) => {
-      scenarioFeaturesDataById[feature.id] = feature;
+    scenarioFeaturesData.forEach(({ id, featureId }) => {
+      scenarioFeaturesDataById[id] = featureId;
     });
 
     return scenarioFeaturesDataById;
@@ -176,11 +179,12 @@ export class ScenarioFeaturesSpecificationPieceExporter
         // config.features array should be filtered here. In practice, only the features
         // array of the last non-draft feature specification config will be exported
         features: config.features
-          .filter(({ featureId }) =>
-            Boolean(scenarioFeaturesDataById[featureId]),
+          .filter(
+            ({ featureId }) =>
+              scenarioFeaturesDataById[featureId] !== undefined,
           )
           .map(({ calculated, featureId }) => ({
-            featureId: scenarioFeaturesDataById[featureId].featureId,
+            featureId: scenarioFeaturesDataById[featureId],
             calculated,
           })),
       };
@@ -268,13 +272,30 @@ export class ScenarioFeaturesSpecificationPieceExporter
     let fileContent: ScenarioFeaturesSpecificationContent[] = [];
 
     if (specifications.length) {
-      const scenarioFeaturesData = await this.scenarioFeaturesDataRepo.find({
-        where: {
-          specificationId: In(specificationIds),
-          scenarioId: input.resourceId,
-        },
-        relations: ['featureData'],
-      });
+      /**
+       * Only the scenario_features_data `id -> integer featureId` mapping is
+       * used below (to translate the specification config feature ids). The
+       * previous `.find({ relations: ['featureData'] })` hydrated every
+       * matching row as a full TypeORM entity AND eagerly loaded the heavy
+       * `featureData` (GeoFeatureGeometry) relation — which is never read here.
+       * On large scenarios the active specification references ~1.14M
+       * scenario_features_data rows, so this materialised millions of entities
+       * and spiked the heap to several GB, blocking the event loop long enough
+       * for the liveness probe to kill the pod mid-export. Selecting just the
+       * two scalar columns we actually need keeps memory flat. See MRXNM-21.
+       */
+      const scenarioFeaturesData: { id: string; featureId: number }[] =
+        await this.scenarioFeaturesDataRepo
+          .createQueryBuilder('sfd')
+          .select('sfd.id', 'id')
+          .addSelect('sfd.featureId', 'featureId')
+          .where('sfd.specificationId IN (:...specificationIds)', {
+            specificationIds,
+          })
+          .andWhere('sfd.scenarioId = :scenarioId', {
+            scenarioId: input.resourceId,
+          })
+          .getRawMany();
 
       const scenarioFeaturesDataById =
         this.getScenarioFeaturesDataById(scenarioFeaturesData);


### PR DESCRIPTION
## Problem

Follow-up to the scenario clone/export OOM fix (#1741). After that fix deployed to prod, re-running the real failing scenario clone (Blueprint Golfo de California / "Base costo hectareas", ~1.14M `scenario_features_data` rows) got **much** further but still killed the geoprocessing pod.

Live prod evidence (memory/CPU sampler during the retry):
- The `scenario-features-data` piece (the one fixed in #1741) **streamed a 438 MB file with memory flat at 570 Mi** — that fix works.
- The crash then hit the **next** piece, `scenario-features-specification` (its output file was never written). Memory spiked 570 Mi → **3164 Mi**, CPU pegged at 1 core, the event loop blocked, and the **liveness probe killed the pod** mid-export.

## Root cause

`scenario-features-specification.piece-exporter.ts` loaded scenario_features_data via:

```ts
this.scenarioFeaturesDataRepo.find({
  where: { specificationId: In(specificationIds), scenarioId },
  relations: ['featureData'],   // heavy GeoFeatureGeometry graph — never read
});
```

Because **100% of the ~1.14M rows reference the active specification**, this materialised millions of full TypeORM entities **plus** the eagerly-joined `featureData` relation that is never used in this file. That is the 3.2 GB spike + event-loop block. #1741 reduced the *number of specifications* loaded but never touched this entity hydration — the twin of the anti-pattern already fixed in `scenario-features-data`.

## Fix

Replace the `.find({ relations: ['featureData'] })` with a `getRawMany()` selecting only the two scalar columns actually used (`id` → integer `featureId`). Drops the relation (and its JOIN) entirely.

- **Output file shape unchanged** → importer untouched.
- Existing integration test `ThenAScenarioFeaturesSpecificationFileIsSaved` asserts `config.features` come out as `{ featureId: <int>, calculated }`, which exercises exactly this mapping path and guards it.
- Existence filter switched from `Boolean(...)` to `!== undefined` (correctly keeps a feature whose integer id is `0`).

## Ripple check

`getScenarioFeaturesDataById`, the `ScenarioFeaturesDataById` type, and `scenarioFeaturesDataRepo` are all private/local to this one file (verified repo-wide). No external contract changes except the unchanged output file.

## Validation

- `tsc -p tsconfig.build.json --noEmit` — 0 source errors.
- Covered by the `integration/cloning` geo-e2e CI shard.