### PR TITLE
perf(geoprocessing/cloning): make scenario-features-data import lookup sargable [MRXNM-95]

### DIFF
--- a/api/apps/geoprocessing/src/import/pieces-importers/scenario-features-data.piece-importer.ts
+++ b/api/apps/geoprocessing/src/import/pieces-importers/scenario-features-data.piece-importer.ts
@@ -9,7 +9,6 @@ import { OutputScenariosFeaturesDataGeoEntity } from '@marxan/marxan-output';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { isLeft } from 'fp-ts/lib/Either';
-import { chunk } from 'lodash';
 import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import { parser } from 'stream-json';
@@ -34,7 +33,8 @@ type FeatureDataIdByFeatureIdAndHashMap = Record<string, string>;
 
 type FeatureDataSelectResult = {
   featureDataId: string;
-  featureIdAndHash: string;
+  featureId: string;
+  hash: string;
 };
 
 type FeatureSelectResult = {
@@ -60,6 +60,16 @@ export class ScenarioFeaturesDataPieceImporter implements ImportPieceProcessor {
   // Default to the prod chunk size; overridable in tests to exercise the
   // multi-batch streaming path with small fixtures. See MRXNM-94.
   private batchSize: number = CHUNK_SIZE_FOR_BATCH_GEODB_OPERATIONS;
+
+  // The geo features_data table name is invariant; resolve it once (lazily, so
+  // it never races entity-metadata initialisation at construction time).
+  private cachedFeaturesDataTable?: string;
+  private get featuresDataTable(): string {
+    return (this.cachedFeaturesDataTable ??=
+      this.geoEntityManager.getRepository(
+        GeoFeatureGeometry,
+      ).metadata.tableName);
+  }
 
   constructor(
     private readonly fileRepository: CloningFilesRepository,
@@ -153,40 +163,43 @@ export class ScenarioFeaturesDataPieceImporter implements ImportPieceProcessor {
     platformFeaturesMap: FeatureIdByClassNameMap,
     featureDataIdByFeatureIdAndHash: FeatureDataIdByFeatureIdAndHashMap,
   ): Promise<void> {
-    const missing = new Set<string>();
+    const missing = new Map<string, { featureId: string; hash: string }>();
     for (const element of batch) {
       const { isCustom, featureClassName } = element.featureDataFeature;
       const featureId = isCustom
         ? customFeaturesMap[featureClassName]
         : platformFeaturesMap[featureClassName];
       const key = `${featureId}/${element.featureDataHash}`;
-      if (featureDataIdByFeatureIdAndHash[key] === undefined) missing.add(key);
+      // Map.set is idempotent for an already-present key, so the cross-batch
+      // cache check alone is enough to dedup within the batch too.
+      if (featureDataIdByFeatureIdAndHash[key] === undefined)
+        missing.set(key, { featureId, hash: element.featureDataHash });
     }
 
     if (missing.size === 0) return;
 
-    const idAndHashesChunks = chunk(
-      Array.from(missing),
-      CHUNK_SIZE_FOR_BATCH_GEODB_OPERATIONS,
+    const pairs = Array.from(missing.values());
+    const featureIds = pairs.map((p) => p.featureId);
+    const hashes = pairs.map((p) => p.hash);
+
+    // Match on the raw (feature_id, hash) columns via an unnest-paired-array
+    // join so the planner can use the unique_feature_data_per_project
+    // (hash, feature_id) index. The previous `feature_id || '/' || hash IN (...)`
+    // predicate was non-sargable: Postgres had to compute the concatenation for
+    // every row of the ~30M-row features_data table, forcing an IO-bound seq
+    // scan on every batch. Passing the keys as two arrays also avoids the
+    // bind-parameter explosion of a large IN list. See MRXNM-95.
+    const rows: FeatureDataSelectResult[] = await this.geoEntityManager.query(
+      `SELECT fd.id AS "featureDataId", fd.feature_id AS "featureId", fd.hash AS "hash"
+       FROM "${this.featuresDataTable}" fd
+       JOIN unnest($1::uuid[], $2::text[]) AS k(feature_id, hash)
+         ON fd.feature_id = k.feature_id AND fd.hash = k.hash`,
+      [featureIds, hashes],
     );
-    const records = await Promise.all(
-      idAndHashesChunks.map((idAndHashes) =>
-        this.geoEntityManager
-          .createQueryBuilder()
-          .select('id', 'featureDataId')
-          .addSelect(`feature_id || '/' || hash`, 'featureIdAndHash')
-          .from(GeoFeatureGeometry, 'fd')
-          .where(`feature_id || '/' || hash IN (:...idAndHashes)`, {
-            idAndHashes,
-          })
-          .execute(),
-      ),
-    );
-    (records.flat() as FeatureDataSelectResult[]).forEach(
-      ({ featureDataId, featureIdAndHash }) => {
-        featureDataIdByFeatureIdAndHash[featureIdAndHash] = featureDataId;
-      },
-    );
+
+    rows.forEach(({ featureDataId, featureId, hash }) => {
+      featureDataIdByFeatureIdAndHash[`${featureId}/${hash}`] = featureDataId;
+    });
   }
 
   private getScenarioFeaturesDataInsertValues(


### PR DESCRIPTION
## What & why

Follow-up to MRXNM-94. After the importer was streamed (MRXNM-94 killed the OOM), the large-scenario clone import became **slow** — a single open transaction for 13+ min, per-batch feature-data lookups running 3–10s each (`wait_event_type=IO`) against the ~30M-row `features_data` table, ~1,140 batches.

**Root cause:** the per-batch lookup filtered on a computed string:

```sql
WHERE feature_id || '/' || hash IN (:...idAndHashes)
```

The concatenation is **non-sargable** — Postgres can't use `unique_feature_data_per_project (hash, feature_id)` (or `features_data_feature_id`), so it computes the concat for every row of `features_data` and seq-scans on **every batch**.

## Change

`resolveFeatureDataIdsForBatch` now matches the **raw** `(feature_id, hash)` columns via an `unnest`-paired-array join, so the planner can use the existing unique index:

```sql
SELECT fd.id, fd.feature_id, fd.hash
FROM features_data fd
JOIN unnest($1::uuid[], $2::text[]) AS k(feature_id, hash)
  ON fd.feature_id = k.feature_id AND fd.hash = k.hash
```

- No schema change — the right index already exists.
- Passing keys as two array params also removes the per-batch IN-list chunking (`chunk` + `Promise.all` dropped).
- Output is **byte-identical**; the cross-batch cache key format (`${featureId}/${hash}`) is preserved.
- Table name resolved from entity metadata (no hard-coded literal), lazily cached.

## Verification

- ✅ `tsc` (project-wide) clean, `eslint` clean.
- ✅ geo e2e — `integration/cloning/piece-importers` (15 suites / 65 tests) green, run twice (incl. the multi-batch MRXNM-94 path; the 15-distinct-`(feature_id,hash)`-combo fixture would catch any array mispairing).
- ✅ Multi-angle code review — no correctness findings; 2 cleanup nits applied.
- ⏳ **Speedup at scale**: not provable locally (tiny table → planner correctly prefers seq scan). To be confirmed via `EXPLAIN ANALYZE` on the staging geo DB; expect Seq Scan → Index Scan and per-batch lookup seconds → ms.

Closes MRXNM-95.
