### PR TITLE
feat(app): QCIF transition banner copy + unify maintenance/normal popup [MRXNM-100]

### DIFF
--- a/app/layout/platform-transition/content.tsx
+++ b/app/layout/platform-transition/content.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import Button from 'components/button';
 import Checkbox from 'components/forms/checkbox';
 
-const GUIDE_URL = 'https://tnc.box.com/s/io7czx68a8nnnj3yos8qa724br86lfis';
 const DONT_SHOW_AGAIN_ID = 'platform-transition-dont-show-again';
 
 export interface PlatformTransitionContentProps {
   onDismiss?: () => void;
   dontShowAgain?: boolean;
   onDontShowAgainChange?: (value: boolean) => void;
-  /** When true, render the non-dismissable maintenance-mode message (no controls). */
+  /** When true, hide the dismissal controls (the modal is a non-dismissable maintenance lock). */
   maintenance?: boolean;
 }
 
@@ -20,114 +19,70 @@ export const PlatformTransitionContent: React.FC<PlatformTransitionContentProps>
   onDontShowAgainChange,
   maintenance = false,
 }) => {
-  if (maintenance) {
-    return (
-      <div className="flex max-h-[80vh] flex-col overflow-y-auto px-10 pb-8 pt-2 text-gray-700">
-        <div className="space-y-3 text-center">
-          <p className="text-3xl font-bold text-gray-800">ATTENTION!</p>
-          <p className="text-lg font-bold text-gray-800">
-            MaPP is currently in Maintenance Mode and will remain non-usable until July 4.
-          </p>
-          <p className="text-sm leading-relaxed">
-            If you have any questions or require assistance, you can contact{' '}
-            <a
-              href="mailto:marxanadmin@tnc.org"
-              className="text-primary-500 underline hover:text-primary-700"
-            >
-              marxanadmin@tnc.org
-            </a>
-            .
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="flex max-h-[80vh] flex-col overflow-y-auto px-10 pb-8 pt-2 text-gray-700">
-      <h2 className="font-heading text-2xl text-gray-800">Important Platform Transition Notice</h2>
-
       <div className="mt-4 space-y-4 text-sm leading-relaxed">
         <div className="border-l-4 border-yellow-600 bg-yellow-50 px-4 py-3 font-bold text-gray-800">
           <p className="text-lg">WARNING!</p>
-          <p className="text-base">
-            MaPP will switch to Maintenance Mode and will be non-usable from June 29 to July 3.
-          </p>
+          <h2 className="font-heading text-base text-gray-800">
+            Important Platform Transition Notice
+          </h2>
         </div>
 
         <p>
-          MaPP will transition from The Nature Conservancy to a new host and long-term steward
-          starting July 1, 2026, an exciting new stage for the platform&apos;s future development
-          and sustainability.
+          MaPP is transitioning from The Nature Conservancy (TNC) to a new long-term steward, QCIF
+          Digital Research, to support its continued development and sustainability. This transition
+          ensures ongoing support, improved infrastructure, and long-term stability for the
+          platform.
         </p>
 
         <p>
-          We do not expect disruptions during the transition period (May–June). However, temporary
-          performance or access issues may occur during the final migration stage.
+          MaPP will be unavailable starting June 29 while we complete the migration to QCIF-hosted
+          infrastructure.
         </p>
 
         <p>
-          To avoid any risk, we strongly recommend that all users by <strong>June 26</strong>:
+          The main cutover is planned for June 30, followed by validation from July 1–3. We expect
+          to confirm broader access from July 4, pending successful validation.
         </p>
 
-        <ul className="ml-6 list-disc space-y-1">
-          <li>Complete any ongoing analyses</li>
-          <li>Export results</li>
-          <li>Back up active/important projects</li>
-          <li>Delete old/inactive projects</li>
-        </ul>
+        <p>
+          While this transition is being carefully managed by TNC, QCIF, and Vizzuality, temporary
+          access or performance issues may occur.
+        </p>
 
         <p>
-          You can download a quick user guide here for instructions:{' '}
+          Please avoid scheduling critical analyses, workshops, or trainings between June 30 and
+          July 15 while the platform is migrated, validated, and optimized.
+        </p>
+
+        <p>
+          For support after migration:{' '}
           <a
-            href={GUIDE_URL}
-            target="_blank"
-            rel="noopener noreferrer"
+            href="mailto:marxan_platform@qcif.edu.au"
             className="text-primary-500 underline hover:text-primary-700"
           >
-            MaPP transition user guide
+            marxan_platform@qcif.edu.au
           </a>
-          .
-        </p>
-
-        <p>
-          Backing up projects is especially important to ensure they can be restored if needed after
-          the transition.
-        </p>
-
-        <p>
-          We will continue to share updates as we approach the final migration and keep you informed
-          throughout the process.
-        </p>
-
-        <p>Thank you for your continued use of MaPP and your support during this transition.</p>
-
-        <p>
-          If you have any questions or require assistance, you can contact{' '}
-          <a
-            href="mailto:marxanadmin@tnc.org"
-            className="text-primary-500 underline hover:text-primary-700"
-          >
-            marxanadmin@tnc.org
-          </a>
-          .
         </p>
       </div>
 
-      <div className="mt-6 flex items-center justify-between gap-4">
-        <label htmlFor={DONT_SHOW_AGAIN_ID} className="flex cursor-pointer items-center gap-2">
-          <Checkbox
-            id={DONT_SHOW_AGAIN_ID}
-            theme="light"
-            checked={dontShowAgain}
-            onChange={(event) => onDontShowAgainChange?.(event.target.checked)}
-          />
-          <span className="text-sm text-gray-700">Don&apos;t show me this again</span>
-        </label>
-        <Button theme="primary" size="base" onClick={onDismiss}>
-          Got it
-        </Button>
-      </div>
+      {!maintenance && (
+        <div className="mt-6 flex items-center justify-between gap-4">
+          <label htmlFor={DONT_SHOW_AGAIN_ID} className="flex cursor-pointer items-center gap-2">
+            <Checkbox
+              id={DONT_SHOW_AGAIN_ID}
+              theme="light"
+              checked={dontShowAgain}
+              onChange={(event) => onDontShowAgainChange?.(event.target.checked)}
+            />
+            <span className="text-sm text-gray-700">Don&apos;t show me this again</span>
+          </label>
+          <Button theme="primary" size="base" onClick={onDismiss}>
+            Got it
+          </Button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What

Applies the client-supplied QCIF transition copy to the platform-transition notice, and unifies the popup so it shows the **same content in and out of maintenance mode**.

### Copy (client-provided)
- Orange header now carries **WARNING!** + **Important Platform Transition Notice**.
- Body: transition to QCIF Digital Research; unavailable from **June 29**; main cutover **June 30**; validation **July 1–3**; broader access from **July 4**; avoid scheduling critical analyses/workshops/trainings **June 30–July 15**; support at **marxan_platform@qcif.edu.au**.
- Removed (not in the client's replacement copy): the "by June 26" recommendations list, the old "MaPP transition user guide" link, and the old `marxanadmin@tnc.org` contact.

### Unify maintenance vs normal popup
- Both modes now render a single shared body. The dismissal controls (the "Don't show me this again" checkbox + "Got it" button) are hidden **only** when it's the non-dismissable maintenance lock.
- This drops the previous separate "ATTENTION / TNC email" maintenance variant — the maintenance lock now shows the same QCIF copy/support email.

## Testing
- Rendered both flags via `next dev` + Playwright:
  - `maintenanceMode`: full copy, **0** dismiss controls, survives Escape + outside-click (non-dismissable).
  - `platformTransition`: identical copy, Close/checkbox/"Got it" present + dismissable; `heading` role present (existing e2e `getByRole('heading', { name: 'Important Platform Transition Notice' })` still matches).
- `tsc --noEmit` + `eslint` clean.

## Notes
- The cookie rename from the prior MRXNM-100 PR is already on staging, so the pre-maintenance notice re-displays once for users who previously dismissed it.
- Activation unchanged: build-time `NEXT_PUBLIC_FEATURE_FLAGS` (`platformTransition` now / add `maintenanceMode` at cutover) → rebuild + redeploy; scale APIs to 0 for the snapshot.