### PR TITLE
fix(app): hide platform transition modal on report routes [MRXNM-98]

### DIFF
--- a/app/e2e/platform-transition.spec.ts
+++ b/app/e2e/platform-transition.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+import { isReportRoute } from '../layout/platform-transition/utils';
+
 const MODAL_TITLE = 'Important Platform Transition Notice';
 const COOKIE_NAME = 'platform-transition';
 
@@ -82,4 +84,38 @@ test.describe('Platform transition modal', () => {
     const cookie = (await context.cookies()).find((c) => c.name === COOKIE_NAME);
     expect(cookie?.value).toBe('true');
   });
+});
+
+test.describe('Platform transition modal — route suppression', () => {
+  const reportRoutes = [
+    '/reports/[pid]/[sid]/blm',
+    '/reports/[pid]/[sid]/solutions',
+    '/reports/[pid]/[sid]/frequency',
+    '/reports/[pid]/[sid]/compare/[sid2]/comparison-map',
+  ];
+
+  // The modal must still show while the user navigates the interface, for both
+  // registered and anonymous users (anonymous report routes redirect here).
+  const interfaceRoutes = [
+    '/',
+    '/about',
+    '/projects',
+    '/projects/[pid]',
+    '/projects/[pid]/scenarios/[sid]/edit',
+    '/community',
+    '/admin',
+    '/auth/sign-in',
+  ];
+
+  for (const route of reportRoutes) {
+    test(`suppressed on report route ${route}`, () => {
+      expect(isReportRoute(route)).toBe(true);
+    });
+  }
+
+  for (const route of interfaceRoutes) {
+    test(`shown on interface route ${route}`, () => {
+      expect(isReportRoute(route)).toBe(false);
+    });
+  }
 });

--- a/app/layout/platform-transition/index.tsx
+++ b/app/layout/platform-transition/index.tsx
@@ -2,17 +2,21 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { useCookies } from 'react-cookie';
 
+import { useRouter } from 'next/router';
+
 import { useFeatureFlags } from 'hooks/feature-flags';
 
 import Modal from 'components/modal';
 
 import PlatformTransitionContent from './content';
+import { isReportRoute } from './utils';
 
 const COOKIE_NAME = 'platform-transition';
 const COOKIE_EXPIRY = new Date('2026-12-31T23:59:59Z');
 const MODAL_TITLE = 'Important Platform Transition Notice';
 
 export const PlatformTransitionModal = (): JSX.Element | null => {
+  const { pathname } = useRouter();
   const [cookies, setCookie] = useCookies([COOKIE_NAME]);
   const { platformTransition } = useFeatureFlags();
 
@@ -35,6 +39,7 @@ export const PlatformTransitionModal = (): JSX.Element | null => {
     setOpen(false);
   }, [dontShowAgain, setCookie]);
 
+  if (isReportRoute(pathname)) return null;
   if (!platformTransition) return null;
   if (persistedDismissal) return null;
   if (!mounted) return null;

--- a/app/layout/platform-transition/utils.ts
+++ b/app/layout/platform-transition/utils.ts
@@ -1,0 +1,3 @@
+export const REPORT_ROUTE_REGEX = /^\/reports(\/|$)/;
+
+export const isReportRoute = (pathname: string): boolean => REPORT_ROUTE_REGEX.test(pathname);


### PR DESCRIPTION
## Description

The platform transition modal ("Important Platform Transition Notice") was mounted unconditionally at the app root (`app/pages/_app.tsx`), so it rendered on **every** route. The webshot service produces BLM-calibration thumbnails and exported report PDFs/PNGs by headlessly rendering the pages under `app/pages/reports/[pid]/[sid]/*` and screenshotting them, so the global modal leaked into those captures.

This suppresses the modal on any `/reports/*` route via a small pure helper (`isReportRoute`), leaving it visible on every navigable route for both registered and anonymous users. The feature-flag, cookie and dismissal behaviour is unchanged.

**Changes**
- `app/layout/platform-transition/utils.ts` (new) — pure, testable `isReportRoute(pathname)` (`/^\/reports(\/|$)/`).
- `app/layout/platform-transition/index.tsx` — reads `useRouter().pathname` and returns `null` on report routes (first early-return, alongside the existing flag/cookie/mount/open guards).
- `app/e2e/platform-transition.spec.ts` — regression tests locking the route contract (4 report routes suppressed, 8 interface routes shown).

> Note on base branch: targeting `staging` rather than `develop`. The platform-transition modal (added in `[MRXNM-85]`) exists on `staging`/`main` but **not** on `develop` (which is ~95 commits behind), so the fix can only apply against `staging`. Sibling work (`[MRXNM-86]`, `[MRXNM-87]`) followed the same pattern. Happy to retarget if preferred.

## Jira story

https://vizzuality.atlassian.net/browse/MRXNM-98

### Designs

_N/A_

### Testing instructions

Requires the `platformTransition` feature flag enabled.

1. **Reports stay clean:** Open a project/scenario and run a BLM calibration (or export a report). The generated calibration thumbnails / report PDFs/PNGs must **not** contain the transition modal. Equivalent: load any `/reports/[pid]/[sid]/blm|solutions|frequency` or `/reports/[pid]/[sid]/compare/[sid2]/comparison-map` page — no modal.
2. **Interface still shows it:** Navigate the app (landing, `/projects`, scenario editor, etc.) as both a registered and an anonymous user — the modal still appears (unless dismissed via "Don't show me this again").
3. **Automated:** `cd app && yarn e2e` runs the route-suppression specs in `e2e/platform-transition.spec.ts`.

## Checklist before submitting

- [x] Meaningful commits.
- [x] Update CHANGELOG file — _no CHANGELOG file exists in the repo._

[MRXNM-85]: https://vizzuality.atlassian.net/browse/MRXNM-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ