### PR TITLE
fix(app): round gap-analysis percentages to 2 decimals [MRXNM-82]

### DIFF
--- a/app/components/gap-analysis/item/component.tsx
+++ b/app/components/gap-analysis/item/component.tsx
@@ -41,7 +41,7 @@ export const Item: React.FC<ItemProps> = ({
 }: ItemProps) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const [chartEl, setChartEl] = useState(null);
-  const percentFormatter = useNumberFormatter({ style: 'percent', maximumFractionDigits: 4 });
+  const percentFormatter = useNumberFormatter({ style: 'percent', maximumFractionDigits: 2 });
 
   const metStyles = useMemo(() => {
     if (chartEl) {


### PR DESCRIPTION
## Jira story

[MRXNM-82](https://vizzuality.atlassian.net/browse/MRXNM-82) — client-reported after the split release: "current values are not being rounded up" in Gap Analysis and Target Achievement.

## What

Both tabs render current/target through the shared `components/gap-analysis/item`, whose formatter allowed **4 fraction digits** (deliberate in 0992f579f, paired with the BE views' `round(x, 4)`). With real-world data that surfaces values like `Current: 89.9999%`. Capping the formatter at **2 fraction digits** makes `Intl` round to nearest: `89.9999 → 90%`, `23.4567 → 23.46%`.

Display-only change; the BE keeps serving 4-decimal precision (tooltips/reports unaffected).

### Testing instructions

Open any scenario → Grid setup → Gap Analysis, and Solutions → Target Achievement: current/target labels now show at most 2 decimals (e.g. `90%`, `23.46%`).

## Notes

- Base is `staging` (split-feature line; same as #1764/#1765).
- If the client expects integer percentages instead, this is a one-character change (`maximumFractionDigits: 0`) — flagging in case the Jira acceptance criteria say otherwise.
- Sibling PR (separate bug from the same report): gap analysis computed from the parent shapefile for split children — API-side fix.

[MRXNM-82]: https://vizzuality.atlassian.net/browse/MRXNM-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ