### PR TITLE
feat(app): maintenance-mode lock modal + pre-maintenance warning [MRXNM-100]

### DIFF
--- a/app/e2e/platform-transition.spec.ts
+++ b/app/e2e/platform-transition.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { isReportRoute } from '../layout/platform-transition/utils';
 
 const MODAL_TITLE = 'Important Platform Transition Notice';
-const COOKIE_NAME = 'platform-transition';
+const COOKIE_NAME = 'platform-transition-2026-maintenance';
 
 async function clearTransitionCookie(context: import('@playwright/test').BrowserContext) {
   const cookies = await context.cookies();

--- a/app/layout/platform-transition/content.tsx
+++ b/app/layout/platform-transition/content.tsx
@@ -10,18 +10,51 @@ export interface PlatformTransitionContentProps {
   onDismiss?: () => void;
   dontShowAgain?: boolean;
   onDontShowAgainChange?: (value: boolean) => void;
+  /** When true, render the non-dismissable maintenance-mode message (no controls). */
+  maintenance?: boolean;
 }
 
 export const PlatformTransitionContent: React.FC<PlatformTransitionContentProps> = ({
   onDismiss,
   dontShowAgain = false,
   onDontShowAgainChange,
+  maintenance = false,
 }) => {
+  if (maintenance) {
+    return (
+      <div className="flex max-h-[80vh] flex-col overflow-y-auto px-10 pb-8 pt-2 text-gray-700">
+        <div className="space-y-3 text-center">
+          <p className="text-3xl font-bold text-gray-800">ATTENTION!</p>
+          <p className="text-lg font-bold text-gray-800">
+            MaPP is currently in Maintenance Mode and will remain non-usable until July 4.
+          </p>
+          <p className="text-sm leading-relaxed">
+            If you have any questions or require assistance, you can contact{' '}
+            <a
+              href="mailto:marxanadmin@tnc.org"
+              className="text-primary-500 underline hover:text-primary-700"
+            >
+              marxanadmin@tnc.org
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex max-h-[80vh] flex-col overflow-y-auto px-10 pb-8 pt-2 text-gray-700">
       <h2 className="font-heading text-2xl text-gray-800">Important Platform Transition Notice</h2>
 
       <div className="mt-4 space-y-4 text-sm leading-relaxed">
+        <div className="border-l-4 border-yellow-600 bg-yellow-50 px-4 py-3 font-bold text-gray-800">
+          <p className="text-lg">WARNING!</p>
+          <p className="text-base">
+            MaPP will switch to Maintenance Mode and will be non-usable from June 29 to July 3.
+          </p>
+        </div>
+
         <p>
           MaPP will transition from The Nature Conservancy to a new host and long-term steward
           starting July 1, 2026, an exciting new stage for the platform&apos;s future development

--- a/app/layout/platform-transition/index.tsx
+++ b/app/layout/platform-transition/index.tsx
@@ -11,14 +11,15 @@ import Modal from 'components/modal';
 import PlatformTransitionContent from './content';
 import { isReportRoute } from './utils';
 
-const COOKIE_NAME = 'platform-transition';
+const COOKIE_NAME = 'platform-transition-2026-maintenance';
 const COOKIE_EXPIRY = new Date('2026-12-31T23:59:59Z');
 const MODAL_TITLE = 'Important Platform Transition Notice';
+const MAINTENANCE_TITLE = 'MaPP Maintenance Mode';
 
 export const PlatformTransitionModal = (): JSX.Element | null => {
   const { pathname } = useRouter();
   const [cookies, setCookie] = useCookies([COOKIE_NAME]);
-  const { platformTransition } = useFeatureFlags();
+  const { platformTransition, maintenanceMode } = useFeatureFlags();
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
@@ -39,10 +40,30 @@ export const PlatformTransitionModal = (): JSX.Element | null => {
     setOpen(false);
   }, [dontShowAgain, setCookie]);
 
+  if (!mounted) return null;
   if (isReportRoute(pathname)) return null;
+
+  // Maintenance mode: a hard, non-dismissable lock shown on every route. The
+  // dismissal cookie is ignored so it cannot be cleared away. This is the
+  // user-facing message; scaling the APIs to zero is the actual enforcement.
+  if (maintenanceMode) {
+    return (
+      <Modal
+        id="maintenance-mode"
+        title={MAINTENANCE_TITLE}
+        open
+        dismissable={false}
+        size="default"
+        onDismiss={() => undefined}
+      >
+        <PlatformTransitionContent maintenance />
+      </Modal>
+    );
+  }
+
+  // Pre-maintenance informational notice: dismissable and remembers dismissal.
   if (!platformTransition) return null;
   if (persistedDismissal) return null;
-  if (!mounted) return null;
   if (!open) return null;
 
   return (


### PR DESCRIPTION
## What

Implements the user-facing half of the QCIF migration write-freeze (MRXNM-100), reusing the existing platform-transition modal that already appears on every page.

Two independent, build-time feature flags now drive the modal:

| Flag | Behavior |
|---|---|
| `platformTransition` (existing) | Dismissable informational notice, **now with a bold WARNING block** announcing the maintenance window |
| `maintenanceMode` (**new**) | **Hard, non-dismissable lock** on every route |

### `maintenanceMode` lock
- `dismissable={false}` → no close button, **Escape disabled**, **outside-click disabled** (via the shared `Modal`'s react-aria config).
- Full-screen `z-50` overlay + `usePreventScroll` → the page behind is non-interactive and can't scroll.
- The dismissal cookie is **ignored**, so it can't be cleared away.
- Shown on all routes; the existing `/reports` carve-out is preserved so webshot rendering is unaffected.
- Copy: **ATTENTION!** — *MaPP is currently in Maintenance Mode and will remain non-usable until July 4.*

### Pre-maintenance WARNING (in the existing dismissable notice)
- Bold callout: **WARNING!** — *MaPP will switch to Maintenance Mode and will be non-usable from June 29 to July 3.*
- Dismissal cookie renamed (`platform-transition` → `platform-transition-2026-maintenance`) so the new warning re-displays once for users who previously dismissed the notice.

## Why this design

`maintenanceMode` is the **message**; **scaling `api` + `geoprocessing` to 0 replicas is the actual enforcement** (the lock is a frontend overlay and can be circumvented in-browser, but with no backend, any action fails). This avoids building a full backend read-only guard (auth-token writes, worker pausing, etc.) for what is a one-way migration cutover.

Both flags are `NEXT_PUBLIC_*`, so activating `maintenanceMode` in production is a rebuild + redeploy of the app image as part of the cutover (not a runtime toggle) — consistent with how `platformTransition` works today.

## Testing

Verified locally against `next dev` with each flag, driven by Playwright:

- **`maintenanceMode`**: ATTENTION text renders; `closeButtonCount=0`, `gotItCount=0`, `dontShowAgainCount=0`; modal **survives Escape + outside-click**; zero page errors.
- **`platformTransition`**: WARNING block renders; Close/"Got it"/checkbox all present; Escape/outside-click **dismiss** it correctly; zero page errors.
- `tsc --noEmit` and `eslint` both clean.

## Cutover usage

1. Show the WARNING ahead of time: ensure `platformTransition` is enabled (it is today).
2. At cutover: add `maintenanceMode` to `NEXT_PUBLIC_FEATURE_FLAGS`, rebuild/redeploy the app, then scale `api` + `geoprocessing` to 0 for the snapshot.