### PR TITLE
fix(geoprocessing): bind split-feature stable ids as a query parameter [MRXNM-97]

### DIFF
--- a/api/apps/geoprocessing/src/modules/features/features.service.spec.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.spec.ts
@@ -42,13 +42,17 @@ describe(`${FeatureService.name}.buildFeaturesWhereQuery`, () => {
       '22222222-2222-2222-2222-222222222222',
     ];
 
-    const where = await buildService({
+    const { where, parameters } = await buildService({
       stableIds,
     }).service.buildFeaturesWhereQuery(splitFeatureId, false);
 
-    expect(where).toBe(
-      `stable_id = ANY(ARRAY['${stableIds[0]}', '${stableIds[1]}']::uuid[])`,
-    );
+    // The ids are bound as a single array parameter, not inlined as literals,
+    // so the SQL text stays small regardless of how many ids a split has
+    // [MRXNM-97].
+    expect(where).toBe('stable_id = ANY(:splitFeatureStableIds::uuid[])');
+    expect(parameters).toEqual({ splitFeatureStableIds: stableIds });
+    expect(where).not.toContain(stableIds[0]);
+    expect(where).not.toContain('ARRAY[');
   });
 
   it('filters by feature_id (and never looks up stable ids) on the project amounts path', async () => {
@@ -59,27 +63,32 @@ describe(`${FeatureService.name}.buildFeaturesWhereQuery`, () => {
       stableIds: ['33333333-3333-3333-3333-333333333333'],
     });
 
-    const where = await service.buildFeaturesWhereQuery(featureId, true);
+    const { where, parameters } = await service.buildFeaturesWhereQuery(
+      featureId,
+      true,
+    );
 
     expect(where).toBe(`feature_id = '${featureId}'`);
     expect(where).not.toContain('stable_id');
+    expect(parameters).toBeUndefined();
     expect(createQueryBuilder).not.toHaveBeenCalled();
   });
 
   it('falls back to feature_id for a plain/legacy feature with no stable ids', async () => {
     const featureId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
-    const where = await buildService({
+    const { where, parameters } = await buildService({
       stableIds: null,
     }).service.buildFeaturesWhereQuery(featureId, false);
 
     expect(where).toBe(`feature_id = '${featureId}'`);
+    expect(parameters).toBeUndefined();
   });
 
   it('appends the bbox envelope filter to a split feature query', async () => {
     const stableIds = ['44444444-4444-4444-4444-444444444444'];
 
-    const where = await buildService({
+    const { where, parameters } = await buildService({
       stableIds,
     }).service.buildFeaturesWhereQuery(
       'dddddddd-dddd-dddd-dddd-dddddddddddd',
@@ -87,9 +96,8 @@ describe(`${FeatureService.name}.buildFeaturesWhereQuery`, () => {
       [-1, 40, 1, 42],
     );
 
-    expect(where).toContain(
-      `stable_id = ANY(ARRAY['${stableIds[0]}']::uuid[])`,
-    );
+    expect(where).toContain('stable_id = ANY(:splitFeatureStableIds::uuid[])');
+    expect(parameters).toEqual({ splitFeatureStableIds: stableIds });
     expect(where).toContain('AND');
     expect(where).toContain('st_intersects');
     expect(where).toContain('the_geom');

--- a/api/apps/geoprocessing/src/modules/features/features.service.ts
+++ b/api/apps/geoprocessing/src/modules/features/features.service.ts
@@ -51,7 +51,7 @@ export class FeatureService {
     id: string,
     forProject: boolean,
     bbox?: BBox,
-  ): Promise<string> {
+  ): Promise<{ where: string; parameters?: Record<string, unknown> }> {
     /**
      * Materialized split features own no `features_data` rows of their own:
      * their geometries are a subset of the *parent* feature's rows, linked via
@@ -76,12 +76,21 @@ export class FeatureService {
           .execute()
           .then((result) => result?.[0]?.feature_data_stable_ids ?? null);
 
-    let whereQuery =
-      featureDataStableIds && featureDataStableIds.length > 0
-        ? `stable_id = ANY(ARRAY[${featureDataStableIds
-            .map((stableId) => `'${stableId}'`)
-            .join(', ')}]::uuid[])`
-        : `feature_id = '${id}'`;
+    /**
+     * Bind the stable ids as a single array parameter rather than inlining them
+     * as SQL literals. A split of a large/global parent can carry tens of
+     * thousands of ids (≈59k seen in production); inlining them builds multi-MB
+     * of SQL text that is re-parsed on every `{z}/{x}/{y}` tile request. As a
+     * bound parameter the SQL text stays tiny and the plan is cached [MRXNM-97].
+     */
+    let whereQuery: string;
+    let parameters: Record<string, unknown> | undefined;
+    if (featureDataStableIds && featureDataStableIds.length > 0) {
+      whereQuery = `stable_id = ANY(:splitFeatureStableIds::uuid[])`;
+      parameters = { splitFeatureStableIds: featureDataStableIds };
+    } else {
+      whereQuery = `feature_id = '${id}'`;
+    }
 
     if (bbox) {
       const { westBbox, eastBbox } = antimeridianBbox(nominatim2bbox(bbox));
@@ -97,7 +106,7 @@ export class FeatureService {
       ))`;
     }
 
-    return whereQuery;
+    return { where: whereQuery, parameters };
   }
 
   /**
@@ -127,17 +136,15 @@ export class FeatureService {
                  stable_id
                  from "${this.featuresRepository.metadata.tableName}")`;
 
-    const customQuery = await this.buildFeaturesWhereQuery(
-      id,
-      forProject,
-      bbox,
-    );
+    const { where: customQuery, parameters: customQueryParameters } =
+      await this.buildFeaturesWhereQuery(id, forProject, bbox);
     return this.tileService.getTile({
       z,
       x,
       y,
       table,
       customQuery,
+      customQueryParameters,
       attributes,
     });
   }

--- a/api/apps/geoprocessing/src/modules/tile/tile.service.ts
+++ b/api/apps/geoprocessing/src/modules/tile/tile.service.ts
@@ -37,6 +37,12 @@ export interface TileInput<T> extends TileRequest {
    * @description Custom query for the different entities
    */
   customQuery?: T | undefined;
+  /**
+   * @description Bound parameters for `customQuery`. Lets callers pass values
+   * (e.g. large id arrays) as query parameters instead of inlining them as SQL
+   * literals, so the generated SQL text stays small and is plan-cached.
+   */
+  customQueryParameters?: Record<string, unknown>;
 
   /**
    * @description Input projection, by default 4326
@@ -97,6 +103,7 @@ export class TileService {
     extent = 4096,
     buffer = 256,
     customQuery = undefined,
+    customQueryParameters = undefined,
     inputProjection = 4326,
     attributes,
   }: TileInput<string>): Promise<Record<'mvt', Buffer>[]> {
@@ -119,7 +126,7 @@ export class TileService {
             { z, x, y },
           );
         if (customQuery) {
-          subQuery.andWhere(customQuery);
+          subQuery.andWhere(customQuery, customQueryParameters);
         }
         return subQuery;
       }, 'tile');


### PR DESCRIPTION
## Problem

Materialized split features render their geometry by selecting the parent's `features_data` rows via the stable ids stored in `(apidb)features.feature_data_stable_ids`. `FeatureService.buildFeaturesWhereQuery` inlined every id as a SQL literal:

```sql
stable_id = ANY(ARRAY['<uuid>', '<uuid>', … ]::uuid[])
```

A split of a large/global parent carries tens of thousands of ids — **production has splits up to 58,820 ids** (the `world_ecosystems_simp` set). At ~37 chars/uuid that is **~2 MB of SQL text per tile**, rebuilt and re-parsed on every `{z}/{x}/{y}` request (many per map view). This does not scale and degrades tile latency badly for those features. (Follow-up to MRXNM-82; deliberately deferred so the first split increment could ship — small/medium splits render fine today.)

## Fix

Bind the ids as a **single array parameter** instead of inlining them:

```sql
stable_id = ANY(:splitFeatureStableIds::uuid[])
```

- `FeatureService.buildFeaturesWhereQuery` now returns `{ where, parameters? }`; the split path carries the id array in `parameters`.
- `TileService` gains an optional `customQueryParameters` that is threaded into `andWhere(customQuery, customQueryParameters)`. **Backward compatible** — every existing caller passes nothing, so `andWhere(str, undefined)` behaves exactly as before (PA/PU/cost tiles unaffected).

The generated SQL text stays tiny regardless of array size, and the plan is cached.

## Why `= ANY(array param)` and not an expanded `IN` list

TypeORM's `IN (:...ids)` spread expands to `IN ($1, $2, … $n)`, which hits the Postgres **65,535-parameters-per-query** wire-protocol cap. Our largest split (58,820) is uncomfortably close; a ~66k split would break it. Binding the whole array as one parameter sidesteps that entirely — the element count is bounded only by ~2 GB/param and ~268M elements/array, ~3–4 orders of magnitude beyond any real split.

## Verification

- **Unit tests** (`features.service.spec.ts`) updated: assert the placeholder + bound array and the *absence* of inline literals (encodes the perf invariant). All green.
- **DB equivalence** (prod geo DB): parameterized vs inline predicate return identical row counts — 58,820 for the largest split.
- **TypeORM binding** (live geo DB): `getQueryAndParameters()` emits `… AND stable_id = ANY($4::uuid[])` — the array binds as a **single** positional parameter, not expanded.
- **No element ceiling**: parameterized `ANY($1::uuid[])` executes fine with 70,000 and 200,000 elements (past the 65,535 cap).

### Recommended before merge
A geoprocessing integration/e2e that renders a real split tile end-to-end through `TileService` (there is no existing e2e for split-feature tiles) to confirm the array binding through the full NestJS path.
