### PR TITLE
fix(api): bulk-deletion residual must reassign to a surviving owner [MRXNM-72]

### DIFF
--- a/api/apps/api/src/maintenance/bulk-user-deletion/deletion-data-access.ts
+++ b/api/apps/api/src/maintenance/bulk-user-deletion/deletion-data-access.ts
@@ -68,25 +68,40 @@ export class DeletionDataAccess {
     deletees: string[],
     exec: QueryExecutor = this.api,
   ): Promise<ResidualPlan> {
+    // Candidate new owner must be a SURVIVING (non-deletee) project_owner —
+    // otherwise we'd "reassign" to another deletee (no-op) and the later
+    // `DELETE FROM users` would still hit the NOT-NULL owner_id FK. When no
+    // surviving owner exists (e.g. an export/import of a blocked bucket-B
+    // project whose every owner is a deletee, or a resource already deleted in
+    // Phase 1), new_owner_id is null → the row is deleted instead. Correlated
+    // subqueries with MIN give exactly one deterministic row per export/import.
     const exportRows: Array<{ id: string; new_owner_id: string | null }> =
       await exec.query(
-        `SELECT e.id, COALESCE(po.user_id, so.user_id) AS new_owner_id
+        `SELECT e.id,
+           COALESCE(
+             (SELECT po.user_id FROM users_projects po
+               WHERE po.project_id = e.resource_id AND po.role_id = 'project_owner'
+                 AND NOT (po.user_id = ANY($1::uuid[]))
+               ORDER BY po.user_id LIMIT 1),
+             (SELECT so.user_id FROM users_projects so
+               JOIN scenarios s ON s.project_id = so.project_id
+               WHERE s.id = e.resource_id AND so.role_id = 'project_owner'
+                 AND NOT (so.user_id = ANY($1::uuid[]))
+               ORDER BY so.user_id LIMIT 1)
+           ) AS new_owner_id
          FROM exports e
-         LEFT JOIN users_projects po
-           ON po.project_id = e.resource_id AND po.role_id = 'project_owner'
-         LEFT JOIN scenarios s ON s.id = e.resource_id
-         LEFT JOIN users_projects so
-           ON so.project_id = s.project_id AND so.role_id = 'project_owner'
          WHERE e.owner_id = ANY($1::uuid[])`,
         [deletees],
       );
     const importRows: Array<{ id: string; new_owner_id: string | null }> =
       await exec.query(
-        `SELECT i.id, po.user_id AS new_owner_id
+        `SELECT i.id,
+           (SELECT po.user_id FROM users_projects po
+             WHERE po.project_id = COALESCE(i.project_id, i.resource_id)
+               AND po.role_id = 'project_owner'
+               AND NOT (po.user_id = ANY($1::uuid[]))
+             ORDER BY po.user_id LIMIT 1) AS new_owner_id
          FROM imports i
-         LEFT JOIN users_projects po
-           ON po.project_id = COALESCE(i.project_id, i.resource_id)
-          AND po.role_id = 'project_owner'
          WHERE i.owner_id = ANY($1::uuid[])`,
         [deletees],
       );


### PR DESCRIPTION
Follow-up to #1757 (merged mid-run). On the production MRXNM-72 run, the Phase 3-5 user-deletion transaction rolled back on `exports_owner_id_fkey`: the residual handler reassigned export/import `owner_id` to *any* project_owner — including deletees — for blocked bucket-B projects whose every owner is a deletee. Reassign-to-deletee is a no-op, so `DELETE FROM users` still violated the FK.

**Fix:** reassign only to a **surviving** (non-deletee) owner via correlated subquery (`ORDER BY user_id LIMIT 1`; note `min(uuid)` is not a valid aggregate). When no survivor exists, the row is **deleted** instead (resource is a blocked/gone project anyway).

**Validated on live prod (read-only) before re-applying:** exports 4 reassign / 26 delete, imports 0 / 426, **0 reassign-to-deletee**. The corrected re-run completed `rc=0` (users 3,926→2,141, 0 dangling refs). The prod deletion is complete; this lands the fix that was applied live so the repo matches.