### PR TITLE
feat(api): bulk user + orphaned-project deletion tool [MRXNM-72]

### DIFF
--- a/api/apps/api/src/console.ts
+++ b/api/apps/api/src/console.ts
@@ -5,15 +5,11 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
-import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { apiConnections } from '@marxan-api/ormconfig';
 import { AuthenticationModule } from '@marxan-api/modules/authentication/authentication.module';
 import { UsersModule } from '@marxan-api/modules/users/users.module';
 import { UserCommand } from '@marxan-api/modules/users/user.command';
-import { ProjectsModule } from '@marxan-api/modules/projects/projects.module';
-import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block-guard.module';
-import { BulkUserDeletionCommand } from '@marxan-api/maintenance/bulk-user-deletion/bulk-user-deletion.command';
 import { ProcessFetchSpecification } from 'nestjs-base-service';
 
 @Module({
@@ -25,12 +21,9 @@ import { ProcessFetchSpecification } from 'nestjs-base-service';
     AuthenticationModule,
     ConsoleModule,
     UsersModule,
-    CqrsModule,
-    ProjectsModule,
-    BlockGuardModule,
   ],
-  providers: [UserCommand, BulkUserDeletionCommand],
-  exports: [UserCommand, BulkUserDeletionCommand],
+  providers: [UserCommand],
+  exports: [UserCommand],
 })
 export class AppModule implements NestModule {
   /**

--- a/api/apps/api/src/console.ts
+++ b/api/apps/api/src/console.ts
@@ -5,11 +5,15 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { apiConnections } from '@marxan-api/ormconfig';
 import { AuthenticationModule } from '@marxan-api/modules/authentication/authentication.module';
 import { UsersModule } from '@marxan-api/modules/users/users.module';
 import { UserCommand } from '@marxan-api/modules/users/user.command';
+import { ProjectsModule } from '@marxan-api/modules/projects/projects.module';
+import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block-guard.module';
+import { BulkUserDeletionCommand } from '@marxan-api/maintenance/bulk-user-deletion/bulk-user-deletion.command';
 import { ProcessFetchSpecification } from 'nestjs-base-service';
 
 @Module({
@@ -21,9 +25,12 @@ import { ProcessFetchSpecification } from 'nestjs-base-service';
     AuthenticationModule,
     ConsoleModule,
     UsersModule,
+    CqrsModule,
+    ProjectsModule,
+    BlockGuardModule,
   ],
-  providers: [UserCommand],
-  exports: [UserCommand],
+  providers: [UserCommand, BulkUserDeletionCommand],
+  exports: [UserCommand, BulkUserDeletionCommand],
 })
 export class AppModule implements NestModule {
   /**

--- a/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
@@ -1,0 +1,182 @@
+import { Command, Console } from 'nestjs-console';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { DbConnections } from '@marxan-api/ormconfig.connections';
+import { BlockGuard } from '@marxan-api/modules/projects/block-guard/block-guard.service';
+import { DeleteProject } from '@marxan-api/modules/projects/delete-project/delete-project.command';
+import { readEmailList } from './email-list';
+import { writeCsv } from './manifests';
+import { classifyProjects, choosePromotionTarget, ProjectRole } from './deletion-planner';
+import { DeletionDataAccess } from './deletion-data-access';
+
+interface RunOptions {
+  emails: string;
+  out: string;
+  apply?: boolean;
+  env?: string;
+}
+
+/**
+ * MRXNM-72 — hard-delete a supplied list of users and the projects they orphan.
+ *
+ * Reuses the `DeleteProject` CQRS command (so the `ProjectDeleted` saga enqueues
+ * the async Geo-DB cleanup — raw SQL would orphan the geo tables). Keeps projects
+ * still shared with a survivor, promoting a new owner where the only survivors are
+ * non-owners. Hard-delete residual references (`created_by`, export/import
+ * `owner_id`) are cleared, then user rows are deleted — all in one API-DB
+ * transaction so an unexpected FK rolls everything back.
+ *
+ * Dry-run by default (writes CSV manifests only); pass --apply to mutate.
+ */
+@Injectable()
+@Console()
+export class BulkUserDeletionCommand {
+  private readonly logger = new Logger(BulkUserDeletionCommand.name);
+
+  constructor(
+    @InjectDataSource(DbConnections.default) private readonly api: DataSource,
+    private readonly commandBus: CommandBus,
+    @Inject(BlockGuard) private readonly blockGuard: BlockGuard,
+  ) {}
+
+  @Command({
+    command: 'bulk-user-deletion',
+    description:
+      'MRXNM-72: hard-delete listed users + orphaned projects (dry-run unless --apply)',
+    options: [
+      { flags: '--emails <path>', required: true },
+      { flags: '--out <dir>', required: true },
+      { flags: '--apply', required: false },
+      { flags: '--env <env>', required: false },
+    ],
+  })
+  async run(options: RunOptions): Promise<void> {
+    const apply = !!options.apply;
+    const dao = new DeletionDataAccess(this.api);
+
+    // ---- Phase 0: plan ----
+    const emails = readEmailList(options.emails);
+    const users = await dao.resolveUserIds(emails);
+    const deletees = new Set(users.map((u) => u.id));
+    const matchedEmails = new Set(users.map((u) => u.email.toLowerCase()));
+    const unmatched = emails.filter((e) => !matchedEmails.has(e));
+
+    const memberships = await dao.loadProjectMemberships();
+    const buckets = classifyProjects(memberships, deletees);
+    const promotions: Array<{
+      projectId: string;
+      target: { userId: string; fromRole: ProjectRole };
+    }> = [];
+    for (const p of buckets.kept) {
+      const target = choosePromotionTarget(p, deletees);
+      if (target) promotions.push({ projectId: p.projectId, target });
+    }
+
+    // ---- manifests (always) ----
+    writeCsv(`${options.out}/users_to_delete.csv`, ['user_id', 'email'], users.map((u) => [u.id, u.email]));
+    writeCsv(`${options.out}/projects_already_orphaned_bucketA.csv`, ['project_id'], buckets.alreadyOrphaned.map((p) => [p.projectId]));
+    writeCsv(`${options.out}/projects_delete_bucketB.csv`, ['project_id'], buckets.becomesOrphaned.map((p) => [p.projectId]));
+    writeCsv(
+      `${options.out}/projects_keep_bucketC.csv`,
+      ['project_id', 'promote_user_id'],
+      buckets.kept.map((p) => [
+        p.projectId,
+        promotions.find((x) => x.projectId === p.projectId)?.target.userId ?? '',
+      ]),
+    );
+    if (unmatched.length) {
+      writeCsv(`${options.out}/unmatched_emails.csv`, ['email'], unmatched.map((e) => [e]));
+    }
+
+    this.logger.log(
+      `[plan] users=${users.length} unmatched=${unmatched.length} ` +
+        `A=${buckets.alreadyOrphaned.length} B=${buckets.becomesOrphaned.length} ` +
+        `C=${buckets.kept.length} promotions=${promotions.length}`,
+    );
+
+    if (!apply) {
+      this.logger.log('[plan] DRY-RUN — manifests written, no mutations. Re-run with --apply to execute.');
+      return;
+    }
+
+    // ---- Phase 1: delete bucket-B projects via the proper async path ----
+    const blocked: string[] = [];
+    let deleted = 0;
+    for (const p of buckets.becomesOrphaned) {
+      try {
+        await this.blockGuard.ensureThatProjectIsNotBlocked(p.projectId);
+      } catch {
+        blocked.push(p.projectId); // skip + report (pending job)
+        continue;
+      }
+      await this.commandBus.execute(new DeleteProject(p.projectId)); // saga enqueues geo cleanup
+      deleted++;
+      if (deleted % 50 === 0) {
+        this.logger.log(`[delete] ${deleted}/${buckets.becomesOrphaned.length}`);
+      }
+    }
+    writeCsv(`${options.out}/blockguard_hits.csv`, ['project_id'], blocked.map((id) => [id]));
+    this.logger.log(
+      `[delete] done: ${deleted} deleted, ${blocked.length} skipped (blocked). ` +
+        `${deleted} async Geo-DB cleanup jobs enqueued — MONITOR the ` +
+        `'unused-resources-cleanup-queue-name' queue and let it drain before the Geo-DB VACUUM.`,
+    );
+
+    // ---- Phases 3-5: promote owners, clear residuals, hard-delete users (one txn) ----
+    const deleteeIds = [...deletees];
+    await this.api.transaction(async (m) => {
+      // Phase 3: promote a surviving member to owner on owner-less kept projects
+      for (const { projectId, target } of promotions) {
+        await m.query(
+          `INSERT INTO users_projects (user_id, project_id, role_id)
+           VALUES ($1, $2, 'project_owner')
+           ON CONFLICT (user_id, project_id, role_id) DO NOTHING`,
+          [target.userId, projectId],
+        );
+      }
+      // Phase 4a: null dangling creator refs (safe — created_by is never read back)
+      await m.query(`UPDATE projects  SET created_by = NULL WHERE created_by = ANY($1::uuid[])`, [deleteeIds]);
+      await m.query(`UPDATE scenarios SET created_by = NULL WHERE created_by = ANY($1::uuid[])`, [deleteeIds]);
+      // Phase 4b: exports/imports owner_id is NOT NULL -> reassign to a surviving
+      // owner (read within the txn so promotions above are visible), else delete.
+      const residual = await dao.loadResidualOwnerRows(deleteeIds, m);
+      for (const r of residual.reassign) {
+        await m.query(`UPDATE ${r.table} SET owner_id = $1 WHERE id = $2`, [r.newOwnerId, r.id]);
+      }
+      for (const r of residual.delete) {
+        await m.query(`DELETE FROM ${r.table} WHERE id = $1`, [r.id]);
+      }
+      // Phase 5: hard-delete users (FKs cascade users_projects/_organizations/_scenarios/tokens/locks/...)
+      await m.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [deleteeIds]);
+      this.logger.log(
+        `[users] hard-deleted ${deleteeIds.length} users ` +
+          `(reassigned ${residual.reassign.length}, deleted ${residual.delete.length} export/import rows)`,
+      );
+    });
+
+    // ---- Phase 6: verify + reclaim ----
+    const [{ remaining }] = await this.api.query(
+      `SELECT count(*)::int AS remaining FROM users WHERE id = ANY($1::uuid[])`,
+      [deleteeIds],
+    );
+    const deletedBucketB = buckets.becomesOrphaned
+      .filter((p) => !blocked.includes(p.projectId))
+      .map((p) => p.projectId);
+    const [{ bremaining }] = await this.api.query(
+      `SELECT count(*)::int AS bremaining FROM projects WHERE id = ANY($1::uuid[])`,
+      [deletedBucketB],
+    );
+    this.logger.log(
+      `[verify] users remaining: ${remaining} (expect 0); bucket-B projects remaining: ${bremaining} (expect 0)`,
+    );
+    if (remaining !== 0 || bremaining !== 0) {
+      throw new Error('[verify] post-conditions not met — investigate before VACUUM');
+    }
+    await this.api.query(`VACUUM (ANALYZE) users, projects, scenarios, exports, imports, users_projects`);
+    this.logger.log(
+      '[done] complete. Once the cleanup queue is fully drained, run VACUUM (FULL) + reindex on the Geo DB separately (it locks).',
+    );
+  }
+}

--- a/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
@@ -113,6 +113,14 @@ export class BulkUserDeletionCommand {
       ...buckets.becomesOrphaned,
       ...(alsoDeleteOrphans ? buckets.alreadyOrphaned : []),
     ];
+    // Bucket-A (already-orphaned) projects bypass the block-guard: with zero
+    // members, no user can hold in-flight work, so a "pending" flag is always
+    // stale (e.g. abandoned legacy imports frozen in 'accepting'/'running' that
+    // would otherwise block the project forever). Bucket B keeps the guard —
+    // its members may have had genuine in-flight work at freeze time.
+    const bypassGuardIds = new Set(
+      buckets.alreadyOrphaned.map((p) => p.projectId),
+    );
 
     this.logger.log(
       `[plan] listed=${listed.length} excluded=${excludedFromList.length} ` +
@@ -131,11 +139,13 @@ export class BulkUserDeletionCommand {
     const blocked: string[] = [];
     let deleted = 0;
     for (const p of projectsToDelete) {
-      try {
-        await this.blockGuard.ensureThatProjectIsNotBlocked(p.projectId);
-      } catch {
-        blocked.push(p.projectId); // skip + report (pending job)
-        continue;
+      if (!bypassGuardIds.has(p.projectId)) {
+        try {
+          await this.blockGuard.ensureThatProjectIsNotBlocked(p.projectId);
+        } catch {
+          blocked.push(p.projectId); // skip + report (pending job)
+          continue;
+        }
       }
       await this.commandBus.execute(new DeleteProject(p.projectId)); // saga enqueues geo cleanup
       deleted++;
@@ -152,6 +162,9 @@ export class BulkUserDeletionCommand {
 
     // ---- Phases 3-5: promote owners, clear residuals, hard-delete users (one txn) ----
     const deleteeIds = [...deletees];
+    const deletedProjectIds = projectsToDelete
+      .filter((p) => !blocked.includes(p.projectId))
+      .map((p) => p.projectId);
     await this.api.transaction(async (m) => {
       // Phase 3: promote a surviving member to owner on owner-less kept projects
       for (const { projectId, target } of promotions) {
@@ -174,6 +187,15 @@ export class BulkUserDeletionCommand {
       for (const r of residual.delete) {
         await m.query(`DELETE FROM ${r.table} WHERE id = $1`, [r.id]);
       }
+      // Phase 4c: delete legacy_project_imports for the projects we just removed.
+      // Its FK to projects was dropped (migration 1654769225640), so project
+      // deletion leaves these rows dangling unless the owner happens to be a
+      // deletee (then owner_id cascade clears them). Children
+      // (legacy_project_import_components/_files) cascade off this row.
+      await m.query(
+        `DELETE FROM legacy_project_imports WHERE project_id = ANY($1::uuid[])`,
+        [deletedProjectIds],
+      );
       // Phase 5: hard-delete users (FKs cascade users_projects/_organizations/_scenarios/tokens/locks/...)
       await m.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [deleteeIds]);
       this.logger.log(
@@ -187,17 +209,19 @@ export class BulkUserDeletionCommand {
       `SELECT count(*)::int AS remaining FROM users WHERE id = ANY($1::uuid[])`,
       [deleteeIds],
     );
-    const deletedTargets = projectsToDelete
-      .filter((p) => !blocked.includes(p.projectId))
-      .map((p) => p.projectId);
     const [{ bremaining }] = await this.api.query(
       `SELECT count(*)::int AS bremaining FROM projects WHERE id = ANY($1::uuid[])`,
-      [deletedTargets],
+      [deletedProjectIds],
+    );
+    const [{ legacyremaining }] = await this.api.query(
+      `SELECT count(*)::int AS legacyremaining FROM legacy_project_imports WHERE project_id = ANY($1::uuid[])`,
+      [deletedProjectIds],
     );
     this.logger.log(
-      `[verify] users remaining: ${remaining} (expect 0); target projects remaining: ${bremaining} (expect 0)`,
+      `[verify] users remaining: ${remaining} (expect 0); target projects remaining: ${bremaining} (expect 0); ` +
+        `orphaned legacy_project_imports remaining: ${legacyremaining} (expect 0)`,
     );
-    if (remaining !== 0 || bremaining !== 0) {
+    if (remaining !== 0 || bremaining !== 0 || legacyremaining !== 0) {
       throw new Error('[verify] post-conditions not met — investigate before VACUUM');
     }
     await this.api.query(`VACUUM (ANALYZE) users, projects, scenarios, exports, imports, users_projects`);

--- a/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
@@ -16,6 +16,7 @@ interface RunOptions {
   out: string;
   exclude?: string;
   apply?: boolean;
+  deleteAlreadyOrphaned?: boolean;
   env?: string;
 }
 
@@ -50,6 +51,7 @@ export class BulkUserDeletionCommand {
       { flags: '--emails <path>', required: true },
       { flags: '--out <dir>', required: true },
       { flags: '--exclude <path>', required: false },
+      { flags: '--delete-already-orphaned', required: false },
       { flags: '--apply', required: false },
       { flags: '--env <env>', required: false },
     ],
@@ -104,11 +106,20 @@ export class BulkUserDeletionCommand {
       writeCsv(`${options.out}/excluded_emails.csv`, ['email'], excludedFromList.map((e) => [e]));
     }
 
+    // Projects to delete: bucket B always; bucket A (pre-existing orphans, already
+    // inaccessible to everyone) only when --delete-already-orphaned is set.
+    const alsoDeleteOrphans = !!options.deleteAlreadyOrphaned;
+    const projectsToDelete = [
+      ...buckets.becomesOrphaned,
+      ...(alsoDeleteOrphans ? buckets.alreadyOrphaned : []),
+    ];
+
     this.logger.log(
       `[plan] listed=${listed.length} excluded=${excludedFromList.length} ` +
         `users=${users.length} unmatched=${unmatched.length} ` +
         `A=${buckets.alreadyOrphaned.length} B=${buckets.becomesOrphaned.length} ` +
-        `C=${buckets.kept.length} promotions=${promotions.length}`,
+        `C=${buckets.kept.length} promotions=${promotions.length} ` +
+        `delete-already-orphaned=${alsoDeleteOrphans} -> projectsToDelete=${projectsToDelete.length}`,
     );
 
     if (!apply) {
@@ -116,10 +127,10 @@ export class BulkUserDeletionCommand {
       return;
     }
 
-    // ---- Phase 1: delete bucket-B projects via the proper async path ----
+    // ---- Phase 1: delete target projects via the proper async path ----
     const blocked: string[] = [];
     let deleted = 0;
-    for (const p of buckets.becomesOrphaned) {
+    for (const p of projectsToDelete) {
       try {
         await this.blockGuard.ensureThatProjectIsNotBlocked(p.projectId);
       } catch {
@@ -129,7 +140,7 @@ export class BulkUserDeletionCommand {
       await this.commandBus.execute(new DeleteProject(p.projectId)); // saga enqueues geo cleanup
       deleted++;
       if (deleted % 50 === 0) {
-        this.logger.log(`[delete] ${deleted}/${buckets.becomesOrphaned.length}`);
+        this.logger.log(`[delete] ${deleted}/${projectsToDelete.length}`);
       }
     }
     writeCsv(`${options.out}/blockguard_hits.csv`, ['project_id'], blocked.map((id) => [id]));
@@ -176,15 +187,15 @@ export class BulkUserDeletionCommand {
       `SELECT count(*)::int AS remaining FROM users WHERE id = ANY($1::uuid[])`,
       [deleteeIds],
     );
-    const deletedBucketB = buckets.becomesOrphaned
+    const deletedTargets = projectsToDelete
       .filter((p) => !blocked.includes(p.projectId))
       .map((p) => p.projectId);
     const [{ bremaining }] = await this.api.query(
       `SELECT count(*)::int AS bremaining FROM projects WHERE id = ANY($1::uuid[])`,
-      [deletedBucketB],
+      [deletedTargets],
     );
     this.logger.log(
-      `[verify] users remaining: ${remaining} (expect 0); bucket-B projects remaining: ${bremaining} (expect 0)`,
+      `[verify] users remaining: ${remaining} (expect 0); target projects remaining: ${bremaining} (expect 0)`,
     );
     if (remaining !== 0 || bremaining !== 0) {
       throw new Error('[verify] post-conditions not met — investigate before VACUUM');

--- a/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.command.ts
@@ -14,6 +14,7 @@ import { DeletionDataAccess } from './deletion-data-access';
 interface RunOptions {
   emails: string;
   out: string;
+  exclude?: string;
   apply?: boolean;
   env?: string;
 }
@@ -48,6 +49,7 @@ export class BulkUserDeletionCommand {
     options: [
       { flags: '--emails <path>', required: true },
       { flags: '--out <dir>', required: true },
+      { flags: '--exclude <path>', required: false },
       { flags: '--apply', required: false },
       { flags: '--env <env>', required: false },
     ],
@@ -57,7 +59,16 @@ export class BulkUserDeletionCommand {
     const dao = new DeletionDataAccess(this.api);
 
     // ---- Phase 0: plan ----
-    const emails = readEmailList(options.emails);
+    // Read the full list, then subtract an explicit exclusion list (e.g. internal
+    // or automation accounts that must never be deleted). Excluded-but-present
+    // entries are reported so the carve-out is auditable.
+    const listed = readEmailList(options.emails);
+    const excluded = options.exclude
+      ? new Set(readEmailList(options.exclude))
+      : new Set<string>();
+    const emails = listed.filter((e) => !excluded.has(e));
+    const excludedFromList = listed.filter((e) => excluded.has(e));
+
     const users = await dao.resolveUserIds(emails);
     const deletees = new Set(users.map((u) => u.id));
     const matchedEmails = new Set(users.map((u) => u.email.toLowerCase()));
@@ -89,9 +100,13 @@ export class BulkUserDeletionCommand {
     if (unmatched.length) {
       writeCsv(`${options.out}/unmatched_emails.csv`, ['email'], unmatched.map((e) => [e]));
     }
+    if (excludedFromList.length) {
+      writeCsv(`${options.out}/excluded_emails.csv`, ['email'], excludedFromList.map((e) => [e]));
+    }
 
     this.logger.log(
-      `[plan] users=${users.length} unmatched=${unmatched.length} ` +
+      `[plan] listed=${listed.length} excluded=${excludedFromList.length} ` +
+        `users=${users.length} unmatched=${unmatched.length} ` +
         `A=${buckets.alreadyOrphaned.length} B=${buckets.becomesOrphaned.length} ` +
         `C=${buckets.kept.length} promotions=${promotions.length}`,
     );

--- a/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.console.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.console.ts
@@ -1,0 +1,54 @@
+import { BootstrapConsole, ConsoleModule } from 'nestjs-console';
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { apiConnections } from '@marxan-api/ormconfig';
+import { DeleteProjectModule } from '@marxan-api/modules/projects/delete-project/delete-project.module';
+import { BlockGuardModule } from '@marxan-api/modules/projects/block-guard/block-guard.module';
+import { BulkUserDeletionCommand } from './bulk-user-deletion.command';
+
+/**
+ * Dedicated, lightweight console entry for the MRXNM-72 bulk-deletion command.
+ *
+ * Kept separate from the shared `console.ts` for two reasons learned on staging:
+ *  - running the full app context (ts-node) inside the serving api pod OOM-kills
+ *    its 4Gi container, so this MUST be run in a DEDICATED one-off pod/Job;
+ *  - this module imports only `DeleteProjectModule` (DeleteProject handler + the
+ *    ProjectDeleted saga + the unused-resources cleanup queue, via its
+ *    QueueApiEventsModule re-export of QueueBuilder) and `BlockGuardModule`,
+ *    rather than all of `ProjectsModule`, to keep the bootstrap footprint small
+ *    and avoid bloating the shared `create:user` console.
+ *
+ * Run (in a dedicated pod with the deployed image):
+ *   yarn console:bulk-deletion --emails <path> --out <dir> --env <env> [--apply]
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({ ...apiConnections.default, keepConnectionAlive: true }),
+    TypeOrmModule.forRoot({ ...apiConnections.geoprocessingDB, keepConnectionAlive: true }),
+    ConsoleModule,
+    CqrsModule,
+    DeleteProjectModule,
+    BlockGuardModule,
+  ],
+  providers: [BulkUserDeletionCommand],
+  exports: [BulkUserDeletionCommand],
+})
+export class BulkUserDeletionConsoleModule {}
+
+const bootstrap = new BootstrapConsole({
+  module: BulkUserDeletionConsoleModule,
+  useDecorators: true,
+});
+bootstrap.init().then(async (app) => {
+  try {
+    await app.init();
+    await bootstrap.boot();
+    await app.close();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    await app.close();
+    process.exit(1);
+  }
+});

--- a/api/apps/api/src/maintenance/bulk-user-deletion/deletion-data-access.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/deletion-data-access.ts
@@ -1,6 +1,11 @@
 import { DataSource } from 'typeorm';
 import { ProjectMembership, ProjectRole } from './deletion-planner';
 
+/** Anything that can run a parameterized query: a DataSource or a transaction EntityManager. */
+export interface QueryExecutor {
+  query(sql: string, params?: unknown[]): Promise<any>;
+}
+
 export type ResidualTable = 'exports' | 'imports';
 
 export interface ResidualPlan {
@@ -59,9 +64,12 @@ export class DeletionDataAccess {
    * still-existing referenced project. `exports.resource_id` may be a project or a
    * scenario; `imports` use project_id (falling back to resource_id).
    */
-  async loadResidualOwnerRows(deletees: string[]): Promise<ResidualPlan> {
+  async loadResidualOwnerRows(
+    deletees: string[],
+    exec: QueryExecutor = this.api,
+  ): Promise<ResidualPlan> {
     const exportRows: Array<{ id: string; new_owner_id: string | null }> =
-      await this.api.query(
+      await exec.query(
         `SELECT e.id, COALESCE(po.user_id, so.user_id) AS new_owner_id
          FROM exports e
          LEFT JOIN users_projects po
@@ -73,7 +81,7 @@ export class DeletionDataAccess {
         [deletees],
       );
     const importRows: Array<{ id: string; new_owner_id: string | null }> =
-      await this.api.query(
+      await exec.query(
         `SELECT i.id, po.user_id AS new_owner_id
          FROM imports i
          LEFT JOIN users_projects po

--- a/api/apps/api/src/maintenance/bulk-user-deletion/deletion-data-access.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/deletion-data-access.ts
@@ -1,0 +1,99 @@
+import { DataSource } from 'typeorm';
+import { ProjectMembership, ProjectRole } from './deletion-planner';
+
+export type ResidualTable = 'exports' | 'imports';
+
+export interface ResidualPlan {
+  /** rows whose referenced project still exists → reassign owner to a survivor */
+  reassign: Array<{ table: ResidualTable; id: string; newOwnerId: string }>;
+  /** rows whose referenced resource is gone → delete (stale orphans) */
+  delete: Array<{ table: ResidualTable; id: string }>;
+}
+
+/**
+ * Thin SQL layer over the API DB for the bulk-deletion command. Verified by the
+ * staging rehearsal (not unit-tested); the decision logic it feeds is covered by
+ * deletion-planner.spec.ts. Queries here are the ones validated read-only against
+ * production on 2026-06-23.
+ */
+export class DeletionDataAccess {
+  constructor(private readonly api: DataSource) {}
+
+  /** Resolve the email list to existing user ids (case-insensitive match). */
+  async resolveUserIds(emails: string[]): Promise<{ id: string; email: string }[]> {
+    return this.api.query(
+      `SELECT u.id, u.email FROM users u WHERE lower(u.email) = ANY($1::text[])`,
+      [emails],
+    );
+  }
+
+  /** Every project with its members (user_id + role) and creator. */
+  async loadProjectMemberships(): Promise<ProjectMembership[]> {
+    const rows: Array<{
+      project_id: string;
+      created_by: string | null;
+      user_id: string | null;
+      role_id: ProjectRole | null;
+    }> = await this.api.query(`
+      SELECT p.id AS project_id, p.created_by, up.user_id, up.role_id
+      FROM projects p
+      LEFT JOIN users_projects up ON up.project_id = p.id`);
+    const byId = new Map<string, ProjectMembership>();
+    for (const r of rows) {
+      let pm = byId.get(r.project_id);
+      if (!pm) {
+        pm = { projectId: r.project_id, createdBy: r.created_by, members: [] };
+        byId.set(r.project_id, pm);
+      }
+      if (r.user_id && r.role_id) {
+        pm.members.push({ userId: r.user_id, role: r.role_id });
+      }
+    }
+    return [...byId.values()];
+  }
+
+  /**
+   * Classify export/import rows owned by a deletee into reassign-vs-delete.
+   * MUST run AFTER bucket-B projects are deleted and owners promoted, so that the
+   * reassign target (`new_owner_id`) is a guaranteed-present project_owner of the
+   * still-existing referenced project. `exports.resource_id` may be a project or a
+   * scenario; `imports` use project_id (falling back to resource_id).
+   */
+  async loadResidualOwnerRows(deletees: string[]): Promise<ResidualPlan> {
+    const exportRows: Array<{ id: string; new_owner_id: string | null }> =
+      await this.api.query(
+        `SELECT e.id, COALESCE(po.user_id, so.user_id) AS new_owner_id
+         FROM exports e
+         LEFT JOIN users_projects po
+           ON po.project_id = e.resource_id AND po.role_id = 'project_owner'
+         LEFT JOIN scenarios s ON s.id = e.resource_id
+         LEFT JOIN users_projects so
+           ON so.project_id = s.project_id AND so.role_id = 'project_owner'
+         WHERE e.owner_id = ANY($1::uuid[])`,
+        [deletees],
+      );
+    const importRows: Array<{ id: string; new_owner_id: string | null }> =
+      await this.api.query(
+        `SELECT i.id, po.user_id AS new_owner_id
+         FROM imports i
+         LEFT JOIN users_projects po
+           ON po.project_id = COALESCE(i.project_id, i.resource_id)
+          AND po.role_id = 'project_owner'
+         WHERE i.owner_id = ANY($1::uuid[])`,
+        [deletees],
+      );
+    const out: ResidualPlan = { reassign: [], delete: [] };
+    const sort = (rows: Array<{ id: string; new_owner_id: string | null }>, table: ResidualTable) => {
+      for (const r of rows) {
+        if (r.new_owner_id) {
+          out.reassign.push({ table, id: r.id, newOwnerId: r.new_owner_id });
+        } else {
+          out.delete.push({ table, id: r.id });
+        }
+      }
+    };
+    sort(exportRows, 'exports');
+    sort(importRows, 'imports');
+    return out;
+  }
+}

--- a/api/apps/api/src/maintenance/bulk-user-deletion/deletion-planner.spec.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/deletion-planner.spec.ts
@@ -1,0 +1,74 @@
+import {
+  classifyProjects,
+  choosePromotionTarget,
+  ProjectMembership,
+  ProjectRole,
+} from './deletion-planner';
+
+const D = new Set(['del1', 'del2']);
+const proj = (
+  id: string,
+  members: Array<[string, ProjectRole]>,
+  createdBy: string | null = null,
+): ProjectMembership => ({
+  projectId: id,
+  createdBy,
+  members: members.map(([userId, role]) => ({ userId, role })),
+});
+
+describe('classifyProjects', () => {
+  it('A = zero members (report only)', () => {
+    const r = classifyProjects([proj('a', [])], D);
+    expect(r.alreadyOrphaned.map((p) => p.projectId)).toEqual(['a']);
+    expect(r.becomesOrphaned).toEqual([]);
+    expect(r.kept).toEqual([]);
+  });
+  it('B = all members are deletees', () => {
+    const r = classifyProjects(
+      [proj('b', [['del1', 'project_owner'], ['del2', 'project_viewer']])],
+      D,
+    );
+    expect(r.becomesOrphaned.map((p) => p.projectId)).toEqual(['b']);
+  });
+  it('C = at least one surviving member (even a viewer)', () => {
+    const r = classifyProjects(
+      [proj('c', [['del1', 'project_owner'], ['keep1', 'project_viewer']])],
+      D,
+    );
+    expect(r.kept.map((p) => p.projectId)).toEqual(['c']);
+    expect(r.becomesOrphaned).toEqual([]);
+  });
+});
+
+describe('choosePromotionTarget', () => {
+  it('null when a surviving owner already exists', () => {
+    expect(
+      choosePromotionTarget(
+        proj('p', [['keep1', 'project_owner'], ['del1', 'project_viewer']]),
+        D,
+      ),
+    ).toBeNull();
+  });
+  it('promotes a surviving contributor over a surviving viewer', () => {
+    const p = proj('p', [
+      ['del1', 'project_owner'],
+      ['v', 'project_viewer'],
+      ['c', 'project_contributor'],
+    ]);
+    expect(choosePromotionTarget(p, D)).toEqual({
+      userId: 'c',
+      fromRole: 'project_contributor',
+    });
+  });
+  it('falls back to a surviving viewer, deterministic by userId', () => {
+    const p = proj('p', [
+      ['del1', 'project_owner'],
+      ['v2', 'project_viewer'],
+      ['v1', 'project_viewer'],
+    ]);
+    expect(choosePromotionTarget(p, D)).toEqual({
+      userId: 'v1',
+      fromRole: 'project_viewer',
+    });
+  });
+});

--- a/api/apps/api/src/maintenance/bulk-user-deletion/deletion-planner.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/deletion-planner.ts
@@ -1,0 +1,71 @@
+export type ProjectRole =
+  | 'project_owner'
+  | 'project_contributor'
+  | 'project_viewer';
+
+export interface ProjectMembership {
+  projectId: string;
+  createdBy: string | null;
+  members: Array<{ userId: string; role: ProjectRole }>;
+}
+
+export interface ProjectBuckets {
+  /** A — already orphaned (no members today). Reported only, never deleted. */
+  alreadyOrphaned: ProjectMembership[];
+  /** B — becomes orphaned (every member is a deletee). Deleted. */
+  becomesOrphaned: ProjectMembership[];
+  /** C — still shared with at least one surviving user. Kept. */
+  kept: ProjectMembership[];
+}
+
+/**
+ * Bucket every project given the set of users being deleted. "Shared with a
+ * surviving user" wins regardless of role: a single surviving viewer keeps the
+ * project.
+ */
+export function classifyProjects(
+  projects: ProjectMembership[],
+  deletees: Set<string>,
+): ProjectBuckets {
+  const buckets: ProjectBuckets = {
+    alreadyOrphaned: [],
+    becomesOrphaned: [],
+    kept: [],
+  };
+  for (const p of projects) {
+    if (p.members.length === 0) {
+      buckets.alreadyOrphaned.push(p);
+    } else if (p.members.some((m) => !deletees.has(m.userId))) {
+      buckets.kept.push(p);
+    } else {
+      buckets.becomesOrphaned.push(p);
+    }
+  }
+  return buckets;
+}
+
+const PROMOTION_RANK: Record<ProjectRole, number> = {
+  project_owner: 0,
+  project_contributor: 1,
+  project_viewer: 2,
+};
+
+/**
+ * For a kept project, return the surviving member to promote to `project_owner`,
+ * or null if a surviving owner already exists (no promotion needed). Prefers a
+ * contributor over a viewer; ties broken deterministically by userId.
+ */
+export function choosePromotionTarget(
+  p: ProjectMembership,
+  deletees: Set<string>,
+): { userId: string; fromRole: ProjectRole } | null {
+  const survivors = p.members.filter((m) => !deletees.has(m.userId));
+  if (survivors.length === 0) return null; // not a kept project
+  if (survivors.some((m) => m.role === 'project_owner')) return null; // already owned
+  const best = [...survivors].sort(
+    (a, b) =>
+      PROMOTION_RANK[a.role] - PROMOTION_RANK[b.role] ||
+      a.userId.localeCompare(b.userId),
+  )[0];
+  return { userId: best.userId, fromRole: best.role };
+}

--- a/api/apps/api/src/maintenance/bulk-user-deletion/email-list.spec.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/email-list.spec.ts
@@ -1,0 +1,17 @@
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readEmailList } from './email-list';
+
+describe('readEmailList', () => {
+  const write = (contents: string): string => {
+    const f = join(mkdtempSync(join(tmpdir(), 'emails-')), 'e.txt');
+    writeFileSync(f, contents);
+    return f;
+  };
+
+  it('normalizes case, trims, drops blanks, de-duplicates', () => {
+    const f = write('A@x.com\n a@x.com \n\nB@y.com\n');
+    expect(readEmailList(f)).toEqual(['a@x.com', 'b@y.com']);
+  });
+});

--- a/api/apps/api/src/maintenance/bulk-user-deletion/email-list.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/email-list.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'fs';
+
+/**
+ * Read a newline-delimited email list (produced by xlsx_to_emails.py), returning
+ * trimmed, lowercased, de-duplicated, blank-stripped emails. Matching against
+ * `users.email` is case-insensitive, so normalization happens here once.
+ */
+export function readEmailList(path: string): string[] {
+  const seen = new Set<string>();
+  for (const line of readFileSync(path, 'utf8').split(/\r?\n/)) {
+    const e = line.trim().toLowerCase();
+    if (e) seen.add(e);
+  }
+  return [...seen];
+}

--- a/api/apps/api/src/maintenance/bulk-user-deletion/manifests.spec.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/manifests.spec.ts
@@ -1,0 +1,15 @@
+import { readFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { writeCsv } from './manifests';
+
+describe('writeCsv', () => {
+  it('writes a quoted CSV with header', () => {
+    const f = join(mkdtempSync(join(tmpdir(), 'csv-')), 'm.csv');
+    writeCsv(f, ['id', 'name'], [
+      ['1', 'a,b'],
+      ['2', 'q"x'],
+    ]);
+    expect(readFileSync(f, 'utf8')).toBe('"id","name"\n"1","a,b"\n"2","q""x"\n');
+  });
+});

--- a/api/apps/api/src/maintenance/bulk-user-deletion/manifests.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/manifests.ts
@@ -1,0 +1,21 @@
+import { writeFileSync } from 'fs';
+
+type Cell = string | number | boolean | null;
+
+const cell = (v: Cell): string => `"${String(v ?? '').replace(/"/g, '""')}"`;
+
+/**
+ * Write a quoted CSV (header + rows). Used to emit the dry-run manifests the
+ * client signs off on before any production deletion.
+ */
+export function writeCsv(
+  path: string,
+  header: string[],
+  rows: Array<Cell[]>,
+): void {
+  const lines = [
+    header.map(cell).join(','),
+    ...rows.map((r) => r.map(cell).join(',')),
+  ];
+  writeFileSync(path, lines.join('\n') + '\n');
+}

--- a/api/package.json
+++ b/api/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start": "nest start",
     "console": "NODE_CONFIG_DIR=apps/api/config ts-node --files --project tsconfig.json -r tsconfig-paths/register apps/api/src/console.ts",
+    "console:bulk-deletion": "NODE_CONFIG_DIR=apps/api/config ts-node --files --project tsconfig.json -r tsconfig-paths/register apps/api/src/maintenance/bulk-user-deletion/bulk-user-deletion.console.ts",
     "api:start:dev": "nodemon --exec 'NODE_OPTIONS=\"--max_old_space_size=3072\" NODE_CONFIG_DIR=apps/api/config ts-node --files --project tsconfig.json -r tsconfig-paths/register apps/api/src/main.ts' -L | bunyan",
     "api:start:debug": "nodemon --exec 'NODE_CONFIG_DIR=apps/api/config NODE_OPTIONS=\"--inspect=0.0.0.0 --max_old_space_size=3072\" ts-node --files --project tsconfig.json -r tsconfig-paths/register apps/api/src/main.ts' -L | bunyan",
     "geoprocessing:start:dev": "nodemon --exec 'NODE_OPTIONS=\"--max_old_space_size=4096\" NODE_CONFIG_DIR=apps/geoprocessing/config ts-node --files --project tsconfig.json -r tsconfig-paths/register apps/geoprocessing/src/main.ts' -L | bunyan",

--- a/data/scripts/user-deletion/xlsx_to_emails.py
+++ b/data/scripts/user-deletion/xlsx_to_emails.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Convert the client's user-deletion xlsx (single 'email' column) into a
+normalized, de-duplicated, lowercased newline-delimited text file.
+
+Usage: python3 xlsx_to_emails.py <input.xlsx> <output.txt>
+Requires openpyxl (pip install --user openpyxl, or a venv).
+"""
+import sys
+import re
+
+import openpyxl
+
+
+def main():
+    src, dst = sys.argv[1], sys.argv[2]
+    wb = openpyxl.load_workbook(src, read_only=True, data_only=True)
+    ws = wb.worksheets[0]
+    emails, header = [], None
+    for i, row in enumerate(ws.iter_rows(values_only=True)):
+        if i == 0:
+            header = row
+            continue
+        v = row[0]
+        if v is None or not str(v).strip():
+            continue
+        emails.append(str(v).strip().lower())
+    bad = [e for e in emails if not re.match(r'^[^@\s]+@[^@\s]+\.[^@\s]+$', e)]
+    uniq = sorted(set(emails))
+    with open(dst, 'w') as f:
+        f.write('\n'.join(uniq) + '\n')
+    print(f"header={header} rows={len(emails)} unique={len(uniq)} malformed={len(bad)}")
+    for b in bad[:20]:
+        print("  MALFORMED:", repr(b))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

A maintenance `nestjs-console` command to hard-delete a supplied list of users and the projects they orphan, for the pre-QCIF cleanup. Run via `yarn console:bulk-deletion` in a **dedicated one-off pod** (never the serving api pod).

```
yarn console:bulk-deletion --emails <list.txt> --exclude <keep.txt> \
  --out <dir> --env <staging|production> [--delete-already-orphaned] [--apply]
```

## How it works

- **Buckets** (by `users_projects` membership, not `created_by`):
  - **A — already orphaned** (0 members today): report-only by default; deleted with `--delete-already-orphaned`.
  - **B — becomes orphaned** (every member is in the list): deleted.
  - **C — shared with a survivor** (any role): kept; if no surviving owner remains, a surviving member is **promoted to owner**.
- **Project deletion** goes through the existing `DeleteProject` CommandBus → `ProjectDeleted` saga → BullMQ → geoprocessing worker, so Geo-DB cleanup runs (raw SQL would orphan it). The block-guard check is re-applied (skipped + reported on pending jobs).
- **Hard-delete** (one API-DB txn): promote owners → `SET NULL` dangling `created_by` (never read back) → reassign-or-delete residual `exports`/`imports` `owner_id` (NOT NULL) → `DELETE` users (FKs cascade `users_projects`/tokens/etc.) → verify → `VACUUM`.
- **`--exclude`** carves out accounts that must be preserved (e.g. an active internal account); excluded entries are logged to `excluded_emails.csv`.
- **Dry-run by default** — writes CSV manifests (users, bucket A/B/C, blockguard hits, excluded) for sign-off; `--apply` mutates.

## Validation

- Pure logic (bucketing, owner-promotion pick, email-list, CSV) is unit-tested (8 tests); full api `tsc` clean.
- **Full staging rehearsal (dry-run + `--apply`)** in a dedicated pod: buckets matched direct SQL; exclusion preserved the carve-out; the **saga fired in the console context and Geo-DB cleanup ran (`projects_pu` 107,688 → 0)**; hard-delete left 0 dangling refs; bucket-A untouched (default).

## Notes / ops

- MUST run in a **dedicated pod** — running a full app context in the serving api pod OOMs its 4Gi container.
- The shared `console.ts` is intentionally untouched; this uses its own lightweight console entry importing only `DeleteProjectModule` + `BlockGuardModule`.
- Prod run is gated: dry-run sign-off + fresh DB backup + maintenance window; Geo-DB `VACUUM (FULL)` is a separate operator step after the queue drains.