### PR TITLE
perf(geoprocessing/cloning): stream the project-feature-amounts exporter [MRXNM-101]

### DIFF
--- a/api/apps/geoprocessing/src/export/pieces-exporters/project-feature-amounts-per-planning-unit.piece-exporter.ts
+++ b/api/apps/geoprocessing/src/export/pieces-exporters/project-feature-amounts-per-planning-unit.piece-exporter.ts
@@ -4,12 +4,9 @@ import { ClonePiece, ExportJobInput, ExportJobOutput } from '@marxan/cloning';
 import { CloningFilesRepository } from '@marxan/cloning-files-repository';
 import { ComponentLocation, ResourceKind } from '@marxan/cloning/domain';
 import { ClonePieceRelativePathResolver } from '@marxan/cloning/infrastructure/clone-piece-data';
-import { ProjectFeatureAmountsPerPlanningUnitContent } from '@marxan/cloning/infrastructure/clone-piece-data/project-feature-amounts-per-planning-unit';
+import { ProjectFeatureGeoOperation } from '@marxan/cloning/infrastructure/clone-piece-data/project-feature-amounts-per-planning-unit';
+import { FeatureAmountsPerPlanningUnitEntity } from '@marxan/feature-amounts-per-planning-unit';
 import { SingleConfigFeatureValueStripped } from '@marxan/features-hash';
-import {
-  FeatureAmountPerProjectPlanningUnit,
-  FeatureAmountsPerPlanningUnitRepository,
-} from '@marxan/feature-amounts-per-planning-unit';
 import { SpecificationOperation } from '@marxan/specification';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
@@ -34,6 +31,16 @@ type ProjectFeaturesSelectResult = {
 
 type FeatureByIdMap = Record<string, Omit<FeaturesSelectResult, 'id'>>;
 
+/**
+ * Raw row shape returned by the streamed feature_amounts_per_planning_unit
+ * query. Keys match the aliases passed to `.select`/`.addSelect`.
+ */
+type FeatureAmountRawRow = {
+  amount: number;
+  projectPuId: string;
+  featureId: string;
+};
+
 @Injectable()
 @PieceExportProvider()
 export class ProjectFeatureAmountsPerPlanningUnitPieceExporter
@@ -45,11 +52,12 @@ export class ProjectFeatureAmountsPerPlanningUnitPieceExporter
 
   constructor(
     private readonly fileRepository: CloningFilesRepository,
-    private readonly featureAmountsPerPlanningUnitRepo: FeatureAmountsPerPlanningUnitRepository,
     @InjectRepository(ProjectsPuEntity)
     private readonly projectPusRepo: Repository<ProjectsPuEntity>,
     @InjectEntityManager(geoprocessingConnections.apiDB)
     private readonly apiEntityManager: EntityManager,
+    @InjectEntityManager(geoprocessingConnections.default)
+    private readonly geoEntityManager: EntityManager,
   ) {}
 
   isSupported(piece: ClonePiece, kind: ResourceKind): boolean {
@@ -62,24 +70,50 @@ export class ProjectFeatureAmountsPerPlanningUnitPieceExporter
   async run(input: ExportJobInput): Promise<ExportJobOutput> {
     const projectId = input.resourceId;
 
-    const featureAmountPerPlanningUnit =
-      await this.featureAmountsPerPlanningUnitRepo.getAmountPerPlanningUnitAndFeatureInProject(
-        projectId,
-      );
+    /**
+     * Memory efficiency (MRXNM-101, same pattern as the import side and the
+     * scenario-features-data exporter MRXNM-96):
+     *
+     * On large projects the `feature_amounts_per_planning_unit` table holds
+     * hundreds of thousands of rows (PU x feature). The previous implementation
+     * loaded the whole table, built the full transformed array AND the entire
+     * `JSON.stringify` string in memory before writing -> a heap spike that on
+     * big projects approaches the ~4GB V8 heap wall.
+     *
+     * This rewrite streams the big side: the feature-amount rows are pulled from
+     * a server-side cursor and transformed + written one at a time (see
+     * `streamFileContent`), so the full array / JSON string is never resident.
+     * The two remaining in-memory lookups do NOT scale with PU x feature:
+     *   - feature properties: one row per distinct feature (tens).
+     *   - project PUs (puid by project_pu_id): bounded by PU count.
+     * The output file shape is byte-compatible so the (streamed, MRXNM-101)
+     * importer keeps working as-is.
+     */
 
-    const featuresAmountPerPlanningUnitParsed =
-      await this.parseFeatureAmountPerPlanningUnit(
-        featureAmountPerPlanningUnit,
-        projectId,
-      );
+    // Small lookup #1: properties for every feature referenced by the project's
+    // feature amounts. Distinct ids are gathered server-side, so we never buffer
+    // the big row set just to collect a handful of feature ids.
+    const featuresById = await this.getFeaturesByIdForProjectAmounts(projectId);
 
+    // Small lookup #2: puid by project_pu_id (bounded by project PU count).
+    const projectPusById = await this.getProjectPusById(projectId);
+
+    // Small side, computed (and validated) up front: the derived-feature geo
+    // operations. Done before streaming so a thrown validation error surfaces
+    // here instead of being swallowed by storeFile's try/catch (the transform
+    // now runs lazily inside the file-write stream).
     const projectFeaturesGeoOperations =
       await this.getProjectFeaturesGeoOperations(projectId);
 
-    const fileContent: ProjectFeatureAmountsPerPlanningUnitContent = {
-      featureAmountsPerPlanningUnit: featuresAmountPerPlanningUnitParsed,
-      projectFeaturesGeoOperations,
-    };
+    // Big side: stream the feature-amount rows from a cursor; transform + write
+    // per row.
+    const amountRowStream = await this.geoEntityManager
+      .createQueryBuilder(FeatureAmountsPerPlanningUnitEntity, 'fappu')
+      .select('fappu.amount', 'amount')
+      .addSelect('fappu.projectPuId', 'projectPuId')
+      .addSelect('fappu.featureId', 'featureId')
+      .where('fappu.projectId = :projectId', { projectId })
+      .stream();
 
     const relativePath = ClonePieceRelativePathResolver.resolveFor(
       ClonePiece.ProjectFeatureAmountsPerPlanningUnit,
@@ -87,7 +121,14 @@ export class ProjectFeatureAmountsPerPlanningUnitPieceExporter
 
     const outputFile = await this.fileRepository.saveCloningFile(
       input.exportId,
-      Readable.from(JSON.stringify(fileContent)),
+      Readable.from(
+        this.streamFileContent(
+          amountRowStream,
+          featuresById,
+          projectPusById,
+          projectFeaturesGeoOperations,
+        ),
+      ),
       relativePath,
     );
 
@@ -103,32 +144,64 @@ export class ProjectFeatureAmountsPerPlanningUnitPieceExporter
     };
   }
 
-  private async parseFeatureAmountPerPlanningUnit(
-    featureAmountPerPlanningUnit: FeatureAmountPerProjectPlanningUnit[],
+  /**
+   * Streams the `{ "featureAmountsPerPlanningUnit": [...],
+   * "projectFeaturesGeoOperations": [...] }` file content. Each raw feature
+   * amount row is transformed and serialised on its own, joined with commas, so
+   * the whole array / JSON string is never held in memory. Backpressure from the
+   * file write pauses the DB cursor.
+   *
+   * @TODO Because the feature_amounts_per_planning_unit table is not accounted
+   * for in the clean up task, it can happen that when exporting after having
+   * deleted a feature, the feature info would not be found below and cause an
+   * error. Because it's not clear whether deleting the feature_amount_per_pu
+   * records of the dangling feature has any implications, to avoid this error
+   * the missing features are discarded (skipped) here.
+   */
+  private async *streamFileContent(
+    rowStream: Readable,
+    featuresById: FeatureByIdMap,
+    projectPusById: Record<string, number>,
+    projectFeaturesGeoOperations: ProjectFeatureGeoOperation[],
+  ): AsyncGenerator<string> {
+    yield '{"featureAmountsPerPlanningUnit":[';
+    let first = true;
+    for await (const row of rowStream as AsyncIterable<FeatureAmountRawRow>) {
+      const feature = featuresById[row.featureId];
+      if (!feature) continue;
+
+      const element = {
+        amount: row.amount,
+        puid: projectPusById[row.projectPuId],
+        featureName: feature.featureName,
+        isCustom: feature.isCustom,
+      };
+      yield (first ? '' : ',') + JSON.stringify(element);
+      first = false;
+    }
+    yield `],"projectFeaturesGeoOperations":${JSON.stringify(
+      projectFeaturesGeoOperations,
+    )}}`;
+  }
+
+  /**
+   * Resolves `featureName`/`isCustom` for every feature referenced by the
+   * project's feature amounts. The distinct feature ids are gathered with a
+   * server-side DISTINCT query so the big row set is never buffered.
+   */
+  private async getFeaturesByIdForProjectAmounts(
     projectId: string,
-  ) {
-    const featureIds = new Set(
-      featureAmountPerPlanningUnit.map(({ featureId }) => featureId),
+  ): Promise<FeatureByIdMap> {
+    const featureIdRows: { featureId: string }[] = await this.geoEntityManager
+      .createQueryBuilder(FeatureAmountsPerPlanningUnitEntity, 'fappu')
+      .select('fappu.featureId', 'featureId')
+      .distinct(true)
+      .where('fappu.projectId = :projectId', { projectId })
+      .getRawMany<{ featureId: string }>();
+
+    return this.getFeaturesById(
+      featureIdRows.map(({ featureId }) => featureId),
     );
-    const featuresById = await this.getFeaturesById([...featureIds]);
-
-    const projectPusById = await this.getProjectPusById(projectId);
-
-    // @TODO: Because the feature_amounts_per_planning_unit table is not accounted for in the clean up task, it can happen
-    // that when exporting after having deleted a feature, in the mapping below the feature info would not be found and
-    // cause an error. Because it's not clear whether deleting the feature_amount_per_pu records of the dangling feature
-    // in the clean up task has any implications, to avoid this error, the missing features are discarded.
-    return featureAmountPerPlanningUnit
-      .filter(({ featureId }) => featuresById[featureId])
-      .map(({ featureId, amount, projectPuId }) => {
-        const feature = featuresById[featureId];
-        return {
-          amount,
-          puid: projectPusById[projectPuId],
-          featureName: feature.featureName,
-          isCustom: feature.isCustom,
-        };
-      });
   }
 
   private async getFeaturesById(featureIds: string[]) {


### PR DESCRIPTION
## What

Fast-follow to #1756 (the importer): streams the `project-feature-amounts-per-planning-unit` **exporter** instead of loading the whole `feature_amounts_per_planning_unit` table and building the full array + `JSON.stringify` string in memory.

## Why

Same memory shape MRXNM-96 fixed for the scenario-features-data exporter: on large projects this table has hundreds of thousands of PU×feature rows, so materializing the transformed array and the entire JSON string spikes the heap toward the ~4GB V8 wall. It survived export on staging but is a latent OOM risk on bigger projects, and it's the last buffering piece in this clone path.

## How

- Stream the big side via a server-side cursor (`.stream()`); transform + write one row at a time. The file write applies backpressure to the cursor, so the full array / JSON string is never resident.
- Two remaining in-memory lookups do **not** scale with PU×feature: feature properties (one row per distinct feature, distinct ids gathered server-side) and `puid` by `project_pu_id` (bounded by PU count).
- Derived-feature geo operations are computed + validated **up front** so a thrown validation error surfaces directly instead of being swallowed by `storeFile`'s try/catch (the transform now runs lazily inside the write stream).
- Output shape is byte-compatible → the (streamed, MRXNM-101) importer is untouched.

## Testing

`make test-e2e-geoprocessing environment=local TEST_SUITE_PATH=integration/cloning/piece-exporters` → 19 suites, 51 passed (incl. empty, custom, platform, both split variants, and the discard-missing-feature path).

## Related

Completes MRXNM-101 (importer = #1756). Mirrors MRXNM-96 (#1755) on the project side.