### PR TITLE
fix(app): bulk edit must not drop splits from the feature spec [MRXNM-82]

### DIFF
--- a/app/e2e/feature-split.spec.ts
+++ b/app/e2e/feature-split.spec.ts
@@ -73,4 +73,41 @@ test.describe('Feature split (materialized)', () => {
     //   .first().getByRole('button').first().click();
     // await tileRequest;
   });
+
+  /**
+   * Regression: bulk-editing split children used to resubmit the spec with
+   * `splits: []` (the modal's row snapshot never populated), which
+   * un-materialized every child — i.e. the edit reversed the split. A bulk
+   * edit must only change target/SPF; the split must survive.
+   *
+   * Requires the same env as the test above, with the scenario ALREADY
+   * containing materialized split children (run the split test first).
+   */
+  test('bulk edit of split children applies values and preserves the split', async ({ page }) => {
+    await page.goto(`/projects/${PROJECT_ID}/scenarios/${SCENARIO_ID}/edit?tab=features`);
+
+    const childRows = page.getByRole('row', { name: new RegExp(`${FEATURE_NAME} / `, 'i') });
+    await expect(childRows.first()).toBeVisible({ timeout: 60_000 });
+    const childCount = await childRows.count();
+
+    // 1. Select every split-child row via its checkbox.
+    for (let i = 0; i < childCount; i += 1) {
+      await childRows.nth(i).getByRole('checkbox').check();
+    }
+
+    // 2. Bulk menu → Edit → set a new target for the selection.
+    await page.getByRole('button', { name: 'Edit' }).click();
+    await expect(page.getByRole('heading', { name: 'Edit selected features' })).toBeVisible();
+    await page.getByLabel('Target (%)').fill('30');
+    await page.getByLabel('SPF').fill('2');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // 3. The edit succeeds…
+    await expect(page.getByText('Features edited')).toBeVisible();
+
+    // 4. …and the split children are still there (the split was NOT reversed),
+    //    even after the spec read-back refreshes the table.
+    await expect(childRows.first()).toBeVisible({ timeout: 60_000 });
+    await expect(childRows).toHaveCount(childCount);
+  });
 });

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/bulk-action-menu/modals/edit/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useMemo } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 import { Form as FormRFF, Field as FieldRFF, FormProps } from 'react-final-form';
 
@@ -34,7 +34,13 @@ const EditModal = ({
   handleModal,
   onDone,
 }: {
-  selectedFeatures: (Feature & { name: string; marxanSettings: { prop?: number; fpf?: number } })[];
+  selectedFeatures: (Feature & {
+    name: string;
+    marxanSettings: { prop?: number; fpf?: number };
+    // present on split-child rows only (`${parentId}-${value}` synthetic rows)
+    parentId?: Feature['id'];
+    value?: string;
+  })[];
   handleModal: (modalKey: 'split' | 'edit' | 'delete', isVisible: boolean) => void;
   onDone?: (res?: unknown) => void;
 }): JSX.Element => {
@@ -53,37 +59,17 @@ const EditModal = ({
     }
   );
 
-  const targetedFeatures = useMemo(() => {
-    let parsedData = [];
-    const formState = formRef.current?.getState();
-
-    if (!formState?.values) return [];
-
-    selectedFeaturesQuery.data?.forEach((feature) => {
-      if (feature.splitFeaturesSelected?.length > 0) {
-        const splitFeatures = feature.splitFeaturesSelected.map((splitFeature) => ({
-          ...splitFeature,
-          id: `${feature.id}-${splitFeature.name}`,
-          parentId: feature.id,
-        }));
-
-        parsedData = [...parsedData, ...splitFeatures];
-      } else {
-        parsedData = [
-          ...parsedData,
-          {
-            ...feature,
-          },
-        ];
-      }
-    });
-
-    return parsedData;
-  }, [selectedFeaturesQuery.data, formRef]);
-
   const onEditSubmit = useCallback(
     (values: FormValues) => {
       const { target, spf = 1, mode } = values;
+
+      // Layer the form values over the existing settings (fractions, as read
+      // back from the API), honouring the edition mode.
+      const applyEdits = (marxanSettings: { prop?: number; fpf?: number }) => ({
+        ...marxanSettings,
+        ...(['only-target', 'all'].includes(mode) && { prop: target / 100 }),
+        ...(['only-spf', 'all'].includes(mode) && { fpf: +spf }),
+      });
 
       const data = {
         status: 'created',
@@ -94,65 +80,26 @@ const EditModal = ({
             return {
               featureId,
               kind,
-              geoprocessingOperations: geoprocessingOperations.map((go) => {
-                const { splits } = go;
-
-                return {
-                  ...go,
-                  splits: splits
-                    .filter((s) => {
-                      return targetedFeatures.find((f) => {
-                        return f.parentId === featureId && f.value === s.value;
-                      });
-                    })
-                    .map((s) => {
-                      const {
-                        marxanSettings: { prop, fpf },
-                      } = targetedFeatures.find((f) => {
-                        return f.parentId === featureId && f.value === s.value;
-                      });
-
-                      return {
-                        ...s,
-                        marxanSettings: {
-                          prop: prop / 100,
-                          fpf,
-                        },
-                      };
-                    }),
-                };
-              }),
-            };
-          }
-
-          let newMarxanSettings = sf.marxanSettings;
-
-          if (mode === 'only-target') {
-            newMarxanSettings = {
-              ...newMarxanSettings,
-              prop: target / 100,
-            };
-          }
-
-          if (mode === 'only-spf') {
-            newMarxanSettings = {
-              ...newMarxanSettings,
-              fpf: +spf,
-            };
-          }
-
-          if (mode === 'all') {
-            newMarxanSettings = {
-              prop: target / 100,
-              fpf: +spf,
+              geoprocessingOperations: geoprocessingOperations.map((go) => ({
+                ...go,
+                // Bulk edit must never drop splits — resubmitting the spec with
+                // missing splits un-materializes those children (reverses the
+                // split). Selected split children get the new settings; the
+                // rest keep theirs.
+                splits: go.splits.map((s) =>
+                  selectedFeatures.some((f) => f.parentId === featureId && f.value === s.value)
+                    ? { ...s, marxanSettings: applyEdits(s.marxanSettings) }
+                    : s
+                ),
+              })),
             };
           }
 
           return {
             featureId,
             kind,
-            marxanSettings: selectedFeatures.find((f) => f.id === featureId)
-              ? newMarxanSettings
+            marxanSettings: selectedFeatures.some((f) => f.id === featureId)
+              ? applyEdits(sf.marxanSettings)
               : sf.marxanSettings,
           };
         }),
@@ -197,7 +144,6 @@ const EditModal = ({
     [
       addToast,
       selectedFeaturesQuery.data,
-      targetedFeatures,
       selectedFeatures,
       selectedFeaturesMutation,
       handleModal,


### PR DESCRIPTION
## Jira story

[MRXNM-82](https://vizzuality.atlassian.net/browse/MRXNM-82) — client-reported regression after the split release: bulk-editing features after a split reversed the split instead of applying the edits.

## What

**Root cause.** The scenario bulk-edit modal (`target-spf/bulk-action-menu/modals/edit`) filtered the specification's splits against a modal-local `targetedFeatures` snapshot that was **deterministically empty**:

- the `useMemo` computed on the mount render, before `formRef.current` was assigned, so it returned `[]`;
- its deps (`[selectedFeaturesQuery.data, formRef]`) never changed afterwards — the ref's identity is stable, and react-query v3's structural sharing (`replaceEqualDeep`) keeps `data` reference-stable across renders/refetches while the server payload is unchanged.

So every submit sent the split operation with `splits: []` and `status: 'created'` → the backend re-materialized with zero children → **split reversed**. The same branch also never applied the form's target/SPF to split children and re-divided the already-fractional read-back `prop` by 100.

**Fix.** Removed the broken memo; the submit now maps over the read-back spec and:

- **never drops a split** — bulk edit only changes settings;
- layers the mode-aware form values (Target / SPF / both) onto the rows the user actually selected: split children matched by `parentId`+`value` from the selected table rows, plain features by id;
- leaves unselected features/splits untouched, and echoes back the read-back split extras (`featureId`, `amountRange`, `creationStatus`), which the API whitelists (see #1714 serializer).

Also adds a flag-gated Playwright regression test next to the existing split scaffold (skipped unless `E2E_FEATURE_SPLIT=true`).

### Testing instructions

Client-supplied test files: `Species.zip` + `Ecoregions.zip` (Ecoregions has 4 records with categorical fields, e.g. `eco_name`).

1. Upload both as project features; add them to a scenario (Grid setup → Features).
2. Split **Ecoregions** by `eco_name` and wait for the children (`Ecoregions / <value>`) to materialize.
3. Select all split children (+ optionally Species), open the bulk **Edit** menu, set Target and/or SPF, Save.
4. **Before this fix:** the Ecoregions children disappear (split reversed). **After:** the children remain and show the new Target/SPF after the table refreshes.

## Notes

- **Base is `staging`, not `develop`:** the MRXNM-82 split feature line only exists on `staging` (develop has none of the split commits, nor `app/e2e/feature-split.spec.ts`), matching recent PRs (#1761).
- `tsc` clean; eslint reports no errors (only this file's pre-existing `no-unsafe-*` warnings from the untyped query data — the project lints with `--quiet`).
- The sibling bulk **Delete** modal builds from the table rows, not the broken memo, so it is not affected.

[MRXNM-82]: https://vizzuality.atlassian.net/browse/MRXNM-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ