### PR TITLE
fix(app): show split children toggled from the map legend [MRXNM-82]

### DIFF
--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -293,7 +293,9 @@ export const useFeaturesLegend = () => {
         }
         dispatch(setSelectedFeatures(newSelectedFeatures));
 
-        const { color } = binaryFeaturesItems.find(({ id }) => id === featureId) || {};
+        // uniqueBinaryFeatures (not binaryFeaturesItems) so split-child rows
+        // — present only in the targeted expansion — resolve their color too.
+        const { color } = uniqueBinaryFeatures.find(({ id }) => id === featureId) || {};
 
         dispatch(
           setLayerSettings({
@@ -312,18 +314,49 @@ export const useFeaturesLegend = () => {
         const { color, amountRange, amountMin, amountMax, splitted } =
           uniqueContinuousFeatures.find(({ id }) => id === featureId) || {};
 
-        const newSelectedFeatures = [...selectedContinuousFeatures];
-        const isIncluded = newSelectedFeatures.includes(featureId);
-
-        if (!splitted) {
+        // Split children are bucketed here by their PARENT's amount range, but
+        // they are drawn as solid-color layers by useTargetedPreviewLayers
+        // (their own child tiles), never by the gradient renderer. Stamping an
+        // amountRange into their layerSettings excludes them from that hook —
+        // and the merging reducer makes the exclusion sticky — leaving them
+        // rendered nowhere: same failure a8b38a92 fixed in the table's eye
+        // toggle. Route them through the discrete toggle instead.
+        if (splitted) {
+          const newSelectedFeatures = [...selectedFeatures];
+          const isIncluded = newSelectedFeatures.includes(featureId);
           if (!isIncluded) {
             newSelectedFeatures.push(featureId);
           } else {
-            const i = newSelectedFeatures.indexOf(featureId);
-            newSelectedFeatures.splice(i, 1);
+            newSelectedFeatures.splice(newSelectedFeatures.indexOf(featureId), 1);
           }
-          dispatch(setSelectedContinuousFeatures(newSelectedFeatures));
+          dispatch(setSelectedFeatures(newSelectedFeatures));
+
+          dispatch(
+            setLayerSettings({
+              id: featureId,
+              settings: {
+                visibility: !isIncluded,
+                color,
+                // null (not undefined — the reducer drops undefined) so a
+                // previously stamped amountRange is cleared and the row passes
+                // useTargetedPreviewLayers' "no amountRange" filter again.
+                amountRange: null,
+              },
+            })
+          );
+          return;
         }
+
+        const newSelectedFeatures = [...selectedContinuousFeatures];
+        const isIncluded = newSelectedFeatures.includes(featureId);
+
+        if (!isIncluded) {
+          newSelectedFeatures.push(featureId);
+        } else {
+          const i = newSelectedFeatures.indexOf(featureId);
+          newSelectedFeatures.splice(i, 1);
+        }
+        dispatch(setSelectedContinuousFeatures(newSelectedFeatures));
 
         dispatch(
           setLayerSettings({


### PR DESCRIPTION
## Jira story

[MRXNM-82](https://vizzuality.atlassian.net/browse/MRXNM-82) — client-reported after the split release: split features are not displayed on the map.

## What

**Root cause.** The map legend buckets split children by their **parent's** amount range. Children of a continuous parent therefore went through the continuous-features visibility handler, which:

- stamped an `amountRange` into the child row's `layerSettings` — `useTargetedPreviewLayers` filters out any row whose settings carry an `amountRange`, so the solid-color child layer was never built;
- skipped `selectedContinuousFeatures` for `splitted` rows, so the gradient renderer ignored them too.

Result: a split child toggled from the legend rendered **nowhere**. Worse, `setLayerSettings` merges, so the stamped `amountRange` stuck for the session and also disabled the targets-table eye toggle (fixed earlier in a8b38a92) for that row.

**Fix.**

- Split children toggled from the legend now go through the discrete toggle (same path as the table eye): `selectedFeatures` + visibility/color, no `amountRange`.
- A previously stamped `amountRange` is healed with an explicit `null` (the reducer drops `undefined`), so poisoned rows recover on the next toggle.
- Binary split-child colors now resolve from `uniqueBinaryFeatures` (they only exist in the targeted expansion, so the old `binaryFeaturesItems` lookup returned `undefined`).

### Testing instructions

1. In a scenario (Grid setup → Features), split a feature — e.g. the client-supplied `Ecoregions` by `eco_name` — and wait for the children to materialize.
2. Open the map legend → Features group and toggle a split child (`Parent / value`) visible → **before:** nothing renders (and afterwards even the table eye can't show it); **after:** the child renders from its own tiles with its legend color.
3. Toggle it off/on from both the legend and the targets-table eye — the two stay in sync.

## Notes

- Base is `staging` for the same reason as #1764: the split feature line only exists there.
- Companion client-reported fix: #1764 (bulk edit reversing splits).
- `tsc` clean; eslint 0 errors (pre-existing warnings only in this legacy file).
- If children still don't render after this fix, the remaining suspect is prod tile data (`feature_data` stable ids backfill, MRXNM-82/99 scripts) — the child tile endpoint would return empty tiles; worth checking one child's `/geo-features/:id/preview/tiles` response on prod.

[MRXNM-82]: https://vizzuality.atlassian.net/browse/MRXNM-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ