### PR TITLE
perf(geoprocessing/cloning): stream the scenario-features-data exporter [MRXNM-96]

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-data.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/scenario-features-data.piece-exporter.ts
@@ -6,7 +6,6 @@ import { ClonePieceRelativePathResolver } from '@marxan/cloning/infrastructure/c
 import {
   FeatureDataElement,
   OutputFeatureDataElement,
-  ScenarioFeaturesDataContent,
 } from '@marxan/cloning/infrastructure/clone-piece-data/scenario-features-data';
 import { ScenarioFeaturesData } from '@marxan/features';
 import { OutputScenariosFeaturesDataGeoEntity } from '@marxan/marxan-output';
@@ -71,48 +70,30 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
   }
 
   async run(input: ExportJobInput): Promise<ExportJobOutput> {
-    /**
-     * Memory/CPU efficiency (MRXNM-21):
-     *
-     * Large scenarios produce ~1.14M scenario_features_data rows
-     * (14.5k planning units x 79 features). The previous implementation:
-     *   1. Hydrated every row as a TypeORM entity with its `featureData`
-     *      relation (a heavy object graph kept fully in memory).
-     *   2. Ran a nested `.filter(...)` over the output rows for EACH sfd row,
-     *      i.e. O(N x M) ~= 1.14M x 7.9k comparisons (a CPU + GC bomb).
-     *   3. Built several full-size intermediate arrays simultaneously.
-     * All three caused the exporter to OOM.
-     *
-     * This rewrite instead:
-     *   - Reads plain rows via `.getRawMany()` (no entity hydration).
-     *   - Indexes the output rows once into a Map for O(1) lookups.
-     *   - Produces the final `featuresData` array in a single pass.
-     * The output file shape (`ScenarioFeaturesDataContent`) is unchanged so
-     * the importer keeps working as-is.
-     */
-    const rows: ScenarioFeaturesDataRawRow[] =
-      await this.geoprocessingEntityManager
-        .createQueryBuilder(ScenarioFeaturesData, 'sfd')
-        .innerJoin('sfd.featureData', 'fd')
-        .select('sfd.id', 'sfdId')
-        .addSelect('sfd.apiFeatureId', 'apiFeatureId')
-        .addSelect('sfd.featureId', 'featureId') // integer marxan feature id
-        .addSelect('sfd.currentArea', 'currentArea')
-        .addSelect('sfd.totalArea', 'totalArea')
-        .addSelect('sfd.fpf', 'fpf')
-        .addSelect('sfd.metadata', 'metadata')
-        .addSelect('sfd.prop', 'prop')
-        .addSelect('sfd.sepNum', 'sepNum')
-        .addSelect('sfd.target2', 'target2')
-        .addSelect('sfd.target', 'target')
-        .addSelect('sfd.targetocc', 'targetocc')
-        .addSelect('fd.featureId', 'featureDataFeatureId') // uuid (features.id)
-        .addSelect('fd.hash', 'featureDataHash')
-        .where('sfd.scenarioId = :scenarioId', { scenarioId: input.resourceId })
-        // Replicates the old `.filter((sfd) => sfd.featureData.featureId)`
-        .andWhere('fd.featureId IS NOT NULL')
-        .getRawMany();
+    const scenarioId = input.resourceId;
 
+    /**
+     * Memory efficiency (MRXNM-21 -> MRXNM-96):
+     *
+     * Large scenarios produce ~1.14M scenario_features_data rows (14.5k PUs x
+     * 79 features). MRXNM-21 already removed the entity hydration and the
+     * O(N x M) nested filter (raw rows + a Map). But it still materialised
+     * every raw row, the full transformed `featuresData` array AND the whole
+     * `JSON.stringify` string at once -> ~4.2GB peak, near the 5Gi limit.
+     *
+     * This rewrite streams the big side: the scenario_features_data rows are
+     * pulled from a server-side cursor and transformed + written to the output
+     * file one at a time (see `streamFeaturesDataFileContent`), so the full
+     * array / JSON string is never resident. The two remaining in-memory
+     * lookups are provably small and do NOT scale with scenario size:
+     *   - output rows: bounded by (scenario features x runs), NOT PU x feature
+     *     (measured max ~1.5k rows/scenario on staging).
+     *   - feature properties: one row per distinct feature (tens).
+     * The output file shape (`ScenarioFeaturesDataContent`) is byte-identical
+     * so the (streamed, MRXNM-94) importer keeps working as-is.
+     */
+
+    // Small lookup #1: output rows indexed by scenario_features_id.
     const outputScenariosFeaturesData: OutputScenarioFeaturesDataSelectResult[] =
       await this.geoprocessingEntityManager
         .createQueryBuilder()
@@ -130,12 +111,9 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
           'osfd',
           'sfd.id = osfd.scenario_features_id',
         )
-        .where('sfd.scenario_id = :scenarioId', {
-          scenarioId: input.resourceId,
-        })
+        .where('sfd.scenario_id = :scenarioId', { scenarioId })
         .execute();
 
-    // Index output rows by scenarioFeaturesId once -> O(1) lookups per sfd row.
     const outputDataBySfdId = new Map<string, OutputFeatureDataElement[]>();
     for (const {
       scenarioFeaturesId,
@@ -149,77 +127,13 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
       }
     }
 
-    const featuresIds = [
-      ...new Set<string>(
-        rows.flatMap((row) => [row.apiFeatureId, row.featureDataFeatureId]),
-      ),
-    ];
+    // Small lookup #2: properties for every feature the scenario references.
+    const featurePropertiesById =
+      await this.getFeaturePropertiesById(scenarioId);
 
-    let features: FeaturesSelectResult[] = [];
-
-    if (featuresIds.length > 0) {
-      features = await this.apiEntityManager
-        .createQueryBuilder()
-        .select('id, feature_class_name, is_custom')
-        .from('features', 'f')
-        .where('id IN (:...featuresIds)', {
-          featuresIds,
-        })
-        .execute();
-    }
-
-    const featurePropertiesById: Record<
-      string,
-      Omit<FeaturesSelectResult, 'id'>
-    > = {};
-    features.forEach(({ id, feature_class_name, is_custom }) => {
-      featurePropertiesById[id] = { feature_class_name, is_custom };
-    });
-
-    const featuresData: FeatureDataElement[] = rows.map((row) => {
-      const apiFeatureProperties = featurePropertiesById[row.apiFeatureId];
-      const featureDataFeatureProperties =
-        featurePropertiesById[row.featureDataFeatureId];
-
-      if (!apiFeatureProperties)
-        throw new Error(
-          `Feature properties not found for feature with id ${row.apiFeatureId}`,
-        );
-
-      if (!featureDataFeatureProperties)
-        throw new Error(
-          `Feature properties not found for feature with id ${row.featureDataFeatureId}`,
-        );
-
-      return {
-        currentArea: row.currentArea,
-        featureDataHash: row.featureDataHash,
-        featureId: row.featureId,
-        specificationId: undefined,
-        totalArea: row.totalArea,
-        fpf: row.fpf,
-        metadata: row.metadata,
-        prop: row.prop,
-        sepNum: row.sepNum,
-        target2: row.target2,
-        target: row.target,
-        targetocc: row.targetocc,
-        apiFeature: {
-          isCustom: apiFeatureProperties.is_custom,
-          featureClassName: apiFeatureProperties.feature_class_name ?? '',
-        },
-        featureDataFeature: {
-          isCustom: featureDataFeatureProperties.is_custom,
-          featureClassName:
-            featureDataFeatureProperties.feature_class_name ?? '',
-        },
-        outputFeaturesData: outputDataBySfdId.get(row.sfdId) ?? [],
-      };
-    });
-
-    const fileContent: ScenarioFeaturesDataContent = {
-      featuresData,
-    };
+    // Big side: stream the sfd rows from a cursor; transform + write per row.
+    const sfdRowStream =
+      await this.buildScenarioFeaturesDataQuery(scenarioId).stream();
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(
       ClonePiece.ScenarioFeaturesData,
@@ -231,7 +145,13 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
 
     const outputFile = await this.fileRepository.saveCloningFile(
       input.exportId,
-      Readable.from(JSON.stringify(fileContent)),
+      Readable.from(
+        this.streamFeaturesDataFileContent(
+          sfdRowStream,
+          outputDataBySfdId,
+          featurePropertiesById,
+        ),
+      ),
       relativePath,
     );
 
@@ -244,6 +164,161 @@ export class ScenarioFeaturesDataPieceExporter implements ExportPieceProcessor {
     return {
       ...input,
       uris: [new ComponentLocation(outputFile.right, relativePath)],
+    };
+  }
+
+  /**
+   * The scenario_features_data query whose rows become `featuresData` entries.
+   * Streamed (`.stream()`) by the caller so the 1.14M-row set is never buffered.
+   */
+  private buildScenarioFeaturesDataQuery(scenarioId: string) {
+    return (
+      this.geoprocessingEntityManager
+        .createQueryBuilder(ScenarioFeaturesData, 'sfd')
+        .innerJoin('sfd.featureData', 'fd')
+        .select('sfd.id', 'sfdId')
+        .addSelect('sfd.apiFeatureId', 'apiFeatureId')
+        .addSelect('sfd.featureId', 'featureId') // integer marxan feature id
+        .addSelect('sfd.currentArea', 'currentArea')
+        .addSelect('sfd.totalArea', 'totalArea')
+        .addSelect('sfd.fpf', 'fpf')
+        .addSelect('sfd.metadata', 'metadata')
+        .addSelect('sfd.prop', 'prop')
+        .addSelect('sfd.sepNum', 'sepNum')
+        .addSelect('sfd.target2', 'target2')
+        .addSelect('sfd.target', 'target')
+        .addSelect('sfd.targetocc', 'targetocc')
+        .addSelect('fd.featureId', 'featureDataFeatureId') // uuid (features.id)
+        .addSelect('fd.hash', 'featureDataHash')
+        .where('sfd.scenarioId = :scenarioId', { scenarioId })
+        // Replicates the old `.filter((sfd) => sfd.featureData.featureId)`
+        .andWhere('fd.featureId IS NOT NULL')
+    );
+  }
+
+  /**
+   * Resolves `feature_class_name`/`is_custom` for every feature referenced by
+   * the scenario. The ids are gathered with DISTINCT queries (server-side) so
+   * we never buffer the 1.14M-row set just to collect a handful of feature ids.
+   */
+  private async getFeaturePropertiesById(
+    scenarioId: string,
+  ): Promise<Record<string, Omit<FeaturesSelectResult, 'id'>>> {
+    const idRows: { id: string }[] = await Promise.all([
+      this.buildScenarioFeaturesDataQuery(scenarioId)
+        .select('sfd.apiFeatureId', 'id')
+        .distinct(true)
+        .getRawMany<{ id: string }>(),
+      this.buildScenarioFeaturesDataQuery(scenarioId)
+        .select('fd.featureId', 'id')
+        .distinct(true)
+        .getRawMany<{ id: string }>(),
+    ]).then(([apiFeatureIds, featureDataFeatureIds]) => [
+      ...apiFeatureIds,
+      ...featureDataFeatureIds,
+    ]);
+
+    const featuresIds = [...new Set(idRows.map((row) => row.id))];
+
+    let features: FeaturesSelectResult[] = [];
+    if (featuresIds.length > 0) {
+      features = await this.apiEntityManager
+        .createQueryBuilder()
+        .select('id, feature_class_name, is_custom')
+        .from('features', 'f')
+        .where('id IN (:...featuresIds)', { featuresIds })
+        .execute();
+    }
+
+    const featurePropertiesById: Record<
+      string,
+      Omit<FeaturesSelectResult, 'id'>
+    > = {};
+    features.forEach(({ id, feature_class_name, is_custom }) => {
+      featurePropertiesById[id] = { feature_class_name, is_custom };
+    });
+
+    // Fail fast: validate up front, before any streaming starts. The transform
+    // now runs lazily inside the file-write stream, where a thrown error would
+    // be swallowed by storeFile's try/catch (-> "couldn't save file") instead
+    // of surfacing as the original "Feature properties not found" error.
+    const missingId = featuresIds.find(
+      (id) => featurePropertiesById[id] === undefined,
+    );
+    if (missingId !== undefined)
+      throw new Error(
+        `Feature properties not found for feature with id ${missingId}`,
+      );
+
+    return featurePropertiesById;
+  }
+
+  /**
+   * Streams the `{ "featuresData": [...] }` file content. Each raw sfd row is
+   * transformed and serialised on its own, joined with commas, so the whole
+   * array / JSON string is never held in memory. Backpressure from the file
+   * write pauses the DB cursor; an empty stream yields `{"featuresData":[]}`.
+   */
+  private async *streamFeaturesDataFileContent(
+    rowStream: Readable,
+    outputDataBySfdId: Map<string, OutputFeatureDataElement[]>,
+    featurePropertiesById: Record<string, Omit<FeaturesSelectResult, 'id'>>,
+  ): AsyncGenerator<string> {
+    yield '{"featuresData":[';
+    let first = true;
+    for await (const row of rowStream as AsyncIterable<ScenarioFeaturesDataRawRow>) {
+      const element = this.toFeatureDataElement(
+        row,
+        outputDataBySfdId,
+        featurePropertiesById,
+      );
+      yield (first ? '' : ',') + JSON.stringify(element);
+      first = false;
+    }
+    yield ']}';
+  }
+
+  private toFeatureDataElement(
+    row: ScenarioFeaturesDataRawRow,
+    outputDataBySfdId: Map<string, OutputFeatureDataElement[]>,
+    featurePropertiesById: Record<string, Omit<FeaturesSelectResult, 'id'>>,
+  ): FeatureDataElement {
+    const apiFeatureProperties = featurePropertiesById[row.apiFeatureId];
+    const featureDataFeatureProperties =
+      featurePropertiesById[row.featureDataFeatureId];
+
+    if (!apiFeatureProperties)
+      throw new Error(
+        `Feature properties not found for feature with id ${row.apiFeatureId}`,
+      );
+
+    if (!featureDataFeatureProperties)
+      throw new Error(
+        `Feature properties not found for feature with id ${row.featureDataFeatureId}`,
+      );
+
+    return {
+      currentArea: row.currentArea,
+      featureDataHash: row.featureDataHash,
+      featureId: row.featureId,
+      specificationId: undefined,
+      totalArea: row.totalArea,
+      fpf: row.fpf,
+      metadata: row.metadata,
+      prop: row.prop,
+      sepNum: row.sepNum,
+      target2: row.target2,
+      target: row.target,
+      targetocc: row.targetocc,
+      apiFeature: {
+        isCustom: apiFeatureProperties.is_custom,
+        featureClassName: apiFeatureProperties.feature_class_name ?? '',
+      },
+      featureDataFeature: {
+        isCustom: featureDataFeatureProperties.is_custom,
+        featureClassName: featureDataFeatureProperties.feature_class_name ?? '',
+      },
+      outputFeaturesData: outputDataBySfdId.get(row.sfdId) ?? [],
     };
   }
 }


### PR DESCRIPTION
## What & why

Follow-up to MRXNM-94 (which streamed the importer; the exporter was deferred). The `scenario-features-data` exporter was the **largest remaining memory peak** in the clone export/import path — **~4177Mi against the 5Gi limit** on a large MaPP scenario (~940Mi headroom). On a larger scenario it's the next piece to OOM-kill the pod; the node is an 8GB VM so raising the limit isn't durable.

MRXNM-21 already removed the entity hydration and the O(N×M) nested filter, but the exporter still **materialised everything at once**: the full ~1.14M-row result set, the transformed `featuresData` array, and the whole `JSON.stringify` string.

## Change

Stream the big side:
- `scenario_features_data` rows are pulled from a **server-side cursor** (TypeORM `.stream()` / pg-query-stream) and transformed + written to the output file **one at a time** via an async generator. The full array / JSON string is never resident. Backpressure from the file write (`storeFile` uses `pipeline`) pauses the cursor.
- The two remaining in-memory lookups are provably small and **do not scale with scenario size**:
  - output rows — bounded by *(scenario features × runs)*, not PU×feature (**measured max ~1,500 rows/scenario on staging**, and the largest 92k-row scenario has 0);
  - feature properties — one row per distinct feature (tens), resolved via `DISTINCT` queries instead of scanning the whole result set.
- Output file shape (`ScenarioFeaturesDataContent`) is **byte-identical** (`{"featuresData":[…]}`), so the streamed importer (MRXNM-94) is untouched.
- Feature-properties validation moved **up front (fail-fast)**: the transform now runs lazily inside the file-write stream, where a throw would be swallowed by `storeFile`'s `try/catch` (→ "couldn't save file"); validating before streaming restores the original `Feature properties not found` error and avoids writing a partial file.

## Verification

- ✅ `tsc` + `eslint` clean.
- ✅ geo e2e `integration/cloning/piece-exporters` — **19 suites / 51 tests** green, incl. the `scenario-features-data` exporter empty/full/error cases (proves `.stream()` row keys match the transform, the streamed JSON parses back identically, and the fail-fast error path works).
- Memory peak at prod scale to be confirmed on the next large-scenario clone (target: well under 3GB).

Closes MRXNM-96.
