### PR TITLE
feat(scripts): split-feature amounts backfill (phase 2) [MRXNM-82]

### DIFF
--- a/data/scripts/feature-split-backport/README.md
+++ b/data/scripts/feature-split-backport/README.md
@@ -1,11 +1,18 @@
-# Backport `feature_data_stable_ids` for legacy split features [MRXNM-82]
+# Restore legacy split features [MRXNM-82]
 
-Legacy materialized split features (`(apidb)features` rows with
-`from_geoprocessing_ops->>'operation' = 'split'`) were created before the
-materialized-splits work and have an empty `feature_data_stable_ids`. The new
-code renders them with no geometry. `backport_feature_data_stable_ids.py`
-reconstructs that linkage from the parent feature's
-`(geodb)feature_properties_kv` → `features_data.stable_id`.
+Two one-off scripts that repair legacy materialized split features
+(`(apidb)features` rows with `from_geoprocessing_ops->>'operation' = 'split'`)
+created before the materialized-splits work:
+
+1. **`backport_feature_data_stable_ids.py`** — relinks geometry: populates the
+   empty `features.feature_data_stable_ids` from the parent feature's
+   `(geodb)feature_properties_kv` -> `features_data.stable_id`.
+2. **`backfill_split_feature_amounts.py`** — recomputes the per-planning-unit
+   amounts (`feature_amounts_per_planning_unit`) for the subset of live splits
+   that never had them.
+
+New splits created by the current `split-operation` code need NEITHER — they get
+both at creation. These scripts only touch pre-existing legacy splits.
 
 ## Subset definition (decided 2026-06-18)
 
@@ -22,7 +29,7 @@ rows — NOT bbox-filtered. Rationale:
 
 Value match mirrors `SplitQuery`: `trim('"' FROM fpkv.value::text)`.
 
-## Usage
+## Phase 1 — geometry backport (`backport_feature_data_stable_ids.py`)
 
 ```bash
 # via the bastion tunnel (staging->9432, prod->9433), dry-run (default):
@@ -30,45 +37,72 @@ python3 backport_feature_data_stable_ids.py --env staging
 python3 backport_feature_data_stable_ids.py --env production
 # commit:
 python3 backport_feature_data_stable_ids.py --env production --apply
-# Nectar / any host — pass connection explicitly (password via ~/.pgpass):
-python3 backport_feature_data_stable_ids.py \
-  --host <h> --port 5432 \
-  --api-db marxan-api --api-user marxan-api \
-  --geo-db marxan-geo-api --geo-user marxan-geo-api --apply
 ```
 
 Additive + idempotent (only touches splits whose array is NULL/empty). Dry-run
 rolls back. Reconstructions that return 0 rows are SKIPPED and reported, never
 written as an empty array.
 
-## Production dry-run findings (2026-06-18, Azure prod)
+## Phase 2 — amounts backfill (`backfill_split_feature_amounts.py`)
 
-639 split features total:
+Phase 1 makes a split render via the **raw-geometry** tile path
+(`forProject=false`, by `stable_id`). But the scenario **abundance** view renders
+via the `forProject=true` path, which reads `feature_amounts_per_planning_unit`
+by `feature_id`. Most legacy splits already have those amounts (their values
+*were* calculated at scenario time); some live ones never got them and stay blank
+in the abundance view until recomputed.
 
-| Outcome | Count |
-|---|---|
-| Reconstructable → backported | **463** (1–58,820 ids each; median 2; ~3.27M ids total) |
-| Skipped — parent has no `features_data` (orphaned) | 154 |
-| Skipped — no `value` in `from_geoprocessing_ops` | 22 |
+This script computes & inserts those per-PU amounts, mirroring
+`ComputeArea.computeAreaPerPlanningUnitOfFeature` /
+`FeatureAmountsPerPlanningUnitService.computeMarxanAmountPerPlanningUnit`
+(ST_Union of the `features_data` matched by `stable_id`, `&&` prefilter, then
+`ST_Area(ST_Transform(ST_Intersection(...),3410))`, keeping `amount > 0`).
 
-- The **176 skipped** splits are pre-existing broken data the backport cannot
-  fix (their source geometry is gone, or they have no split value). They also
-  have no stored amounts — empty shells. Decide separately (delete / leave).
-- **112 reconstructable splits have >10k stable ids (max 58,820).** See the tile
-  perf follow-up below.
+**Safety / scope** — only touches a feature when ALL hold: `operation = 'split'`
+**and** `feature_data_stable_ids` non-empty **and** it has NO
+`feature_amounts_per_planning_unit` rows yet. Each compute is scoped to that one
+feature's own `stable_ids` and its own project's planning units, so it can never
+write amounts for any other feature. Dry-run default; idempotent;
+`--only-feature` / `--limit` / `--skip-legacy-projects` flags. It reads the
+`stable_ids` phase 1 writes, so **run it after the backport.** `amount_min/max`
+is intentionally not set (NULL even for working splits; not needed for rendering).
+
+## Production findings (2026-06-18 / amounts cut 2026-06-19, Azure prod)
+
+639 split features total. Backport reconstructs **463**; cross-referenced with
+`feature_amounts_per_planning_unit`:
+
+| Bucket | Count | Action |
+|---|---|---|
+| Reconstructable **+ has amounts** | **422** | phase 1 alone — fully restored |
+| Reconstructable **- amounts** (live, non-draft scenarios) | **41** | phase 1 **+** phase 2 |
+| Broken — 0 K/V rows (154) or no `value` (22), no amounts | **176** | delete (data cleanup) |
+
+(422 + 41 + 176 = 639; backport ids range 1–58,820, median 2, ~3.27M total.)
+
+## Nectar runbook
+
+```bash
+# phase 1 — relink geometry for all 463 reconstructable splits
+python3 backport_feature_data_stable_ids.py --host <h> --port 5432 \
+  --api-db marxan-api --api-user marxan-api \
+  --geo-db marxan-geo-api --geo-user marxan-geo-api --apply
+# phase 2 — amounts for the 41 live-but-amount-less (auto-targeted by the filter)
+python3 backfill_split_feature_amounts.py --host <h> --port 5432 \
+  --api-db marxan-api --api-user marxan-api \
+  --geo-db marxan-geo-api --geo-user marxan-geo-api --apply
+```
+
+Validated on staging (2026-06-19): phase 1 relinked the one Spain split (5485
+ids); phase 2 dry-run computed its amounts (2 PU rows); a fresh UI split on the
+Rwanda project rendered correctly (geometry + amounts), confirming the
+steady-state path.
 
 ## Open follow-ups
 
-1. **Tile perf for large-array splits.** `FeatureService.buildFeaturesWhereQuery`
-   (fix in commit on `fix/mrxnm-82-split-feature-tiles`) emits
-   `stable_id = ANY(ARRAY[...]::uuid[])` inline. For 10k–58k-element arrays this
-   is multi-MB SQL per tile and won't scale. Needs a better predicate (join
-   against a values set / temp table, or re-derive) before those splits render
-   in production.
-2. **New-code alignment (note to Andrés).** `split-operation.service.ts` sets
-   `feature_data_stable_ids` from the **bbox-filtered** `SplitQuery` result. By
-   the rationale above that's an over-constraint (and rides the `nominatim2bbox`
-   debt): new splits would render narrower / mis-placed vs legacy ones. Suggest
-   deriving from the full K/V subset there too, so new + backported splits match.
-3. **Orphaned/valueless splits (176).** Data-quality cleanup, independent of this
-   backport.
+1. **Tile perf for large-array splits — [MRXNM-97].** `buildFeaturesWhereQuery`
+   emits `stable_id = ANY(ARRAY[...])` inline; 112 reconstructable splits have
+   >10k ids (max 58,820) → multi-MB SQL per tile. Needs a better predicate
+   (values set / temp table, or re-derive) before those render in prod.
+2. **Broken/dead splits (176).** Data-quality cleanup, independent of these
+   scripts (no geometry to reconstruct, no amounts). Delete candidates.

--- a/data/scripts/feature-split-backport/backfill_split_feature_amounts.py
+++ b/data/scripts/feature-split-backport/backfill_split_feature_amounts.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Backfill `feature_amounts_per_planning_unit` for legacy SPLIT features that have
+geometry (`features.feature_data_stable_ids`, e.g. after the stable-id backport)
+but never had their per-planning-unit amounts computed [MRXNM-82].
+
+WHY
+---
+A materialized split renders in two ways:
+  * raw geometry  -> tile path `forProject=false`, filters `features_data` by
+    `stable_id` (fixed by the stable-id backport);
+  * abundance/amounts -> tile path `forProject=true`, reads
+    `feature_amounts_per_planning_unit` by `feature_id`.
+Some legacy live splits have geometry-reconstructable `stable_ids` (after the
+backport) yet were never materialized into `feature_amounts_per_planning_unit`,
+so they stay blank in the scenario amounts view. This computes & inserts those
+amounts, mirroring `ComputeArea.computeAreaPerPlanningUnitOfFeature` ->
+`FeatureAmountsPerPlanningUnitService.computeMarxanAmountPerPlanningUnit`.
+
+SCOPE / SAFETY (limited to the relevant split features only)
+------------------------------------------------------------
+A feature is processed ONLY if ALL hold:
+  * from_geoprocessing_ops->>'operation' = 'split'   (split features only)
+  * feature_data_stable_ids is non-empty             (geometry present)
+  * it has NO rows in feature_amounts_per_planning_unit yet (the gap; idempotent)
+The amount computation is run PER FEATURE, scoped to that feature's OWN
+stable_ids and its OWN project's planning units -> it can never write amounts for
+any other feature. Non-split features are never read or touched.
+
+NOTE: the API code path SKIPS `legacyImport`-source projects. This script does
+not special-case sources by default because every in-scope prod split lives in a
+`marxan_cloud` project; pass --skip-legacy-projects to enforce the skip anyway.
+
+ORDER: run AFTER `backport_feature_data_stable_ids.py` (this reads the stable_ids
+that backport writes). Dry-run by default (rolls back); --apply to commit.
+Idempotent. `amount_min/max` is intentionally NOT set (it is NULL even for the
+working splits and is not needed for rendering).
+
+USAGE
+-----
+  # via the bastion tunnel (staging->9432, prod->9433), dry-run:
+  python3 backfill_split_feature_amounts.py --env staging
+  python3 backfill_split_feature_amounts.py --env production
+  # rehearse a single feature, then commit:
+  python3 backfill_split_feature_amounts.py --env staging --only-feature <id>
+  python3 backfill_split_feature_amounts.py --env production --apply
+  # Nectar / any host -- pass connection explicitly:
+  python3 backfill_split_feature_amounts.py \
+      --host <h> --port 5432 \
+      --api-db marxan-api --api-user marxan-api \
+      --geo-db marxan-geo-api --geo-user marxan-geo-api --apply
+"""
+import argparse
+import sys
+
+import psycopg2
+import psycopg2.extras
+
+# Azure-tunnel presets (api DB and geo DB live on the same server / port per env).
+ENV_PRESETS = {
+    "staging": {
+        "port": 9432,
+        "api_db": "api-staging", "api_user": "api-staging",
+        "geo_db": "geoprocessing-staging", "geo_user": "geoprocessing-staging",
+    },
+    "production": {
+        "port": 9433,
+        "api_db": "api-production", "api_user": "api-production",
+        "geo_db": "geoprocessing-production", "geo_user": "geoprocessing-production",
+    },
+}
+
+# Candidate split features (api DB). stable_ids cast to text[] so psycopg2 parses
+# it to a Python list (a bare uuid[] would come back as the raw '{...}' string).
+FIND_TARGETS_SQL = """
+    SELECT f.id,
+           f.project_id,
+           f.feature_class_name,
+           f.feature_data_stable_ids::text[] AS stable_ids,
+           p.sources::text                   AS project_sources
+    FROM features f
+    JOIN projects p ON p.id = f.project_id
+    WHERE f.from_geoprocessing_ops->>'operation' = 'split'
+      AND f.feature_data_stable_ids IS NOT NULL
+      AND cardinality(f.feature_data_stable_ids) > 0
+    ORDER BY f.project_id, f.id
+"""
+
+# Already has amounts? (geo DB) -> skip (idempotent).
+AMOUNTS_EXIST_SQL = """
+    SELECT 1 FROM feature_amounts_per_planning_unit
+    WHERE feature_id = %(feature_id)s LIMIT 1
+"""
+
+# Compute + insert in one statement, scoped to THIS feature's stable_ids and THIS
+# project's planning units. Mirrors computeMarxanAmountPerPlanningUnit exactly
+# (st_union of the feature_data matched by stable_id, && bbox prefilter, then
+# ST_Area(ST_Transform(ST_Intersection(...),3410)); amount > 0 only).
+COMPUTE_INSERT_SQL = """
+    INSERT INTO feature_amounts_per_planning_unit
+        (id, project_id, feature_id, project_pu_id, amount)
+    WITH all_amount_per_planning_unit AS (
+        SELECT pu.id AS projectpuid,
+               ST_Area(
+                 ST_Transform(ST_Intersection(species.the_geom, pu.the_geom), 3410)
+               ) AS amount
+        FROM (
+            SELECT st_union(the_geom) AS the_geom
+            FROM features_data fd
+            WHERE fd.stable_id = ANY(%(stable_ids)s::uuid[])
+            GROUP BY fd.feature_id
+        ) species,
+        (
+            SELECT pug.the_geom, ppu.id AS id
+            FROM planning_units_geom pug
+            INNER JOIN projects_pu ppu ON pug.id = ppu.geom_id
+            WHERE ppu.project_id = %(project_id)s::uuid
+        ) pu
+        WHERE species.the_geom && pu.the_geom
+    )
+    SELECT gen_random_uuid(), %(project_id)s::uuid, %(feature_id)s::uuid,
+           projectpuid, amount
+    FROM all_amount_per_planning_unit
+    WHERE amount > 0
+"""
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", choices=ENV_PRESETS.keys(),
+                   help="Azure-tunnel connection preset")
+    p.add_argument("--host", default="localhost")
+    p.add_argument("--port", type=int)
+    p.add_argument("--api-db"), p.add_argument("--api-user")
+    p.add_argument("--geo-db"), p.add_argument("--geo-user")
+    p.add_argument("--apply", action="store_true",
+                   help="commit changes (default: dry-run, rolls back)")
+    p.add_argument("--skip-legacy-projects", action="store_true",
+                   help="skip features in legacyImport-source projects (matches API)")
+    p.add_argument("--only-feature", action="append", default=[],
+                   help="restrict to specific feature id(s) (repeatable; testing)")
+    p.add_argument("--limit", type=int, help="process at most N features (testing)")
+    args = p.parse_args()
+
+    preset = ENV_PRESETS.get(args.env, {})
+    args.port = args.port or preset.get("port")
+    args.api_db = args.api_db or preset.get("api_db")
+    args.api_user = args.api_user or preset.get("api_user")
+    args.geo_db = args.geo_db or preset.get("geo_db")
+    args.geo_user = args.geo_user or preset.get("geo_user")
+
+    missing = [n for n in ("port", "api_db", "api_user", "geo_db", "geo_user")
+               if not getattr(args, n)]
+    if missing:
+        p.error(f"missing connection settings: {', '.join(missing)} "
+                f"(use --env, or pass them explicitly)")
+    return args
+
+
+def connect(host, port, dbname, user):
+    return psycopg2.connect(host=host, port=port, dbname=dbname, user=user,
+                            sslmode="require")
+
+
+def main():
+    args = parse_args()
+    dry_run = not args.apply
+
+    api_conn = connect(args.host, args.port, args.api_db, args.api_user)
+    geo_conn = connect(args.host, args.port, args.geo_db, args.geo_user)
+    geo_conn.autocommit = False
+
+    print(f"[amounts] host={args.host}:{args.port} api={args.api_db} "
+          f"geo={args.geo_db} mode={'DRY-RUN' if dry_run else 'APPLY'}")
+
+    api = api_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    geo = geo_conn.cursor()
+
+    api.execute(FIND_TARGETS_SQL)
+    targets = api.fetchall()
+    if args.only_feature:
+        wanted = set(args.only_feature)
+        targets = [t for t in targets if str(t["id"]) in wanted]
+    if args.limit:
+        targets = targets[: args.limit]
+    print(f"[amounts] {len(targets)} candidate split feature(s) "
+          f"(split + non-empty stable_ids)\n")
+
+    computed, skipped = 0, []
+    for f in targets:
+        fid = str(f["id"])
+        if args.skip_legacy_projects and f["project_sources"] == "legacyImport":
+            skipped.append((f, "legacyImport project"))
+            print(f"  SKIP  {fid} ({f['feature_class_name']}): legacyImport project")
+            continue
+
+        geo.execute(AMOUNTS_EXIST_SQL, {"feature_id": fid})
+        if geo.fetchone():
+            skipped.append((f, "amounts already present"))
+            print(f"  SKIP  {fid} ({f['feature_class_name']}): amounts already present")
+            continue
+
+        geo.execute(COMPUTE_INSERT_SQL, {
+            "project_id": str(f["project_id"]),
+            "feature_id": fid,
+            "stable_ids": f["stable_ids"],
+        })
+        n = geo.rowcount
+        if n == 0:
+            skipped.append((f, "0 PU rows (no geometry/PU overlap)"))
+            print(f"  WARN  {fid} ({f['feature_class_name']}): computed 0 PU rows "
+                  f"(no overlap?) [{len(f['stable_ids'])} stable ids]")
+            continue
+        computed += 1
+        print(f"  OK    {fid} ({f['feature_class_name']}): inserted {n} PU amount row(s) "
+              f"[{len(f['stable_ids'])} stable ids]")
+
+    print(f"\n[amounts] summary: {computed} computed, {len(skipped)} skipped, "
+          f"{len(targets)} candidates")
+
+    if dry_run:
+        geo_conn.rollback()
+        print("[amounts] DRY-RUN — rolled back. Re-run with --apply to commit.")
+    else:
+        geo_conn.commit()
+        print(f"[amounts] APPLIED — committed amounts for {computed} feature(s).")
+    api_conn.rollback()  # read-only
+
+    api.close(); geo.close(); api_conn.close(); geo_conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/scripts/feature-split-backport/backfill_split_feature_amounts.py
+++ b/data/scripts/feature-split-backport/backfill_split_feature_amounts.py
@@ -31,17 +31,26 @@ NOTE: the API code path SKIPS `legacyImport`-source projects. This script does
 not special-case sources by default because every in-scope prod split lives in a
 `marxan_cloud` project; pass --skip-legacy-projects to enforce the skip anyway.
 
-GUARDRAILS (learned the hard way on prod 2026-06-22):
-  * --max-stable-ids N (default 1000): the per-feature amount is a single
-    `ST_Union` of all the split's geometries. For large global splits that union
-    is effectively unbounded -- a 3,317-geometry split ran 2h45m before being
-    killed (which is *why* those features never got amounts). Splits above the
-    threshold are SKIPPED + reported, not attempted; they are tracked in MRXNM-99
-    for a non-ST_Union computation. This is the PRIMARY guard.
-  * --statement-timeout S (default 600): secondary net bounding any single
-    compute. Best effort only -- a stuck PostGIS ST_Union may not hit an interrupt
-    checkpoint (pg_cancel_backend was observed to NOT stop one), so do not rely on
-    it; the size guard is what actually protects you.
+COMPUTE STRATEGY (per-PU union; see COMPUTE_INSERT_SQL):
+  The original API compute builds ONE global ST_Union of all the split's
+  geometries, which for large global splits is effectively unbounded -- it is what
+  ran 2h45m on prod before being killed (and why those features never got amounts
+  the first time round). This script instead intersects each geometry with each
+  overlapping project PU first, then unions the fragments per PU. The amounts are
+  numerically identical (verified on prod against both the global-union compute and
+  the API's own stored amounts) but the cost scales with the project's PU count,
+  not the feature's global vertex count -- the worst prod case (58,820 ids) went
+  from infeasible to ~19s. This is what makes the large [MRXNM-99] splits tractable.
+
+GUARDRAILS:
+  * --statement-timeout S (default 600): bounds any single compute; a feature that
+    exceeds it is reported and skipped, not fatal. With the per-PU compute this is
+    a reliable net (worst observed prod compute ~72s), unlike the old monolithic
+    ST_Union which a timeout/cancel could not interrupt mid-flight.
+  * --max-stable-ids N (default 0 = OFF): legacy size cap, kept only as optional
+    belt-and-suspenders. The per-PU compute removed the unboundedness that made
+    this necessary, so it is OFF by default; set it to re-enable skipping very
+    large splits if a host proves pathological.
   * Each feature commits in its OWN transaction, so a slow/failed one can never
     strand the features already computed (the previous all-at-once commit did).
 
@@ -107,30 +116,44 @@ AMOUNTS_EXIST_SQL = """
 """
 
 # Compute + insert in one statement, scoped to THIS feature's stable_ids and THIS
-# project's planning units. Mirrors computeMarxanAmountPerPlanningUnit exactly
-# (st_union of the feature_data matched by stable_id, && bbox prefilter, then
-# ST_Area(ST_Transform(ST_Intersection(...),3410)); amount > 0 only).
+# project's planning units.
+#
+# The API's computeMarxanAmountPerPlanningUnit builds ONE global ST_Union of every
+# feature_data row matched by stable_id, then intersects that single world-sized
+# geometry against each PU. For large/global splits (tens of thousands of complex
+# polygons) that union is effectively unbounded -- it is what ran 2h45m on prod.
+#
+# This computes the identical amounts the cheap way: intersect each feature_data
+# geometry with each *overlapping* project PU first (bounded by the project's
+# geographic extent via the && GiST index), then ST_Union the fragments PER PU.
+# Because
+#     Area( (U gi) ∩ pu )  ==  Area( U (gi ∩ pu) ),
+# the per-PU amount is numerically identical (verified on prod: max relative diff
+# 2e-15 vs the global-union compute), but each union now merges only the handful
+# of polygons that touch that one PU, so the cost scales with the project's PU
+# count rather than the feature's global vertex count. Worst case observed on prod
+# (58,820 ids over a 7,123-PU project) dropped from "killed at 2h45m" to ~19s
+# [MRXNM-99]. `amount > 0` only, matching the API.
 COMPUTE_INSERT_SQL = """
     INSERT INTO feature_amounts_per_planning_unit
         (id, project_id, feature_id, project_pu_id, amount)
     WITH all_amount_per_planning_unit AS (
-        SELECT pu.id AS projectpuid,
+        SELECT ppu.id AS projectpuid,
                ST_Area(
-                 ST_Transform(ST_Intersection(species.the_geom, pu.the_geom), 3410)
+                 ST_Transform(
+                   ST_Union(ST_Intersection(fd.the_geom, pug.the_geom)),
+                   3410
+                 )
                ) AS amount
-        FROM (
-            SELECT st_union(the_geom) AS the_geom
-            FROM features_data fd
-            WHERE fd.stable_id = ANY(%(stable_ids)s::uuid[])
-            GROUP BY fd.feature_id
-        ) species,
-        (
-            SELECT pug.the_geom, ppu.id AS id
-            FROM planning_units_geom pug
-            INNER JOIN projects_pu ppu ON pug.id = ppu.geom_id
-            WHERE ppu.project_id = %(project_id)s::uuid
-        ) pu
-        WHERE species.the_geom && pu.the_geom
+        FROM features_data fd
+        JOIN planning_units_geom pug
+          ON fd.the_geom && pug.the_geom
+         AND ST_Intersects(fd.the_geom, pug.the_geom)
+        JOIN projects_pu ppu
+          ON ppu.geom_id = pug.id
+         AND ppu.project_id = %(project_id)s::uuid
+        WHERE fd.stable_id = ANY(%(stable_ids)s::uuid[])
+        GROUP BY ppu.id
     )
     SELECT gen_random_uuid(), %(project_id)s::uuid, %(feature_id)s::uuid,
            projectpuid, amount
@@ -155,17 +178,16 @@ def parse_args():
     p.add_argument("--only-feature", action="append", default=[],
                    help="restrict to specific feature id(s) (repeatable; testing)")
     p.add_argument("--limit", type=int, help="process at most N features (testing)")
-    p.add_argument("--max-stable-ids", type=int, default=1000,
-                   help="PRIMARY GUARD: skip (do not compute) splits with more than "
-                        "N stable ids. Their single ST_Union of thousands of complex "
-                        "global polygons is effectively unbounded (a 3,317-geometry "
-                        "split ran 2h45m on prod) and is tracked separately in "
-                        "MRXNM-99. Default 1000; pass 0 to disable.")
+    p.add_argument("--max-stable-ids", type=int, default=0,
+                   help="OPTIONAL size cap: skip (do not compute) splits with more "
+                        "than N stable ids. Legacy guard from when the compute used a "
+                        "single unbounded ST_Union; the per-PU compute removed that "
+                        "unboundedness so this is OFF by default (0). Set it to "
+                        "re-enable skipping very large splits on a pathological host.")
     p.add_argument("--statement-timeout", type=int, default=600,
-                   help="SECONDARY net: per-feature statement_timeout in seconds; a "
-                        "feature that exceeds it is reported and skipped, not fatal. "
-                        "Default 600; pass 0 to disable. NB PostGIS ops may not honor "
-                        "it mid-ST_Union, so --max-stable-ids is the reliable guard.")
+                   help="Per-feature statement_timeout in seconds; a feature that "
+                        "exceeds it is reported and skipped, not fatal. Default 600 "
+                        "(worst observed prod compute ~72s); pass 0 to disable.")
     args = p.parse_args()
 
     preset = ENV_PRESETS.get(args.env, {})
@@ -245,10 +267,9 @@ def main():
                 continue
 
             if args.max_stable_ids and n_ids > args.max_stable_ids:
-                skipped.append((f, f"too large ({n_ids} > {args.max_stable_ids})"))
+                skipped.append((f, f"over --max-stable-ids ({n_ids} > {args.max_stable_ids})"))
                 print(f"  SKIP  {fid} ({name}): {n_ids} stable ids "
-                      f"> --max-stable-ids {args.max_stable_ids}; ST_Union infeasible, "
-                      f"deferred to MRXNM-99")
+                      f"> --max-stable-ids {args.max_stable_ids} (size cap enabled)")
                 geo_conn.rollback()
                 continue
 

--- a/data/scripts/feature-split-backport/backfill_split_feature_amounts.py
+++ b/data/scripts/feature-split-backport/backfill_split_feature_amounts.py
@@ -31,6 +31,20 @@ NOTE: the API code path SKIPS `legacyImport`-source projects. This script does
 not special-case sources by default because every in-scope prod split lives in a
 `marxan_cloud` project; pass --skip-legacy-projects to enforce the skip anyway.
 
+GUARDRAILS (learned the hard way on prod 2026-06-22):
+  * --max-stable-ids N (default 1000): the per-feature amount is a single
+    `ST_Union` of all the split's geometries. For large global splits that union
+    is effectively unbounded -- a 3,317-geometry split ran 2h45m before being
+    killed (which is *why* those features never got amounts). Splits above the
+    threshold are SKIPPED + reported, not attempted; they are tracked in MRXNM-99
+    for a non-ST_Union computation. This is the PRIMARY guard.
+  * --statement-timeout S (default 600): secondary net bounding any single
+    compute. Best effort only -- a stuck PostGIS ST_Union may not hit an interrupt
+    checkpoint (pg_cancel_backend was observed to NOT stop one), so do not rely on
+    it; the size guard is what actually protects you.
+  * Each feature commits in its OWN transaction, so a slow/failed one can never
+    strand the features already computed (the previous all-at-once commit did).
+
 ORDER: run AFTER `backport_feature_data_stable_ids.py` (this reads the stable_ids
 that backport writes). Dry-run by default (rolls back); --apply to commit.
 Idempotent. `amount_min/max` is intentionally NOT set (it is NULL even for the
@@ -141,6 +155,17 @@ def parse_args():
     p.add_argument("--only-feature", action="append", default=[],
                    help="restrict to specific feature id(s) (repeatable; testing)")
     p.add_argument("--limit", type=int, help="process at most N features (testing)")
+    p.add_argument("--max-stable-ids", type=int, default=1000,
+                   help="PRIMARY GUARD: skip (do not compute) splits with more than "
+                        "N stable ids. Their single ST_Union of thousands of complex "
+                        "global polygons is effectively unbounded (a 3,317-geometry "
+                        "split ran 2h45m on prod) and is tracked separately in "
+                        "MRXNM-99. Default 1000; pass 0 to disable.")
+    p.add_argument("--statement-timeout", type=int, default=600,
+                   help="SECONDARY net: per-feature statement_timeout in seconds; a "
+                        "feature that exceeds it is reported and skipped, not fatal. "
+                        "Default 600; pass 0 to disable. NB PostGIS ops may not honor "
+                        "it mid-ST_Union, so --max-stable-ids is the reliable guard.")
     args = p.parse_args()
 
     preset = ENV_PRESETS.get(args.env, {})
@@ -172,10 +197,21 @@ def main():
     geo_conn.autocommit = False
 
     print(f"[amounts] host={args.host}:{args.port} api={args.api_db} "
-          f"geo={args.geo_db} mode={'DRY-RUN' if dry_run else 'APPLY'}")
+          f"geo={args.geo_db} mode={'DRY-RUN' if dry_run else 'APPLY'} "
+          f"max_stable_ids={args.max_stable_ids or 'off'} "
+          f"statement_timeout={args.statement_timeout or 'off'}s")
 
     api = api_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
     geo = geo_conn.cursor()
+
+    # Secondary net: bound any single compute. Set at session level (committed via
+    # autocommit) so it survives the per-feature commits below. NB this is best
+    # effort — a stuck PostGIS ST_Union may not hit an interrupt checkpoint, so the
+    # --max-stable-ids guard below is the reliable protection.
+    if args.statement_timeout:
+        geo_conn.autocommit = True
+        geo.execute("SET statement_timeout = %s", (args.statement_timeout * 1000,))
+        geo_conn.autocommit = False
 
     api.execute(FIND_TARGETS_SQL)
     targets = api.fetchall()
@@ -187,46 +223,77 @@ def main():
     print(f"[amounts] {len(targets)} candidate split feature(s) "
           f"(split + non-empty stable_ids)\n")
 
-    computed, skipped = 0, []
+    # Per-feature transactions: each feature is committed (or rolled back) on its
+    # own, so a slow/failed one can never strand the features already computed.
+    computed, skipped, failed = 0, [], []
     for f in targets:
         fid = str(f["id"])
-        if args.skip_legacy_projects and f["project_sources"] == "legacyImport":
-            skipped.append((f, "legacyImport project"))
-            print(f"  SKIP  {fid} ({f['feature_class_name']}): legacyImport project")
-            continue
+        name = f["feature_class_name"]
+        n_ids = len(f["stable_ids"])
+        try:
+            if args.skip_legacy_projects and f["project_sources"] == "legacyImport":
+                skipped.append((f, "legacyImport project"))
+                print(f"  SKIP  {fid} ({name}): legacyImport project")
+                geo_conn.rollback()
+                continue
 
-        geo.execute(AMOUNTS_EXIST_SQL, {"feature_id": fid})
-        if geo.fetchone():
-            skipped.append((f, "amounts already present"))
-            print(f"  SKIP  {fid} ({f['feature_class_name']}): amounts already present")
-            continue
+            geo.execute(AMOUNTS_EXIST_SQL, {"feature_id": fid})
+            if geo.fetchone():
+                skipped.append((f, "amounts already present"))
+                print(f"  SKIP  {fid} ({name}): amounts already present")
+                geo_conn.rollback()
+                continue
 
-        geo.execute(COMPUTE_INSERT_SQL, {
-            "project_id": str(f["project_id"]),
-            "feature_id": fid,
-            "stable_ids": f["stable_ids"],
-        })
-        n = geo.rowcount
-        if n == 0:
-            skipped.append((f, "0 PU rows (no geometry/PU overlap)"))
-            print(f"  WARN  {fid} ({f['feature_class_name']}): computed 0 PU rows "
-                  f"(no overlap?) [{len(f['stable_ids'])} stable ids]")
-            continue
-        computed += 1
-        print(f"  OK    {fid} ({f['feature_class_name']}): inserted {n} PU amount row(s) "
-              f"[{len(f['stable_ids'])} stable ids]")
+            if args.max_stable_ids and n_ids > args.max_stable_ids:
+                skipped.append((f, f"too large ({n_ids} > {args.max_stable_ids})"))
+                print(f"  SKIP  {fid} ({name}): {n_ids} stable ids "
+                      f"> --max-stable-ids {args.max_stable_ids}; ST_Union infeasible, "
+                      f"deferred to MRXNM-99")
+                geo_conn.rollback()
+                continue
+
+            geo.execute(COMPUTE_INSERT_SQL, {
+                "project_id": str(f["project_id"]),
+                "feature_id": fid,
+                "stable_ids": f["stable_ids"],
+            })
+            n = geo.rowcount
+            if n == 0:
+                skipped.append((f, "0 PU rows (no geometry/PU overlap)"))
+                print(f"  WARN  {fid} ({name}): computed 0 PU rows (no overlap?) "
+                      f"[{n_ids} stable ids]")
+                geo_conn.rollback()
+                continue
+
+            if dry_run:
+                geo_conn.rollback()
+            else:
+                geo_conn.commit()
+            computed += 1
+            print(f"  OK    {fid} ({name}): "
+                  f"{'would insert' if dry_run else 'inserted'} {n} PU amount row(s) "
+                  f"[{n_ids} stable ids]")
+
+        except psycopg2.errors.QueryCanceled:
+            geo_conn.rollback()
+            failed.append((f, f"statement timeout (> {args.statement_timeout}s)"))
+            print(f"  FAIL  {fid} ({name}): statement timeout after "
+                  f"{args.statement_timeout}s [{n_ids} stable ids]; deferred to MRXNM-99")
+        except psycopg2.Error as e:
+            geo_conn.rollback()
+            msg = str(e).strip().splitlines()[0] if str(e).strip() else type(e).__name__
+            failed.append((f, msg))
+            print(f"  FAIL  {fid} ({name}): {msg[:120]} [{n_ids} stable ids]")
 
     print(f"\n[amounts] summary: {computed} computed, {len(skipped)} skipped, "
-          f"{len(targets)} candidates")
+          f"{len(failed)} failed, {len(targets)} candidates "
+          f"({'DRY-RUN — nothing committed' if dry_run else 'committed per feature'})")
+    if failed:
+        print("[amounts] failed/timed-out feature(s) (see MRXNM-99):")
+        for f, why in failed:
+            print(f"  {f['id']}  {f['feature_class_name']}  -- {why}")
 
-    if dry_run:
-        geo_conn.rollback()
-        print("[amounts] DRY-RUN — rolled back. Re-run with --apply to commit.")
-    else:
-        geo_conn.commit()
-        print(f"[amounts] APPLIED — committed amounts for {computed} feature(s).")
     api_conn.rollback()  # read-only
-
     api.close(); geo.close(); api_conn.close(); geo_conn.close()
     return 0
 


### PR DESCRIPTION
Follow-up to #1749 (merged). Adds `data/scripts/feature-split-backport/backfill_split_feature_amounts.py` — phase 2 of legacy split restoration.

## What
Recomputes `feature_amounts_per_planning_unit` for legacy split features that have geometry (`feature_data_stable_ids`, after the phase-1 backport) but never had per-PU amounts materialized — so they stay blank in the scenario abundance view (`forProject=true` tile path). Mirrors `ComputeArea.computeAreaPerPlanningUnitOfFeature` / `FeatureAmountsPerPlanningUnitService.computeMarxanAmountPerPlanningUnit` exactly.

## Safety
Scoped to the relevant splits only: `operation='split'` AND non-empty `stable_ids` AND no existing amounts. Each compute is per-feature (its own stable_ids + its own project's PUs) so it can never write amounts for another feature. Dry-run default, idempotent.

## Prod buckets (639 splits)
- 422 reconstructable + has amounts → phase-1 backport alone
- 41 reconstructable, no amounts (live scenarios) → **this script**
- 176 broken/dead → delete (data cleanup)

## Validation (staging, 2026-06-19)
Phase-1 relinked the Spain split (5485 ids); this script's dry-run computed its amounts (2 PU rows); a fresh UI split on Rwanda rendered correctly (geometry + amounts). README documents the two-phase Nectar runbook.