### PR TITLE
fix(app): render materialized split children like continuous features [MRXNM-82]

### DIFF
--- a/app/hooks/map/index.ts
+++ b/app/hooks/map/index.ts
@@ -241,11 +241,15 @@ export function useContinuousFeaturesLayers({
 
     return features
       .map((fid) => {
-        const { amountRange, color, opacity = 1 } = layerSettings[fid] || {};
+        const { amountRange, color, opacity = 1, childFeatureId } = layerSettings[fid] || {};
 
         if (!amountRange || amountRange.min == null || amountRange.max == null || !color) {
           return null;
         }
+
+        // Split-child rows are keyed by a synthetic `${parentId}-${value}` id;
+        // tiles must be requested with the materialized child's real feature id.
+        const tileFeatureId = childFeatureId ?? fid;
 
         return {
           id: `continuous-features-layer-${pid}-${fid}`,
@@ -253,7 +257,7 @@ export function useContinuousFeaturesLayers({
           source: {
             type: 'vector',
             tiles: [
-              `${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${pid}/features/${fid}/preview/tiles/{z}/{x}/{y}.mvt`,
+              `${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${pid}/features/${tileFeatureId}/preview/tiles/{z}/{x}/{y}.mvt`,
             ],
           },
           render: {

--- a/app/hooks/map/types.ts
+++ b/app/hooks/map/types.ts
@@ -187,6 +187,9 @@ export interface UsePUGridLayer {
           max: number;
         };
         color?: string;
+        // real feature id of a materialized split child, when the entry is
+        // keyed by the synthetic `${parentId}-${value}` row id
+        childFeatureId?: string;
       };
     };
   };

--- a/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/target-spf/index.tsx
@@ -18,7 +18,12 @@ import { getScenarioEditSlice } from 'store/slices/scenarios/edit';
 import Fuse from 'fuse.js';
 import { useDebouncedCallback } from 'use-debounce';
 
-import { useAllFeatures, useSaveSelectedFeatures, useSelectedFeatures } from 'hooks/features';
+import {
+  useAllFeatures,
+  useColorFeatures,
+  useSaveSelectedFeatures,
+  useSelectedFeatures,
+} from 'hooks/features';
 import { useCanEditScenario } from 'hooks/permissions';
 import { useScenarioStatus } from 'hooks/scenarios';
 
@@ -96,6 +101,8 @@ const TargetAndSPFFeatures = (): JSX.Element => {
     keepPreviousData: true,
   });
 
+  const featureColors = useColorFeatures(pid, sid);
+
   // A split materialises its child features asynchronously (the `geofeatureSplit`
   // job). Once that job finishes, refetch the specification so the real,
   // materialised child ids read back from the API replace the pending
@@ -128,9 +135,15 @@ const TargetAndSPFFeatures = (): JSX.Element => {
           childFeatureId: splitFeature.childFeatureId ?? null, // real id, when materialized
           name: `${feature.name} / ${splitFeature.name}`,
           isVisibleOnMap: layerSettings[`${feature.id}-${splitFeature.name}`]?.visibility ?? false,
-          color: feature.color,
+          // each child gets its own ramp color (keyed by the synthetic row id),
+          // matching the legend, instead of inheriting the parent's
+          color:
+            featureColors.find(({ id }) => id === `${feature.id}-${splitFeature.name}`)?.color ??
+            feature.color,
           // prefer the materialized child's own amounts; fall back to the parent's
           amountRange: splitFeature.amountRange ?? feature.amountRange,
+          // the child's own amounts only — null until materialization computes them
+          childAmountRange: splitFeature.amountRange ?? null,
           isCustom: feature.metadata?.isCustom,
           scenarioUsageCount: featureMetadata?.scenarioUsageCount,
           type: featureMetadata?.tag,
@@ -195,7 +208,14 @@ const TargetAndSPFFeatures = (): JSX.Element => {
     }
 
     return parsedData;
-  }, [selectedFeaturesQuery.data, allFeaturesQuery.data, filters, featureValues, layerSettings]);
+  }, [
+    selectedFeaturesQuery.data,
+    allFeaturesQuery.data,
+    filters,
+    featureValues,
+    layerSettings,
+    featureColors,
+  ]);
 
   const handleSearch = useDebouncedCallback(
     (value: Parameters<ComponentProps<typeof Search>['onChange']>[0]) => {
@@ -244,16 +264,17 @@ const TargetAndSPFFeatures = (): JSX.Element => {
       const selectedFeature = targetedFeatures.find(({ id: featureId }) => featureId === id);
       const isContinuous =
         selectedFeature.amountRange.min !== null && selectedFeature.amountRange.max !== null;
-      const { splitted } = selectedFeature;
+      const { splitted, childFeatureId, childAmountRange } = selectedFeature;
 
-      // Only genuine, non-split continuous features use the gradient renderer
-      // (useContinuousFeaturesLayers). Materialized split children are drawn as
-      // solid-color layers via their own child tiles (useTargetedPreviewLayers).
-      // Routing a split child through this branch would (a) stamp an `amountRange`
-      // into layerSettings that excludes it from useTargetedPreviewLayers, and
-      // (b) never add it to `selectedContinuousFeatures` (so the gradient renderer
-      // ignores it too) — leaving it rendered nowhere and the eye stuck on.
-      if (isContinuous && !splitted) {
+      // The gradient renderer (useContinuousFeaturesLayers) needs a real feature
+      // id with per-PU amounts behind it. A materialized split child qualifies
+      // once it has both (childFeatureId + its own amount range) — from then on
+      // it renders exactly like any other continuous feature. Children still
+      // pending materialization fall through to the solid path below, which
+      // draws them from the parent's tiles with a property filter.
+      const isMaterializedContinuousChild = Boolean(childFeatureId && childAmountRange);
+
+      if (isContinuous && (!splitted || isMaterializedContinuousChild)) {
         const newSelectedFeatures = [...selectedContinuousFeatures];
         const isIncluded = newSelectedFeatures.includes(id);
 
@@ -271,6 +292,7 @@ const TargetAndSPFFeatures = (): JSX.Element => {
               visibility: !isIncluded,
               color: selectedFeature?.color,
               amountRange: selectedFeature.amountRange,
+              ...(splitted && { childFeatureId }),
             },
           })
         );
@@ -293,6 +315,9 @@ const TargetAndSPFFeatures = (): JSX.Element => {
           settings: {
             visibility: !isIncluded,
             color: selectedFeature?.color,
+            // null (not undefined — the reducer drops undefined) so a stale
+            // amountRange can't exclude the row from useTargetedPreviewLayers
+            ...(splitted && { amountRange: null }),
           },
         })
       );

--- a/app/layout/scenarios/edit/map/legend/hooks/index.ts
+++ b/app/layout/scenarios/edit/map/legend/hooks/index.ts
@@ -225,25 +225,35 @@ export const useFeaturesLegend = () => {
 
   const targetedFeatures = useTargetedFeatures(sid);
 
-  const parsedTargetedFeatures = targetedFeatures.data?.map(({ id, name, splitted, parentId }) => {
-    const allFeatures = queryClient.getQueryData<any>(['all-features', pid], {
-      exact: false,
-    })?.data;
+  const parsedTargetedFeatures = targetedFeatures.data?.map(
+    ({ id, name, splitted, amountRange, childFeatureId }) => {
+      const allFeatures = queryClient.getQueryData<any>(['all-features', pid], {
+        exact: false,
+      })?.data;
 
-    const f = allFeatures?.find(({ id: featureId }) =>
-      splitted ? parentId === featureId : id === featureId
-    );
+      const f = allFeatures?.find(({ id: featureId }) => id === featureId);
 
-    return {
-      id,
-      name,
-      amountRange: f?.amountRange ?? { min: null, max: null },
-      amountMin: f?.amountMin,
-      amountMax: f?.amountMax,
-      splitted,
-      color: featureColors?.find(({ id: featureId }) => featureId === id)?.color,
-    };
-  });
+      // Split children are bucketed by their OWN amount range (available once
+      // materialization computes their amounts), so the legend swatch matches
+      // what the map draws: gradient for materialized children, solid square
+      // while still pending. Using the parent's range here would promise a
+      // gradient the child renderer can't honor.
+      const featureAmountRange = splitted
+        ? amountRange ?? { min: null, max: null }
+        : f?.amountRange ?? { min: null, max: null };
+
+      return {
+        id,
+        name,
+        amountRange: featureAmountRange,
+        amountMin: splitted ? featureAmountRange.min : f?.amountMin,
+        amountMax: splitted ? featureAmountRange.max : f?.amountMax,
+        splitted,
+        ...(splitted && { childFeatureId: childFeatureId ?? null }),
+        color: featureColors?.find(({ id: featureId }) => featureId === id)?.color,
+      };
+    }
+  );
 
   const targetedFeaturesByRange = parsedTargetedFeatures?.reduce(
     (acc, x) => ({
@@ -295,7 +305,7 @@ export const useFeaturesLegend = () => {
 
         // uniqueBinaryFeatures (not binaryFeaturesItems) so split-child rows
         // — present only in the targeted expansion — resolve their color too.
-        const { color } = uniqueBinaryFeatures.find(({ id }) => id === featureId) || {};
+        const { color, splitted } = uniqueBinaryFeatures.find(({ id }) => id === featureId) || {};
 
         dispatch(
           setLayerSettings({
@@ -303,6 +313,10 @@ export const useFeaturesLegend = () => {
             settings: {
               visibility: !isIncluded,
               color,
+              // null (not undefined — the reducer drops undefined) so a stale
+              // amountRange can't exclude a pending split child from
+              // useTargetedPreviewLayers' "no amountRange" filter.
+              ...(splitted && { amountRange: null }),
             },
           })
         );
@@ -311,42 +325,14 @@ export const useFeaturesLegend = () => {
     ...LEGEND_LAYERS['continuous-features']({
       items: uniqueContinuousFeatures,
       onChangeVisibility: (featureId: Feature['id']) => {
-        const { color, amountRange, amountMin, amountMax, splitted } =
+        const { color, amountRange, amountMin, amountMax, splitted, childFeatureId } =
           uniqueContinuousFeatures.find(({ id }) => id === featureId) || {};
 
-        // Split children are bucketed here by their PARENT's amount range, but
-        // they are drawn as solid-color layers by useTargetedPreviewLayers
-        // (their own child tiles), never by the gradient renderer. Stamping an
-        // amountRange into their layerSettings excludes them from that hook —
-        // and the merging reducer makes the exclusion sticky — leaving them
-        // rendered nowhere: same failure a8b38a92 fixed in the table's eye
-        // toggle. Route them through the discrete toggle instead.
-        if (splitted) {
-          const newSelectedFeatures = [...selectedFeatures];
-          const isIncluded = newSelectedFeatures.includes(featureId);
-          if (!isIncluded) {
-            newSelectedFeatures.push(featureId);
-          } else {
-            newSelectedFeatures.splice(newSelectedFeatures.indexOf(featureId), 1);
-          }
-          dispatch(setSelectedFeatures(newSelectedFeatures));
-
-          dispatch(
-            setLayerSettings({
-              id: featureId,
-              settings: {
-                visibility: !isIncluded,
-                color,
-                // null (not undefined — the reducer drops undefined) so a
-                // previously stamped amountRange is cleared and the row passes
-                // useTargetedPreviewLayers' "no amountRange" filter again.
-                amountRange: null,
-              },
-            })
-          );
-          return;
-        }
-
+        // A split child only lands in this bucket once it is materialized with
+        // its own amounts (see parsedTargetedFeatures), so it can take the same
+        // gradient path as any other continuous feature — it just needs its
+        // real feature id stamped so the renderer requests the child's tiles
+        // rather than the synthetic `${parentId}-${value}` row id.
         const newSelectedFeatures = [...selectedContinuousFeatures];
         const isIncluded = newSelectedFeatures.includes(featureId);
 
@@ -368,6 +354,7 @@ export const useFeaturesLegend = () => {
                 max: amountMax ?? amountRange?.max,
               },
               color,
+              ...(splitted && { childFeatureId }),
             },
           })
         );


### PR DESCRIPTION
Client feedback on the split functionality: *"the features are not visualized like other features."*

Split children of a continuous feature were deliberately kept out of the gradient
renderer (`useContinuousFeaturesLayers`), because their synthetic
`${parentId}-${value}` row ids had no tiles or per-PU amounts behind them. They
therefore drew as flat, fully saturated polygons from raw geometry with a black
outline, while every other feature in a non-legacy project draws as a
planning-unit-grid amount gradient — two different visual languages on the same
map.

Materialization now computes each child's own per-PU amounts, and the scenario
specification reads back the child's real feature id and amount range. That is
everything the gradient renderer needs, so a materialized child now takes exactly
the same path as any other continuous feature.

## Jira story

https://vizzuality.atlassian.net/browse/MRXNM-82

### What changed

- **`hooks/map/index.ts`** — `useContinuousFeaturesLayers` resolves a
  `childFeatureId` from layer settings, so gradient tiles are requested with the
  child's real feature id instead of the synthetic row id.
- **`target-spf/index.tsx`** (table eye toggle) — materialized children with their
  own amounts route through `selectedContinuousFeatures`; child rows also take
  their own ramp colour instead of inheriting the parent's, so siblings are
  distinguishable and the table agrees with the legend.
- **`legend/hooks/index.ts`** — children are bucketed by their **own** amount
  range rather than the parent's, so the legend swatch matches what the map draws
  (gradient once materialized, solid square while pending). The legend toggle now
  stamps the same settings as the table, ending the "colour depends on which
  control you used" divergence.
- Both solid-path toggles clear a stale stamped `amountRange` (`null`, not
  `undefined` — the reducer drops `undefined`) so a pending child can no longer
  get stuck excluded from `useTargetedPreviewLayers`.

Children still pending materialization keep the previous fallback: solid fill from
the parent's tiles with a property filter. A child that materializes while already
visible stays on the solid path until re-toggled.

### Testing instructions

Verified against the staging API using the client's own data: project
**Galapagos test 1** → scenario **Baseline check** (13 materialized split children).

1. Open the scenario's **Features** step and the map layer panel.
2. In the bottom **Features** legend group, toggle the eye on **Habitats** (an
   ordinary continuous feature). Expect a white→orange PU-grid gradient and a
   gradient legend bar labelled `0.001` – `92`. Toggle it off.
3. Toggle **Habitats / Abyssal hills** (a split child). Expect the *same* PU-grid
   gradient style in a different hue, covering only the units where that habitat
   occurs, with a gradient legend bar labelled `9.763` – `92,000,000` — the
   child's own range, not the parent's.
4. Confirm the legend swatch hue matches the map fill.
5. In DevTools → Network, filter `preview/tiles` and re-toggle a child. Requests
   must go to `/api/v1/projects/{pid}/features/{realChildUuid}/preview/tiles/...`
   and return 200 — **not** `/geo-features/...?bbox=`, and never the synthetic
   `{parentId}-{value}` id.
6. Toggle the same child from the left-hand table row: identical result, and the
   two eyes stay in sync.
7. Each child should have a visibly different colour from its siblings.

Not exercised live: the pending (not-yet-materialized) child fallback, since every
child in that scenario is already materialized. That path is unchanged by this PR.

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `staging` (base branch for the
      MRXNM-82 work stream; branch is current with it).
- [ ] Update CHANGELOG file — n/a, this repo has no CHANGELOG.