### PR TITLE
fix(splits): render materialized split tiles via stable ids + legacy backport [MRXNM-82]

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/split/split-operation.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-operation.service.spec.ts
@@ -1,0 +1,85 @@
+import { SplitOperation } from './split-operation.service';
+
+/**
+ * A materialized split feature's `feature_data_stable_ids` must be the FULL
+ * key/value-matching subset of the parent's features_data rows — the same set
+ * the legacy backport writes and what splits historically rendered (full class).
+ * It must NOT be the bbox-filtered scenario-preparation rows that `SplitQuery`
+ * returns (those are only for scenario prep / amounts).
+ */
+describe('SplitOperation feature_data_stable_ids derivation', () => {
+  it('derives stable ids from the full K/V subset, not the bbox-filtered split-query rows', async () => {
+    const featureId = 'split-feature-1';
+    const singleSplitFeature = {
+      operation: 'split',
+      baseFeatureId: 'parent-feature-1',
+      splitByProperty: 'w_ecosystm',
+      subset: {
+        value: 'Warm Temperate Moist Sparsley or Non vegetated on Plains',
+      },
+    };
+    const kvStableIdRows = [{ stable_id: 's1' }, { stable_id: 's2' }];
+
+    // 1st geo query = SplitQuery (scenario prep); 2nd = the stable-id lookup.
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ id: 'sfp-1', features_data_id: 'fd-bbox-1' }])
+      .mockResolvedValueOnce(kvStableIdRows);
+
+    const setFeatureDataStableIdsForFeature = jest.fn();
+    const splitCreateFeatures = {
+      createSplitFeatures: jest
+        .fn()
+        .mockResolvedValue([{ id: featureId, singleSplitFeature }]),
+      setFeatureDataStableIdsForFeature,
+    };
+    const splitDataProvider = {
+      prepareData: jest.fn().mockResolvedValue({
+        project: { id: 'project-1', bbox: [0, 0, 1, 1] },
+        protectedAreaFilterByIds: [],
+        planningAreaLocation: undefined,
+      }),
+    };
+    const splitQuery = {
+      prepareQuery: jest
+        .fn()
+        .mockReturnValue({ query: 'SPLIT_QUERY_SQL', parameters: [] }),
+    };
+    const computeArea = {
+      computeAreaPerPlanningUnitOfFeature: jest
+        .fn()
+        .mockResolvedValue(undefined),
+    };
+    const events = { create: jest.fn().mockResolvedValue(undefined) };
+
+    const sut = new SplitOperation(
+      splitCreateFeatures as never,
+      splitDataProvider as never,
+      splitQuery as never,
+      computeArea as never,
+      { query } as never,
+      events as never,
+    );
+
+    await sut.split({
+      scenarioId: 'scenario-1',
+      specificationId: 'spec-1',
+      input: {} as never,
+    });
+
+    const kvCall = query.mock.calls.find(
+      ([sql]) =>
+        typeof sql === 'string' && sql.includes('feature_properties_kv'),
+    );
+    expect(kvCall).toBeDefined();
+    expect(kvCall![1]).toEqual([
+      'parent-feature-1',
+      'w_ecosystm',
+      'Warm Temperate Moist Sparsley or Non vegetated on Plains',
+    ]);
+    expect(setFeatureDataStableIdsForFeature).toHaveBeenCalledWith(
+      featureId,
+      kvStableIdRows,
+    );
+  });
+});

--- a/api/apps/api/src/modules/scenarios-features/split/split-operation.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-operation.service.ts
@@ -61,13 +61,21 @@ export class SplitOperation {
         scenarioFeaturePreparationIds.push(
           ...scenarioFeaturePreparationIdsForFeature,
         );
+        // Link the split feature to the FULL key/value-matching subset of the
+        // parent's features_data rows — not the bbox-filtered scenario-prep rows
+        // SplitQuery returns. This matches how splits render (the full class) and
+        // the legacy backport; amounts are planning-unit-bounded, so the broader
+        // set is harmless. Value match mirrors SplitQuery's.
+        const { baseFeatureId, splitByProperty, subset } =
+          singleSplitFeatureWithId.singleSplitFeature;
         const featureDataStableIds = await this.geoEntityManager.query(
-          'select stable_id from features_data where id = any($1)',
-          [
-            scenarioFeaturePreparationIdsForFeature.map(
-              (i) => i.features_data_id,
-            ),
-          ],
+          `select fd.stable_id
+             from feature_properties_kv fpkv
+             join features_data fd on fd.id = fpkv.feature_data_id
+            where fpkv.feature_id = $1
+              and fpkv.key = $2
+              and trim('"' from fpkv.value::text) = trim('"' from $3::text)`,
+          [baseFeatureId, splitByProperty, subset?.value],
         );
         await this.splitCreateFeatures.setFeatureDataStableIdsForFeature(
           singleSplitFeatureWithId.id,

--- a/api/apps/geoprocessing/src/modules/features/features.service.spec.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.spec.ts
@@ -1,0 +1,97 @@
+import { FeatureService } from './features.service';
+
+/**
+ * Unit tests for the WHERE-clause builder that drives feature MVT tiles.
+ *
+ * Materialized split features do not own any `features_data` rows of their own:
+ * their geometries are a subset of the *parent* feature's rows, identified by
+ * the stable ids stored in `(apidb)features.feature_data_stable_ids`. The tile
+ * query for a split feature must therefore select geometries by `stable_id`,
+ * not by the split feature's own `feature_id` (which matches zero rows).
+ */
+
+const buildService = ({
+  stableIds,
+  tableName = 'features_data',
+}: {
+  stableIds: string[] | null;
+  tableName?: string;
+}): { service: FeatureService; createQueryBuilder: jest.Mock } => {
+  const queryBuilder = {
+    select: () => queryBuilder,
+    from: () => queryBuilder,
+    where: () => queryBuilder,
+    execute: () => Promise.resolve([{ feature_data_stable_ids: stableIds }]),
+  };
+  const createQueryBuilder = jest.fn(() => queryBuilder);
+  const apiEntityManager = { createQueryBuilder };
+  const featuresRepository = { metadata: { tableName } };
+  const service = new FeatureService(
+    featuresRepository as never,
+    apiEntityManager as never,
+    {} as never,
+  );
+  return { service, createQueryBuilder };
+};
+
+describe(`${FeatureService.name}.buildFeaturesWhereQuery`, () => {
+  it('filters a split feature by its features_data stable ids, not by the split feature id', async () => {
+    const splitFeatureId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const stableIds = [
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+    ];
+
+    const where = await buildService({
+      stableIds,
+    }).service.buildFeaturesWhereQuery(splitFeatureId, false);
+
+    expect(where).toBe(
+      `stable_id = ANY(ARRAY['${stableIds[0]}', '${stableIds[1]}']::uuid[])`,
+    );
+  });
+
+  it('filters by feature_id (and never looks up stable ids) on the project amounts path', async () => {
+    const featureId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    const { service, createQueryBuilder } = buildService({
+      // even if stable ids exist, the amounts table has no stable_id column and
+      // amounts are materialized per feature id, so they must not be used here
+      stableIds: ['33333333-3333-3333-3333-333333333333'],
+    });
+
+    const where = await service.buildFeaturesWhereQuery(featureId, true);
+
+    expect(where).toBe(`feature_id = '${featureId}'`);
+    expect(where).not.toContain('stable_id');
+    expect(createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('falls back to feature_id for a plain/legacy feature with no stable ids', async () => {
+    const featureId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+    const where = await buildService({
+      stableIds: null,
+    }).service.buildFeaturesWhereQuery(featureId, false);
+
+    expect(where).toBe(`feature_id = '${featureId}'`);
+  });
+
+  it('appends the bbox envelope filter to a split feature query', async () => {
+    const stableIds = ['44444444-4444-4444-4444-444444444444'];
+
+    const where = await buildService({
+      stableIds,
+    }).service.buildFeaturesWhereQuery(
+      'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      false,
+      [-1, 40, 1, 42],
+    );
+
+    expect(where).toContain(
+      `stable_id = ANY(ARRAY['${stableIds[0]}']::uuid[])`,
+    );
+    expect(where).toContain('AND');
+    expect(where).toContain('st_intersects');
+    expect(where).toContain('the_geom');
+  });
+});

--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -47,19 +47,45 @@ export class FeatureService {
    * @todo move the string to int transformation to the AdminAreaLevelFilters class
    */
 
-  async buildFeaturesWhereQuery(id: string, bbox?: BBox): Promise<string> {
-    let whereQuery = `feature_id = '${id}'`;
-    const featureDataStableIds: Array<string> = await this.apiEntityManager
-      .createQueryBuilder()
-      .select('feature_data_stable_ids')
-      .from('features', 'f')
-      .where('id = :id', { id })
-      .execute()
-      .then((result) => result?.[0].feature_data_stable_ids);
+  async buildFeaturesWhereQuery(
+    id: string,
+    forProject: boolean,
+    bbox?: BBox,
+  ): Promise<string> {
+    /**
+     * Materialized split features own no `features_data` rows of their own:
+     * their geometries are a subset of the *parent* feature's rows, linked via
+     * the stable ids stored in `(apidb)features.feature_data_stable_ids`. On the
+     * geometry path (`forProject === false`, reading from `features_data`) we
+     * must therefore select rows by `stable_id`, since the split feature's own
+     * `feature_id` matches no rows.
+     *
+     * On the project path (`forProject === true`) tiles are rendered from
+     * `feature_amounts_per_planning_unit`, where amounts are already
+     * materialized per feature id (including for split features); that table has
+     * no `stable_id` column, so we keep filtering by `feature_id` and skip the
+     * stable-id lookup entirely.
+     */
+    const featureDataStableIds: Array<string> | null = forProject
+      ? null
+      : await this.apiEntityManager
+          .createQueryBuilder()
+          .select('feature_data_stable_ids')
+          .from('features', 'f')
+          .where('id = :id', { id })
+          .execute()
+          .then((result) => result?.[0]?.feature_data_stable_ids ?? null);
+
+    let whereQuery =
+      featureDataStableIds && featureDataStableIds.length > 0
+        ? `stable_id = ANY(ARRAY[${featureDataStableIds
+            .map((stableId) => `'${stableId}'`)
+            .join(', ')}]::uuid[])`
+        : `feature_id = '${id}'`;
 
     if (bbox) {
       const { westBbox, eastBbox } = antimeridianBbox(nominatim2bbox(bbox));
-      whereQuery += `AND
+      whereQuery += ` AND
       (st_intersects(
         st_intersection(st_makeenvelope(${eastBbox}, 4326),
         ST_MakeEnvelope(0, -90, 180, 90, 4326)),
@@ -71,12 +97,6 @@ export class FeatureService {
       ))`;
     }
 
-    if (featureDataStableIds?.length > 0) {
-      const formattedIds = featureDataStableIds
-        .map((id) => `'${id}'`)
-        .join(', ');
-      whereQuery += `AND feature_data_stable_ids = ANY(ARRAY[${formattedIds}]::uuid[])`;
-    }
     return whereQuery;
   }
 
@@ -103,10 +123,15 @@ export class FeatureService {
                  INNER JOIN planning_units_geom pug on pug.id=ppu.geom_id)`
       : `(select ST_RemoveRepeatedPoints((st_dump(the_geom)).geom, ${simplificationLevel}) as the_geom,
                  (coalesce(properties,'{}'::jsonb) || jsonb_build_object('amount', amount)) as properties,
-                 feature_id
+                 feature_id,
+                 stable_id
                  from "${this.featuresRepository.metadata.tableName}")`;
 
-    const customQuery = await this.buildFeaturesWhereQuery(id, bbox);
+    const customQuery = await this.buildFeaturesWhereQuery(
+      id,
+      forProject,
+      bbox,
+    );
     return this.tileService.getTile({
       z,
       x,

--- a/data/scripts/feature-split-backport/README.md
+++ b/data/scripts/feature-split-backport/README.md
@@ -1,0 +1,74 @@
+# Backport `feature_data_stable_ids` for legacy split features [MRXNM-82]
+
+Legacy materialized split features (`(apidb)features` rows with
+`from_geoprocessing_ops->>'operation' = 'split'`) were created before the
+materialized-splits work and have an empty `feature_data_stable_ids`. The new
+code renders them with no geometry. `backport_feature_data_stable_ids.py`
+reconstructs that linkage from the parent feature's
+`(geodb)feature_properties_kv` → `features_data.stable_id`.
+
+## Subset definition (decided 2026-06-18)
+
+The array is the **full K/V-matching subset** of the parent's `features_data`
+rows — NOT bbox-filtered. Rationale:
+
+- Matches how splits historically rendered (parent tiles + a client-side
+  property filter = the full class geometry, viewport-clipped only).
+- Amounts are unaffected: `feature_amounts_per_planning_unit` is bounded by the
+  project's planning units, so out-of-project geometry contributes nothing
+  regardless of how broad the array is (verified against prod).
+- Matches the design doc's wording ("the subset that matches the K/V pair") and
+  avoids the `nominatim2bbox` bbox `@debt` in `SplitQuery` entirely.
+
+Value match mirrors `SplitQuery`: `trim('"' FROM fpkv.value::text)`.
+
+## Usage
+
+```bash
+# via the bastion tunnel (staging->9432, prod->9433), dry-run (default):
+python3 backport_feature_data_stable_ids.py --env staging
+python3 backport_feature_data_stable_ids.py --env production
+# commit:
+python3 backport_feature_data_stable_ids.py --env production --apply
+# Nectar / any host — pass connection explicitly (password via ~/.pgpass):
+python3 backport_feature_data_stable_ids.py \
+  --host <h> --port 5432 \
+  --api-db marxan-api --api-user marxan-api \
+  --geo-db marxan-geo-api --geo-user marxan-geo-api --apply
+```
+
+Additive + idempotent (only touches splits whose array is NULL/empty). Dry-run
+rolls back. Reconstructions that return 0 rows are SKIPPED and reported, never
+written as an empty array.
+
+## Production dry-run findings (2026-06-18, Azure prod)
+
+639 split features total:
+
+| Outcome | Count |
+|---|---|
+| Reconstructable → backported | **463** (1–58,820 ids each; median 2; ~3.27M ids total) |
+| Skipped — parent has no `features_data` (orphaned) | 154 |
+| Skipped — no `value` in `from_geoprocessing_ops` | 22 |
+
+- The **176 skipped** splits are pre-existing broken data the backport cannot
+  fix (their source geometry is gone, or they have no split value). They also
+  have no stored amounts — empty shells. Decide separately (delete / leave).
+- **112 reconstructable splits have >10k stable ids (max 58,820).** See the tile
+  perf follow-up below.
+
+## Open follow-ups
+
+1. **Tile perf for large-array splits.** `FeatureService.buildFeaturesWhereQuery`
+   (fix in commit on `fix/mrxnm-82-split-feature-tiles`) emits
+   `stable_id = ANY(ARRAY[...]::uuid[])` inline. For 10k–58k-element arrays this
+   is multi-MB SQL per tile and won't scale. Needs a better predicate (join
+   against a values set / temp table, or re-derive) before those splits render
+   in production.
+2. **New-code alignment (note to Andrés).** `split-operation.service.ts` sets
+   `feature_data_stable_ids` from the **bbox-filtered** `SplitQuery` result. By
+   the rationale above that's an over-constraint (and rides the `nominatim2bbox`
+   debt): new splits would render narrower / mis-placed vs legacy ones. Suggest
+   deriving from the full K/V subset there too, so new + backported splits match.
+3. **Orphaned/valueless splits (176).** Data-quality cleanup, independent of this
+   backport.

--- a/data/scripts/feature-split-backport/backport_feature_data_stable_ids.py
+++ b/data/scripts/feature-split-backport/backport_feature_data_stable_ids.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Backport `feature_data_stable_ids` for legacy materialized split features [MRXNM-82].
+
+WHY
+---
+Split features are real `(apidb)features` rows (`from_geoprocessing_ops->>'operation'
+= 'split'`) that own no geometry of their own: their geometry is a *subset* of the
+parent feature's `(geodb)features_data` rows, identified by a key/value property.
+The materialized-splits work links a split to that subset via the
+`features.feature_data_stable_ids` uuid[] column. Splits created before that work
+have an empty array, so the new code renders them with no geometry. This script
+reconstructs and backfills that array.
+
+SUBSET DEFINITION (decided 2026-06-18)
+--------------------------------------
+The subset is the **full K/V-matching set** of the parent's `features_data` rows
+(the design doc's definition) — NOT bbox-filtered:
+  * it matches how splits historically rendered (parent geometry filtered to the
+    split property value, viewport-clipped only);
+  * amounts are unaffected (they are bounded by the project's planning units, so
+    out-of-project geometry contributes nothing regardless of subset breadth);
+  * it avoids the `nominatim2bbox` bbox `@debt` in SplitQuery entirely.
+The value match mirrors SplitQuery exactly: `trim('"' FROM fpkv.value::text)`.
+
+SAFETY
+------
+* Additive + idempotent: only touches splits whose array is NULL/empty.
+* Dry-run by default (rolls back); pass --apply to commit.
+* Reconstructions that return 0 rows are SKIPPED and reported (never written as an
+  empty array) so orphaned/anomalous splits can be investigated.
+* Passwords come from ~/.pgpass / PGPASSWORD — never hard-coded here.
+
+USAGE
+-----
+  # Azure (via the bastion tunnel: staging->9432, prod->9433), dry-run:
+  python3 backport_feature_data_stable_ids.py --env staging
+  python3 backport_feature_data_stable_ids.py --env production
+  # commit:
+  python3 backport_feature_data_stable_ids.py --env production --apply
+  # Nectar (or any host) — pass connection explicitly:
+  python3 backport_feature_data_stable_ids.py \
+      --host db.example --port 5432 \
+      --api-db marxan-api --api-user marxan-api \
+      --geo-db marxan-geo-api --geo-user marxan-geo-api --apply
+"""
+import argparse
+import sys
+
+import psycopg2
+import psycopg2.extras
+
+# Azure-tunnel presets (api DB and geo DB live on the same server / port per env).
+ENV_PRESETS = {
+    "staging": {
+        "port": 9432,
+        "api_db": "api-staging",
+        "api_user": "api-staging",
+        "geo_db": "geoprocessing-staging",
+        "geo_user": "geoprocessing-staging",
+    },
+    "production": {
+        "port": 9433,
+        "api_db": "api-production",
+        "api_user": "api-production",
+        "geo_db": "geoprocessing-production",
+        "geo_user": "geoprocessing-production",
+    },
+}
+
+FIND_SPLITS_SQL = """
+    SELECT id,
+           project_id,
+           feature_class_name,
+           from_geoprocessing_ops->>'baseFeatureId'   AS base_feature_id,
+           from_geoprocessing_ops->>'splitByProperty' AS split_by_property,
+           from_geoprocessing_ops->>'value'           AS value
+    FROM features
+    WHERE from_geoprocessing_ops->>'operation' = 'split'
+      AND (feature_data_stable_ids IS NULL
+           OR cardinality(feature_data_stable_ids) = 0)
+    ORDER BY project_id, id
+"""
+
+# Full K/V-matching subset of the PARENT's features_data rows. Value match mirrors
+# SplitQuery's `trim('"' FROM fpkv.value::text)`. No bbox filter (see module docs).
+# NOTE: aggregate stable_id::text — psycopg2 does not parse a bare `uuid[]` result
+# and would hand it back as the raw '{...}' string; a `text[]` is parsed to a list.
+# `n` is returned alongside so we can assert the list length matches.
+RECONSTRUCT_SQL = """
+    SELECT array_agg(DISTINCT fd.stable_id::text) AS stable_ids,
+           count(DISTINCT fd.stable_id)           AS n
+    FROM feature_properties_kv fpkv
+    JOIN features_data fd ON fd.id = fpkv.feature_data_id
+    WHERE fpkv.feature_id = %(base_feature_id)s
+      AND fpkv.key        = %(split_by_property)s
+      AND trim('"' FROM fpkv.value::text) = trim('"' FROM %(value)s::text)
+"""
+
+UPDATE_SQL = """
+    UPDATE features
+    SET feature_data_stable_ids = %(stable_ids)s::uuid[]
+    WHERE id = %(id)s
+"""
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", choices=ENV_PRESETS.keys(),
+                   help="Azure-tunnel connection preset")
+    p.add_argument("--host", default="localhost")
+    p.add_argument("--port", type=int)
+    p.add_argument("--api-db"), p.add_argument("--api-user")
+    p.add_argument("--geo-db"), p.add_argument("--geo-user")
+    p.add_argument("--apply", action="store_true",
+                   help="commit changes (default: dry-run, rolls back)")
+    p.add_argument("--limit", type=int,
+                   help="process at most N split features (testing)")
+    args = p.parse_args()
+
+    preset = ENV_PRESETS.get(args.env, {})
+    args.port = args.port or preset.get("port")
+    args.api_db = args.api_db or preset.get("api_db")
+    args.api_user = args.api_user or preset.get("api_user")
+    args.geo_db = args.geo_db or preset.get("geo_db")
+    args.geo_user = args.geo_user or preset.get("geo_user")
+
+    missing = [n for n in ("port", "api_db", "api_user", "geo_db", "geo_user")
+               if not getattr(args, n)]
+    if missing:
+        p.error(f"missing connection settings: {', '.join(missing)} "
+                f"(use --env, or pass them explicitly)")
+    return args
+
+
+def connect(host, port, dbname, user):
+    # password resolved from ~/.pgpass / PGPASSWORD; ssl required (Azure/Nectar).
+    return psycopg2.connect(host=host, port=port, dbname=dbname, user=user,
+                            sslmode="require")
+
+
+def main():
+    args = parse_args()
+    dry_run = not args.apply
+
+    api_conn = connect(args.host, args.port, args.api_db, args.api_user)
+    geo_conn = connect(args.host, args.port, args.geo_db, args.geo_user)
+    api_conn.autocommit = False
+
+    print(f"[backport] host={args.host}:{args.port} api={args.api_db} "
+          f"geo={args.geo_db} mode={'DRY-RUN' if dry_run else 'APPLY'}")
+
+    api = api_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    geo = geo_conn.cursor()
+
+    sql = FIND_SPLITS_SQL + (f" LIMIT {int(args.limit)}" if args.limit else "")
+    api.execute(sql)
+    todo = api.fetchall()
+    print(f"[backport] {len(todo)} split feature(s) need backporting\n")
+
+    updated, skipped = 0, []
+    for f in todo:
+        if not f["value"]:
+            skipped.append((f, "no 'value' in from_geoprocessing_ops"))
+            print(f"  SKIP  {f['id']} ({f['feature_class_name']}): no value")
+            continue
+
+        geo.execute(RECONSTRUCT_SQL, {
+            "base_feature_id": f["base_feature_id"],
+            "split_by_property": f["split_by_property"],
+            "value": f["value"],
+        })
+        stable_ids, n = geo.fetchone()  # text[] (list) + count
+
+        if not stable_ids:
+            skipped.append((f, "0 matching features_data rows"))
+            print(f"  SKIP  {f['id']} ({f['feature_class_name']}): 0 rows "
+                  f"[base={f['base_feature_id']} key={f['split_by_property']} "
+                  f"value={f['value']!r}]")
+            continue
+
+        assert len(stable_ids) == n, (
+            f"array/count mismatch for {f['id']}: {len(stable_ids)} != {n}")
+
+        api.execute(UPDATE_SQL, {"stable_ids": stable_ids, "id": f["id"]})
+        updated += 1
+        print(f"  OK    {f['id']} ({f['feature_class_name']}): "
+              f"{len(stable_ids)} stable ids")
+
+    print(f"\n[backport] summary: {updated} to update, {len(skipped)} skipped, "
+          f"{len(todo)} total")
+
+    if dry_run:
+        api_conn.rollback()
+        print("[backport] DRY-RUN — rolled back. Re-run with --apply to commit.")
+    else:
+        api_conn.commit()
+        print(f"[backport] APPLIED — committed {updated} update(s).")
+    geo_conn.rollback()  # read-only
+
+    if skipped:
+        print(f"\n[backport] {len(skipped)} skipped split feature(s) "
+              f"(investigate before relying on them):")
+        for f, reason in skipped:
+            print(f"  {f['id']}  project={f['project_id']}  "
+                  f"base={f['base_feature_id']}  key={f['split_by_property']}  "
+                  f"value={f['value']!r}  -- {reason}")
+
+    api.close(); geo.close(); api_conn.close(); geo_conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacks on top of the BE split PR (#1714). Two pieces:

## 1. Tile rendering fix (`250b70060`)
Split features own no `features_data` rows of their own; their geometry is a subset of the **parent's** rows, linked via `features.feature_data_stable_ids`. `FeatureService.buildFeaturesWhereQuery` is now path-aware:
- **geometry path** (`forProject=false`): filter by `stable_id = ANY(...)` when the feature has stable ids (dropping the split's own `feature_id`, which matches zero rows); fall back to `feature_id` for plain/legacy features. `findTile` also exposes `stable_id` in the geometry subquery.
- **amounts path** (`forProject=true`): unchanged — keeps `feature_id`, skips the stable-id lookup.

The previous attempt filtered by a non-existent `feature_data_stable_ids` column on the geo table (it has `stable_id`) and kept the split's `feature_id` predicate → 400s / empty tiles. `TileService` is untouched, so PA/PU tiles are unaffected. 4 unit tests added.

## 2. Legacy backport (`0a99e4e1e`)
`data/scripts/feature-split-backport/` — standalone dual-DB script backfilling `feature_data_stable_ids` for pre-existing split features (empty arrays → render nothing). Uses the **full K/V-matching subset** (no bbox — agreed with Andrés; matches historical split rendering + design doc; amounts are PU-bounded so breadth is harmless). Dry-run default, idempotent, skips+reports orphaned/valueless splits.

Prod dry-run: **463/639 reconstructable**; 176 un-reconstructable (154 orphaned parents w/ no `features_data`, 22 no split value). Migration to Nectar already done; **backport runs on Nectar later** (reconstruction inputs travelled in the dump).

## Follow-ups (not in this PR)
- **New-split alignment:** `split-operation.service.ts` should derive `feature_data_stable_ids` from the full K/V subset too (currently bbox-filtered), so new splits match the backport. Andrés's area.
- **Tile perf for large-array splits:** inline `ANY(ARRAY[...])` won't scale for >10k-id splits (max ~58.8k) — tracked as **MRXNM-97**.

Deploy must go **with the FE branch** `feature/app/MRXNM-82-materialized-feature-splits`.