### PR TITLE
fix(api): compute split gap data from each child's own amounts [MRXNM-82]

### DIFF
--- a/api/apps/api/src/modules/scenarios-features/split/split-operation.service.spec.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-operation.service.spec.ts
@@ -20,11 +20,13 @@ describe('SplitOperation feature_data_stable_ids derivation', () => {
     };
     const kvStableIdRows = [{ stable_id: 's1' }, { stable_id: 's2' }];
 
-    // 1st geo query = SplitQuery (scenario prep); 2nd = the stable-id lookup.
+    // 1st geo query = the stable-id lookup; 2nd = SplitQuery (scenario prep).
+    // Stable ids must land first: ComputeArea derives the child's per-PU
+    // amounts from them, and the prep insert reads those amounts.
     const query = jest
       .fn()
-      .mockResolvedValueOnce([{ id: 'sfp-1', features_data_id: 'fd-bbox-1' }])
-      .mockResolvedValueOnce(kvStableIdRows);
+      .mockResolvedValueOnce(kvStableIdRows)
+      .mockResolvedValueOnce([{ id: 'sfp-1', features_data_id: 'fd-bbox-1' }]);
 
     const setFeatureDataStableIdsForFeature = jest.fn();
     const splitCreateFeatures = {
@@ -81,5 +83,27 @@ describe('SplitOperation feature_data_stable_ids derivation', () => {
       featureId,
       kvStableIdRows,
     );
+
+    // Gap-analysis correctness depends on this ordering: the prep insert
+    // fills total_area/current_pa from the CHILD's per-PU amounts, so
+    // ComputeArea must have run for the child before the SplitQuery insert
+    // (and after its stable ids were stored).
+    expect(
+      computeArea.computeAreaPerPlanningUnitOfFeature,
+    ).toHaveBeenCalledWith('project-1', 'scenario-1', featureId);
+
+    const computeAreaOrder =
+      computeArea.computeAreaPerPlanningUnitOfFeature.mock
+        .invocationCallOrder[0];
+    const prepInsertCallIndex = query.mock.calls.findIndex(
+      ([sql]) => sql === 'SPLIT_QUERY_SQL',
+    );
+    expect(prepInsertCallIndex).toBeGreaterThanOrEqual(0);
+    const prepInsertOrder = query.mock.invocationCallOrder[prepInsertCallIndex];
+    const stableIdsOrder =
+      setFeatureDataStableIdsForFeature.mock.invocationCallOrder[0];
+
+    expect(stableIdsOrder).toBeLessThan(computeAreaOrder);
+    expect(computeAreaOrder).toBeLessThan(prepInsertOrder);
   });
 });

--- a/api/apps/api/src/modules/scenarios-features/split/split-operation.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-operation.service.ts
@@ -46,21 +46,6 @@ export class SplitOperation {
       const scenarioFeaturePreparationIds: { id: string }[] = [];
 
       for (const singleSplitFeatureWithId of singleSplitFeaturesWithId) {
-        const { parameters, query } = this.splitQuery.prepareQuery(
-          singleSplitFeatureWithId,
-          data.scenarioId,
-          data.specificationId,
-          planningAreaLocation,
-          protectedAreaFilterByIds,
-          project,
-        );
-        const scenarioFeaturePreparationIdsForFeature: {
-          id: string;
-          features_data_id: string;
-        }[] = await this.geoEntityManager.query(query, parameters);
-        scenarioFeaturePreparationIds.push(
-          ...scenarioFeaturePreparationIdsForFeature,
-        );
         // Link the split feature to the FULL key/value-matching subset of the
         // parent's features_data rows — not the bbox-filtered scenario-prep rows
         // SplitQuery returns. This matches how splits render (the full class) and
@@ -81,13 +66,35 @@ export class SplitOperation {
           singleSplitFeatureWithId.id,
           featureDataStableIds,
         );
+
+        // The child's own per-PU amounts must exist BEFORE the scenario-prep
+        // insert: SplitQuery fills total_area/current_pa from them, so the
+        // gap analysis reflects each split value's subset rather than the
+        // parent's totals. ComputeArea reads the stable ids set above and is
+        // idempotent (skips children that already have amounts).
+        await this.computeArea.computeAreaPerPlanningUnitOfFeature(
+          project.id,
+          data.scenarioId,
+          singleSplitFeatureWithId.id,
+        );
+
+        const { parameters, query } = this.splitQuery.prepareQuery(
+          singleSplitFeatureWithId,
+          data.scenarioId,
+          data.specificationId,
+          planningAreaLocation,
+          protectedAreaFilterByIds,
+          project,
+        );
+        const scenarioFeaturePreparationIdsForFeature: {
+          id: string;
+          features_data_id: string;
+        }[] = await this.geoEntityManager.query(query, parameters);
+        scenarioFeaturePreparationIds.push(
+          ...scenarioFeaturePreparationIdsForFeature,
+        );
       }
 
-      await this.computeAmountPerFeature(
-        singleSplitFeaturesWithId.map(({ id }) => id),
-        project.id,
-        data.scenarioId,
-      );
       await this.events.create({
         topic: data.scenarioId,
         kind: API_EVENT_KINDS.scenario__geofeatureSplit__finished__v1__alpha1,
@@ -100,21 +107,5 @@ export class SplitOperation {
       });
       throw error;
     }
-  }
-
-  private async computeAmountPerFeature(
-    featuresIds: string[],
-    projectId: string,
-    scenarioId: string,
-  ) {
-    return Promise.all(
-      featuresIds.map((featureId) =>
-        this.computeArea.computeAreaPerPlanningUnitOfFeature(
-          projectId,
-          scenarioId,
-          featureId,
-        ),
-      ),
-    );
   }
 }

--- a/api/apps/api/src/modules/scenarios-features/split/split-query.service.ts
+++ b/api/apps/api/src/modules/scenarios-features/split/split-query.service.ts
@@ -76,16 +76,21 @@ export class SplitQuery {
               : ``
           }
       ),
+      -- total_area/current_pa must reflect THIS split value's subset, not the
+      -- parent feature: the gap-analysis views derive met% from these columns,
+      -- so parent-wide sums make every sibling read identical. Requires the
+      -- child's feature_amounts_per_planning_unit rows to exist already —
+      -- SplitOperation runs ComputeArea for the child before this insert.
       total_amounts as (
         select feature_id, SUM(amount) as total_amount from feature_amounts_per_planning_unit
-        where feature_id = ${fields.baseFeatureId}
+        where feature_id = ${fields.apiFeatureId}
         group by feature_id
       ),
       protected_amounts as (
         select spd.scenario_id, fappu.feature_id, SUM(fappu.amount) as protected_amount
         from scenarios_pu_data spd inner join feature_amounts_per_planning_unit fappu on fappu.project_pu_id = spd.project_pu_id
         where spd.lockin_status = 1 and fappu.feature_id = ${
-          fields.baseFeatureId
+          fields.apiFeatureId
         } and spd.scenario_id = ${fields.scenarioId}
         group by spd.scenario_id, fappu.feature_id
       )
@@ -97,10 +102,10 @@ export class SplitQuery {
              ${fields.target},
              ${fields.prop},
              (select total_amount from total_amounts ta where ta.feature_id = ${
-               fields.baseFeatureId
+               fields.apiFeatureId
              }),
              (select protected_amount from protected_amounts pa where pa.feature_id = ${
-               fields.baseFeatureId
+               fields.apiFeatureId
              } and pa.scenario_id = ${fields.scenarioId})
       from split
              join features_data as fd


### PR DESCRIPTION
## Jira story

[MRXNM-82](https://vizzuality.atlassian.net/browse/MRXNM-82) — client-reported after the split release: "Gap Analysis appears to be calculated based on the merged shapefile, not the split features … all features originating from the same file show identical values. This does not occur in Target Achievement."

## What

**Root cause.** `SplitQuery.prepareQuery`'s insert into `scenario_features_preparation` computed `total_area` and `current_pa` from `feature_amounts_per_planning_unit` filtered by **`baseFeatureId` (the parent)** — no restriction to the split value's subset. The `scenario_features_gap_data` view derives `met%` from exactly those columns, so every child of one shapefile showed the parent's ratio. Target Achievement reads `output_scenarios_features_data` (per-run solver amounts, which already flow from per-child puvspr), which is why it differed per child — precisely the client's observation.

**Fix.**

- `SplitQuery`: the `total_amounts` / `protected_amounts` CTEs (and their correlated subqueries) now filter by the **child** `api_feature_id`.
- `SplitOperation`: per child, ComputeArea (per-PU amounts derived from the child's `feature_data_stable_ids`; idempotent) now runs **before** the scenario-prep insert — previously it ran after the whole loop, so child amounts wouldn't have existed yet. Stable ids are stored first, as ComputeArea reads them.
- Unit spec updated for the new ordering + a regression assertion: stable ids → ComputeArea(child) → prep insert.

## Testing

- `yarn jest split-operation.service.spec.ts` → 1 passed (the new ordering assertion fails against the old code).
- `tsc --noEmit -p apps/api/tsconfig.app.json` → clean.
- The `split-query.service.e2e-spec` integration suite asserts fpf/prop/target/api_feature_id only and seeds no per-PU amounts — unaffected.
- Manual: split a feature (e.g. client's `Ecoregions` by `eco_name`), open Gap Analysis → each child now shows its own current %, no longer the parent's value repeated.

## Notes

- Base is `staging` (split-feature line; same as #1764/#1765/#1766).
- **Existing scenarios are not healed automatically**: their `scenario_features_data` rows keep parent-based totals until the spec is reprocessed (re-saving the scenario's features regenerates them). If we want to heal prod data in bulk, that would be a follow-up script in the spirit of the MRXNM-82/99 backfills.
- Legacy projects: ComputeArea early-returns and they have no `feature_amounts_per_planning_unit` rows for either parent or child, so the sums stay NULL exactly as before — no behavior change.

[MRXNM-82]: https://vizzuality.atlassian.net/browse/MRXNM-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ