### PR TITLE
fix(app): surface every split category in the split modal [MRXNM-82]

### DIFF
--- a/app/e2e/feature-split.spec.ts
+++ b/app/e2e/feature-split.spec.ts
@@ -51,7 +51,7 @@ test.describe('Feature split (materialized)', () => {
     // is not exposed as a native combobox/option.
     await page.getByText('You can split this feature into categories').click();
     await page.getByText(SPLIT_PROPERTY, { exact: true }).click();
-    await page.locator('.modal-checkbox-list input[type="checkbox"]').first().check();
+    await page.locator('[data-testid="split-values-list"] input[type="checkbox"]').first().check();
 
     // 4. Save → submits the spec as `created`, triggering BE materialization.
     await page.getByRole('button', { name: 'Save' }).click();

--- a/app/layout/project/sidebar/scenario/grid-setup/features/modals/split/index.tsx
+++ b/app/layout/project/sidebar/scenario/grid-setup/features/modals/split/index.tsx
@@ -160,6 +160,15 @@ const SplitModal = ({
     setSplitFeaturesSelected([]);
   }, []);
 
+  const onSelectAllSplitValues = useCallback(
+    (opt: FormValues['splitOption']) => {
+      setSplitFeaturesSelected(
+        (getSplitOptionValues(opt) ?? []).map((value) => ({ id: `${value.name}` }))
+      );
+    },
+    [getSplitOptionValues]
+  );
+
   return (
     <FormRFF<FormValues>
       initialValues={{
@@ -217,51 +226,80 @@ const SplitModal = ({
 
               <div>
                 <FieldRFF<string> name="splitValues">
-                  {(fprops) => (
-                    <Field id="splitValues" {...fprops} className="relative">
-                      <div className="flex justify-between">
-                        <div className="modal-checkbox-list max-h-48 w-full space-y-2 overflow-y-auto pt-1">
-                          {getSplitOptionValues(values.splitOption)?.map((value) => {
-                            const checked = !!splitFeaturesSelected.find(
-                              (sfs) => sfs.id === `${value.name}`
-                            );
-                            return (
-                              <div key={value.name} className="flex items-center space-x-2.5 pl-1">
-                                <Checkbox
-                                  id={`checkbox-${value.name}`}
-                                  value={`${value.name}`}
-                                  theme="light"
-                                  checked={checked}
-                                  className="h-4 w-4"
-                                  onChange={onSplitFeaturesChanged}
-                                />
-                                <label
-                                  htmlFor={`checkbox-${value.name}`}
-                                  className="ml-2.5 inline-block max-w-sm text-xs"
-                                >
-                                  {value.name}
-                                </label>
-                              </div>
-                            );
-                          })}
-                        </div>
+                  {(fprops) => {
+                    const splitOptionValues = getSplitOptionValues(values.splitOption);
 
-                        {getSplitOptionValues(values.splitOption) && (
-                          <div>
-                            <Button
-                              className="flex space-x-2 whitespace-nowrap"
-                              theme="secondary"
-                              size="xs"
-                              onClick={onClearSplitCheckedValues}
-                            >
-                              <p>Clear all</p>
-                              <Icon icon={CLOSE_SVG} className="h-2.5 w-2.5" />
-                            </Button>
+                    return (
+                      <Field id="splitValues" {...fprops} className="relative">
+                        {splitOptionValues && (
+                          <div className="mb-2 flex items-center justify-between">
+                            <p className="text-xs text-gray-400">
+                              {`${splitFeaturesSelected.length} of ${splitOptionValues.length} selected`}
+                            </p>
+
+                            <div className="flex space-x-2">
+                              <Button
+                                className="whitespace-nowrap"
+                                theme="secondary"
+                                size="xs"
+                                onClick={() => onSelectAllSplitValues(values.splitOption)}
+                              >
+                                Select all
+                              </Button>
+
+                              <Button
+                                className="flex space-x-2 whitespace-nowrap"
+                                theme="secondary"
+                                size="xs"
+                                onClick={onClearSplitCheckedValues}
+                              >
+                                <p>Clear all</p>
+                                <Icon icon={CLOSE_SVG} className="h-2.5 w-2.5" />
+                              </Button>
+                            </div>
                           </div>
                         )}
-                      </div>
-                    </Field>
-                  )}
+
+                        {/* `split-values-list` forces a persistently visible scrollbar (see
+                            globals.css): with a categorical attribute the list routinely
+                            overflows, and an auto-hiding scrollbar is the only cue that more
+                            values exist below the fold. */}
+                        <div
+                          className="split-values-list max-h-48 w-full overflow-y-auto"
+                          data-testid="split-values-list"
+                        >
+                          <div className="space-y-2 pr-1 pt-1">
+                            {splitOptionValues?.map((value) => {
+                              const checked = !!splitFeaturesSelected.find(
+                                (sfs) => sfs.id === `${value.name}`
+                              );
+                              return (
+                                <div
+                                  key={value.name}
+                                  className="flex items-center space-x-2.5 pl-1"
+                                >
+                                  <Checkbox
+                                    id={`checkbox-${value.name}`}
+                                    value={`${value.name}`}
+                                    theme="light"
+                                    checked={checked}
+                                    className="h-4 w-4"
+                                    onChange={onSplitFeaturesChanged}
+                                  />
+                                  <label
+                                    htmlFor={`checkbox-${value.name}`}
+                                    className="ml-2.5 inline-block max-w-sm text-xs"
+                                  >
+                                    {value.name}
+                                  </label>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      </Field>
+                    );
+                  }}
                 </FieldRFF>
               </div>
 

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -804,11 +804,25 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
   }
 }
 
-.modal-checkbox-list::-webkit-scrollbar {
-  display: none;
+/* Categorical value lists overflow routinely, and an overlay scrollbar that
+   auto-hides reads as "nothing more to see". Declaring an explicit width keeps
+   the scrollbar rendered regardless of the OS "show scroll bars" setting. */
+.split-values-list::-webkit-scrollbar {
+  width: 6px;
 }
 
-.modal-checkbox-list {
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none;  /* Firefox */
+.split-values-list::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
 }
+
+.split-values-list::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.28);
+  border-radius: 3px;
+}
+
+.split-values-list {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.28) rgba(0, 0, 0, 0.06);
+}
+


### PR DESCRIPTION
Client feedback on the split functionality: *"the split did not unpack all the features, and some features included in the zip file are missing."*

This turned out **not** to be data loss. The backend offered every category;
the modal just never showed them.

The split modal's value list is a 192px box (`max-h-48`) that fits about 8
rows, and `.modal-checkbox-list` hid its scrollbar on WebKit, Firefox and
Edge alike. With a 12-value attribute the list therefore presented as a
complete set: no scrollbar, not even a partially cut row at the bottom, no
count of how many values exist, and a "Clear all" button but no "Select
all". The user ticked everything visible, saved, and got a partial split —
which surfaces later as missing features.

Measured on a real scenario splitting **Habitats** by `NAME`:

| | |
|---|---|
| Values offered by the API | 12 |
| Values in the saved specification | 8 |
| Missing children | Rift Valley, Seamount, Shelf high, Spreading Ridge |
| Rows fully visible in the modal | 8 (`clientHeight` 192 vs `scrollHeight` 284) |

The four hidden rows are exactly the four missing children. A "Species"
feature in the same scenario has 5 values, all of which fit — and all 5
were split correctly.

## Jira story

https://vizzuality.atlassian.net/browse/MRXNM-82

## What changed

- **Scrollbar stays visible.** Replaced the scrollbar-hiding rule with an
  explicit `::-webkit-scrollbar` width plus `scrollbar-width: thin`.
  Declaring a width defeats overlay auto-hiding, so the cue survives
  regardless of the OS "show scroll bars" setting.
- **"Select all" button**, so splitting by every category — the common
  intent — requires no scrolling at all.
- **"N of M selected" count**, making a partial selection evident before
  saving. This alone would have prevented the report.

Native overflow is kept rather than switching to the shared `ScrollArea`
component: its viewport is `h-full`, which cannot resolve against a
`max-h-*` parent, so the list clipped its overflow *without* scrolling —
strictly worse than the original. Verified and rejected before landing.

The e2e selector moves from `.modal-checkbox-list` to a `data-testid`,
since that class is no longer a behavioural marker.

## Testing instructions

Needs the `split` flag (`NEXT_PUBLIC_FEATURE_FLAGS=split`) and a scenario
containing an unsplit feature with more than ~8 categories. There is a
throwaway scenario set up for this in *Galapagos test 1* — **"TEMP
split-UX check (safe to delete)"**, which has the 12-category "Habitats"
feature added and nothing split.

1. Open the scenario's **Features** step, find the **Habitats** row, click
   the **⋯** menu and choose **Split**.
2. Pick **NAME** in the categories dropdown.
3. Expect **"0 of 12 selected"** above the list, with **Select all** and
   **Clear all** beside it, and a **visible scrollbar** on the list.
4. Click **Select all** → count reads **"12 of 12 selected"** and all 12
   boxes are checked, including the four that need scrolling to see.
5. Click **Clear all** → back to "0 of 12 selected", nothing checked.
6. Scroll the list → Rift Valley, Seamount, Shelf high and Spreading Ridge
   are reachable.
7. Pick a property with few values (e.g. a single-category feature) and
   confirm the list still sizes to its content with no stray scrollbar.

Verified in the real modal against the staging API at each of those steps.
Cancel rather than Save unless you want to materialize a split.

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `staging` (base branch for the
      MRXNM-82 work stream).
- [ ] Update CHANGELOG file — n/a, this repo has no CHANGELOG.