### PR TITLE
fix(app): show/hide split feature layers via the eye toggle [MRXNM-82]

### DIFF
--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -246,18 +246,23 @@ const TargetAndSPFFeatures = (): JSX.Element => {
         selectedFeature.amountRange.min !== null && selectedFeature.amountRange.max !== null;
       const { splitted } = selectedFeature;
 
-      if (isContinuous) {
+      // Only genuine, non-split continuous features use the gradient renderer
+      // (useContinuousFeaturesLayers). Materialized split children are drawn as
+      // solid-color layers via their own child tiles (useTargetedPreviewLayers).
+      // Routing a split child through this branch would (a) stamp an `amountRange`
+      // into layerSettings that excludes it from useTargetedPreviewLayers, and
+      // (b) never add it to `selectedContinuousFeatures` (so the gradient renderer
+      // ignores it too) — leaving it rendered nowhere and the eye stuck on.
+      if (isContinuous && !splitted) {
         const newSelectedFeatures = [...selectedContinuousFeatures];
         const isIncluded = newSelectedFeatures.includes(id);
 
-        if (!splitted) {
-          if (!isIncluded) {
-            newSelectedFeatures.push(id);
-          } else {
-            newSelectedFeatures.splice(newSelectedFeatures.indexOf(id), 1);
-          }
-          dispatch(setSelectedContinuousFeatures(newSelectedFeatures));
+        if (!isIncluded) {
+          newSelectedFeatures.push(id);
+        } else {
+          newSelectedFeatures.splice(newSelectedFeatures.indexOf(id), 1);
         }
+        dispatch(setSelectedContinuousFeatures(newSelectedFeatures));
 
         dispatch(
           setLayerSettings({


### PR DESCRIPTION
## Problem

In the Scenario Edit feature list, clicking the **eye** on a **split feature layer** does nothing on the map, and a second click leaves the eye stuck highlighted (it never toggles off). Reported from a staging test (22 Jun, Rwanda scenario).

## Root cause

A split child inherits its parent's `amountRange` (`splitFeature.amountRange ?? feature.amountRange`), so `isContinuous` is `true` for essentially every split child of a feature that has amounts. In `toggleSeeOnMap` it was therefore routed into the **continuous/gradient branch**, where an `if (!splitted)` guard skipped adding it to `selectedContinuousFeatures` while still stamping `amountRange` into `layerSettings`.

That orphaned the split child between the two map renderers:

- `useTargetedPreviewLayers` (the hook that draws split tiles via `childFeatureId`) **excludes** anything with `amountRange` in `layerSettings`:
  `Object.keys(layerSettings).includes(ft.id) && !layerSettings[ft.id]?.amountRange`.
- `useContinuousFeaturesLayers` only iterates `selectedContinuousFeatures`, which the guard never populated (and it builds tile URLs from the synthetic `${parentId}-${value}` id anyway).

So it rendered **nowhere** → *layer never appears*. And `isIncluded` (read from `selectedContinuousFeatures`) stayed `false`, so `visibility: !isIncluded` was **always `true`** → *eye stuck highlighted*.

## Fix

Gate the continuous branch on `isContinuous && !splitted`. Only genuine non-split continuous features use the gradient renderer; split children fall through to the discrete `selectedFeatures` toggle, which flips `visibility` correctly and writes **no** `amountRange` — letting `useTargetedPreviewLayers` draw them via their materialized `childFeatureId` tiles. The now-redundant inner `if (!splitted)` is removed.

Frontend-only; no backend change needed (the geoprocessing `childFeatureId`/`stable_id` tile path is already on `staging`).

## Testing

- [ ] On staging, toggle a continuous split child (e.g. Rwanda scenario): layer shows on first click, hides on second, eye state tracks correctly.
- [ ] Verify non-split continuous features still render their gradient unchanged.
